### PR TITLE
Add ScriptEngine extension

### DIFF
--- a/Extensions/ScriptEngine.json
+++ b/Extensions/ScriptEngine.json
@@ -1,0 +1,427 @@
+{
+  "author": "Arthur Pacaud (arthuro555)",
+  "description": "Adds a mechanism to execute arbitrary JavaScript from a GDevelop game, while not exposing a direct access to the game by running the code in another isolated thread (via WebWorkers).  The code can still interract with the game but only through APIs designed by you.\n\n## Usage\n\nThe first step is defining the API. This is necessary to do **before** executing a script. To define the API, you only need to run the condition that checks if the api has been called once. If you do not want to check if the APIs have been called yet, you can still define the APIs with the \"Define API\" action.  \nOnce you have done that, you can execute a script, call APIs from it and process the calls from events.\n\n## Notes\n\n - When an \"API called\" condition is trigered, the api call linked to it will be picked. This means that the return actions and the get argument expressions will apply to it. \n - Checking if another API has been called implicitely returns the currently picked api call. \n - Once you have returned an API call, it is unpicked, meaning that its return value cannot be changed and its argument not read anymore.\n - Once you have executed a script, new APIs cannot be defined for that script, they will be defined for next scripts though.\n",
+  "extensionNamespace": "",
+  "fullName": "Script Engine",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPHBhdGggZD0iTTE0LDIzYzAtNS41LDQuNS0xMCwxMC0xMGMxLjIsMCwyLjMsMC4yLDMuMywwLjZsMi45LTQuNGMwLjQtMC42LDAuNi0xLjIsMC43LTEuOUMzMSw3LjIsMzEsNy4xLDMxLDdjMC0wLjEsMC0wLjEsMC0wLjINCgljMC0wLjgtMC4xLTEuNS0wLjQtMi4zYy0wLjctMS40LTItMi40LTMuNS0yLjZjLTAuMiwwLTAuNCwwLTAuNiwwYy0wLjEsMC0wLjEsMC0wLjIsMGMtMC4xLDAtMC4yLDAtMC4zLDBjMCwwLDAsMCwwLDBjMCwwLDAsMCwwLDANCglIOS41QzkuNCwyLDkuMywyLDkuMiwyLjFDOS4yLDIsOS4xLDIsOSwyQzYuMiwyLDQsNC4yLDQsN2MwLDAuNywwLjIsMS4zLDAuNiwxLjlDNS40LDEwLjIsNi44LDExLDguNCwxMWgxLjJMMS44LDIyLjgNCgljLTAuOSwxLjQtMSwzLjEtMC4zLDQuNmMwLjcsMS40LDIsMi40LDMuNSwyLjZjMC4yLDAsMC40LDAsMC42LDBoMTEuNEMxNS4xLDI4LjIsMTQsMjUuNywxNCwyM3ogTTguNCw5QzcuNSw5LDYuNyw4LjYsNi4zLDcuOQ0KCUM2LjEsNy42LDYsNy4zLDYsN2MwLTEuNywxLjMtMywzLTNjMC4xLDAsMC4yLDAsMC4yLTAuMUM5LjMsNCw5LjQsNCw5LjUsNGgxMi43Yy0xLjcsMi4yLTEsNC4yLTAuNiw1YzAsMCwwLDAsMCwwSDguNHoiLz4NCjxwYXRoIGQ9Ik0yNSwxNS4xdjguNWwxLjMtMS4zYzAuNC0wLjQsMS0wLjQsMS40LDBzMC40LDEsMCwxLjRsLTMsM2MtMC4xLDAuMS0wLjIsMC4yLTAuMywwLjJDMjQuMywyNywyNC4xLDI3LDI0LDI3cy0wLjMsMC0wLjQtMC4xDQoJYy0wLjEtMC4xLTAuMi0wLjEtMC4zLTAuMmwtMy0zYy0wLjQtMC40LTAuNC0xLDAtMS40czEtMC40LDEuNCwwbDEuMywxLjN2LTguNWMtMy45LDAuNS03LDMuOS03LDcuOWMwLDQuNCwzLjYsOCw4LDhzOC0zLjYsOC04DQoJQzMyLDE4LjksMjguOSwxNS42LDI1LDE1LjF6Ii8+DQo8L3N2Zz4NCg==",
+  "name": "ScriptEngine",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Applications and Programming/Applications and Programming_script_code_snippet_download_save.svg",
+  "shortDescription": "Execute arbitrary JavaScript safely in GDevelop games.",
+  "version": "1.0.0",
+  "tags": [
+    "worker",
+    "thread",
+    "javascript",
+    "engine",
+    "code",
+    "script"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onFirstSceneLoaded",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "/** \n * @typedef Trigger\n * @property {string} name\n * @property {string} fn\n * @property {number} id\n * @property {Array<any>} args\n */\n\n/** @type {Set<string>} */\nconst apiToDefine = new Set();\n/** @type {Map<string, Array<Trigger>>} */\nconst scriptTriggers = new Map();\n/** @type {Map<string, Worker>} */\nconst workers = new Map();\n/** @type {Trigger | null} */\nlet currentEvent = null;\n\n/**\n * The minimal runtime required for the API to run.\n */\nconst workerRuntime = `\n// GDevelop ScriptEngine extension worker runtime\n// By arthuro555\nlet id = 0;\nconst generateUID = () => id++;\nconst fnMap = new Map();\nconst getResolvers = (fn) => {\n    if(!fnMap.has(fn)) \n        fnMap.set(fn, new Map());\n    return fnMap.get(fn);\n}\nconst createFunction = (fn) => {\n    return (...args) => {\n        const id = generateUID();\n        return new Promise(r => {\n            getResolvers(fn).set(id, r);\n            postMessage({ op: \"call\", fn, id, args, });\n        });\n    } \n}\nself.addEventListener('message', ({data}) => {\n    if(typeof data !== \"object\") return;\n    const { op } = data;\n\n    if(op === \"call\" && typeof self[data.fn] === \"function\") \n        return self[data.fn](...data.args);\n\n    if(op === \"resolve\") {\n        const r = getResolvers(data.fn);\n        if(!r.has(data.id)) return;\n        r.get(data.id)(data.val);\n        r.delete(data.id);\n    }\n});\n`;\n\n// Internal functions\nconst generateAPI = () => `\n(() => {\n${workerRuntime}\n${Array.from(apiToDefine, fn => `self.${fn} = createFunction(\"${fn}\");`).join(\"\\n\")}\n})();\n`;\n\n/** \n * @param {string} fn\n * @returns {Array<Trigger>} \n */\nconst getTriggers = (fn) => {\n    if (!scriptTriggers.has(fn))\n        scriptTriggers.set(fn, []);\n    return scriptTriggers.get(fn);\n}\n\n// API exposed to GDevelop\n/** \n * Defines an API, so that it becomes available on executed scripts.\n * @param {string} fn The name of the API to add.\n */\nconst define = (fn) => apiToDefine.add(fn);\n\n/** \n * Load a script. Be sure to call that after defining all necessary APIs.\n * @param {string} name The name of the script.\n * @param {string} code The script code.\n */\nconst loadScript = (name, code) => {\n    if (workers.has(name)) terminate(name);\n\n    const url = URL.createObjectURL(new Blob([generateAPI() + code], { type: \"text/javascript\" }));\n    const worker = new Worker(url, { name });\n    URL.revokeObjectURL(url);\n    workers.set(name, worker);\n\n    worker.onmessage = ({ data }) => {\n        if (typeof data !== \"object\") return;\n        const { op, fn, id, args } = data;\n\n        if (op === \"call\")\n            getTriggers(fn).push({ name, fn, id, args });\n    }\n};\n\n/** \n * Call a function attached to the global namespace of the script.\n * @param {string} name The name of the script.\n * @param {string} fn The global function name.\n * @param {Array<any>} args Arguments to pass to the function.\n */\nconst call = (name, fn, args) => {\n    const worker = workers.get(name);\n    if (worker) worker.postMessage({ op: \"call\", fn, args });\n};\n\n/** \n * Condition that triggers when an API has been called.\n * Also selects that call for next operations (Get argument, return a value...).\n * @param {string} fn The API to check for a call.\n */\nconst on = (fn) => {\n    if (currentEvent) returnFn();\n    define(fn);\n    const triggers = getTriggers(fn);\n    if (triggers.length === 0) return false;\n    currentEvent = triggers.shift();\n    return true;\n};\n\n/**\n * Returns a value to the currently selected API call.\n * Also deselects that call.\n * @param {any} val The value to return.\n */\nconst returnFn = (val) => {\n    if (!currentEvent) return;\n    const { name, fn, id } = currentEvent;\n    if (!workers.has(name)) return;\n    workers.get(name).postMessage({ op: \"resolve\", fn, id, val });\n    currentEvent = null;\n};\n\n/**\n * Get an argument of the currently selected API call.\n * @param {number} index The index of the argument in the argument list.\n * @returns {any} The argument.\n */\nconst getArg = (index) => currentEvent ? currentEvent.args[index] : undefined;\n\n/**\n * Get the argument count.\n * @returns {number} The number of arguments\n */\nconst getArgCount = (index) => currentEvent ? currentEvent.args.length : 0;\n\n/**\n * Terminates a script.\n * @param {string} name The name of the script to terminateö\n */\nconst terminate = (name) => {\n    const worker = workers.get(name);\n    if (worker) worker.terminate();\n};\n\n/**\n * The API namespace of the extension.\n * @namespace\n */\ngdjs._scriptingAPI = {\n    define,\n    loadScript,\n    on,\n    call,\n    returnFn,\n    getArg,\n    getArgCount,\n    terminate,\n};\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Loads a JavaScript script. Note that you must have defined all APIs you want to use before starting the script.",
+      "fullName": "Run JavaScript code",
+      "functionType": "Action",
+      "name": "LoadScript",
+      "private": false,
+      "sentence": "Run JavaScript script named _PARAM1_ with code _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const code = eventsFunctionContext.getArgument(\"code\");\r\nconst name = eventsFunctionContext.getArgument(\"name\");\r\ngdjs._scriptingAPI.loadScript(name, code);\r\n",
+          "parameterObjects": "",
+          "useStrict": false,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the script",
+          "longDescription": "",
+          "name": "name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The code to run",
+          "longDescription": "",
+          "name": "code",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Unloads a previously loaded script.",
+      "fullName": "Run JavaScript code",
+      "functionType": "Action",
+      "name": "UnloadScript",
+      "private": false,
+      "sentence": "Unload script _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"name\");\r\ngdjs._scriptingAPI.terminate(code);\r\n",
+          "parameterObjects": "",
+          "useStrict": false,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the script to unload",
+          "longDescription": "",
+          "name": "name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Define an API. Note that you do not need to do that if you checked if the API was called at least once before executing the script.",
+      "fullName": "Define API",
+      "functionType": "Action",
+      "name": "DefineAPI",
+      "private": false,
+      "sentence": "Define API _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"name\");\r\ngdjs._scriptingAPI.define(name);\r\n",
+          "parameterObjects": "",
+          "useStrict": false,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the API to define",
+          "longDescription": "",
+          "name": "name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "When an API is called from a script, triggers this condition. It will also select the call for the get argument expression and return actions. If another call is already selected, the other call will be returned. If the API was not previously defined, also defines it.",
+      "fullName": "API called",
+      "functionType": "Condition",
+      "name": "OnAPICall",
+      "private": false,
+      "sentence": "On call of function _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"name\");\neventsFunctionContext.returnValue = gdjs._scriptingAPI.on(name);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Name of the function",
+          "longDescription": "",
+          "name": "name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Get the amount of arguments passed by the API call.",
+      "fullName": "Get arguments count",
+      "functionType": "Expression",
+      "name": "ArgumentsCount",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = gdjs._scriptingAPI.getArgCount();\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Get an argument passed to the last API call as a number.",
+      "fullName": "Get argument as number",
+      "functionType": "Expression",
+      "name": "ArgumentAsNumber",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const index = eventsFunctionContext.getArgument(\"index\");\r\neventsFunctionContext.returnValue = gdjs._scriptingAPI.getArg(index);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The index of the argument",
+          "longDescription": "",
+          "name": "index",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Get an argument passed to the last API call as a string.",
+      "fullName": "Get argument as string",
+      "functionType": "StringExpression",
+      "name": "ArgumentAsString",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const index = eventsFunctionContext.getArgument(\"index\");\r\neventsFunctionContext.returnValue = gdjs._scriptingAPI.getArg(index);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The index of the argument",
+          "longDescription": "",
+          "name": "index",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Sets a scene variable to an argument of the last API call.",
+      "fullName": "Get argument as variable",
+      "functionType": "Action",
+      "name": "ArgumentAsVariable",
+      "private": false,
+      "sentence": "Set variable _PARAM1_ to the argument _PARAM2_ of the call",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const index = eventsFunctionContext.getArgument(\"index\");\r\nconst name = eventsFunctionContext.getArgument(\"name\");\r\nruntimeScene.getVariables().get(name).fromJSObject(gdjs._scriptingAPI.getArg(index));\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the variable",
+          "longDescription": "",
+          "name": "name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The index of the argument",
+          "longDescription": "",
+          "name": "index",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Returns a value to the script.",
+      "fullName": "Return a number",
+      "functionType": "Action",
+      "name": "ReturnNumber",
+      "private": false,
+      "sentence": "Return _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const returnValue = eventsFunctionContext.getArgument(\"returnValue\");\ngdjs._scriptingAPI.returnFn(returnValue);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The return value",
+          "longDescription": "",
+          "name": "returnValue",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Returns a value to the script.",
+      "fullName": "Return a string ",
+      "functionType": "Action",
+      "name": "ReturnString",
+      "private": false,
+      "sentence": "Return _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const returnValue = eventsFunctionContext.getArgument(\"returnValue\");\ngdjs._scriptingAPI.returnFn(returnValue);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The return value",
+          "longDescription": "",
+          "name": "returnValue",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Returns a value to the script.",
+      "fullName": "Return a boolean",
+      "functionType": "Action",
+      "name": "ReturnBoolean",
+      "private": false,
+      "sentence": "Return _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const returnValue = eventsFunctionContext.getArgument(\"returnValue\");\ngdjs._scriptingAPI.returnFn(returnValue);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The return value",
+          "longDescription": "",
+          "name": "returnValue",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "trueorfalse"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Returns nothing to the script.",
+      "fullName": "Return nothing",
+      "functionType": "Action",
+      "name": "Return",
+      "private": false,
+      "sentence": "Return the script",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs._scriptingAPI.returnFn();\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/extensions-registry.json
+++ b/extensions-registry.json
@@ -202,6 +202,11 @@
     "rotate13",
     "wrap",
     "teleport",
+    "worker",
+    "thread",
+    "engine",
+    "code",
+    "script",
     "animate",
     "shadow",
     "clone",
@@ -942,6 +947,19 @@
       "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/monitor-screenshot.svg",
       "eventsBasedBehaviorsCount": 1,
       "eventsFunctionsCount": 0
+    },
+    {
+      "shortDescription": "Execute arbitrary JavaScript safely in GDevelop games.",
+      "extensionNamespace": "",
+      "fullName": "Script Engine",
+      "name": "ScriptEngine",
+      "version": "1.0.0",
+      "url": "https://resources.gdevelop-app.com/extensions/ScriptEngine.json",
+      "headerUrl": "https://resources.gdevelop-app.com/extensions/ScriptEngine-header.json",
+      "tags": "worker,thread,javascript,engine,code,script",
+      "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Applications and Programming/Applications and Programming_script_code_snippet_download_save.svg",
+      "eventsBasedBehaviorsCount": 0,
+      "eventsFunctionsCount": 13
     },
     {
       "shortDescription": "Create and animate shadow clones that follow the path of a primary object.",


### PR DESCRIPTION
Adds a script engine extension, which allows executing JavaScript safely by isolating it in a web worker and exposing an events sheet controlled JavaScript API to that script. This allows to execute arbitrary scripts to allow extensions/mods/custom stuff to be made for games without exposing all of the game internals.  
Electron/node APIs seem to not be accessible from there as well, so this keeps players machines integrity safe (tested on preview and build).

Example game: [scripting.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/6819760/scripting.zip)