### PR TITLE
[Slider] Draw only when needed.

### DIFF
--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "Use a shape-painter object to draw a horizontal slider that can be dragged by the users. ",
-  "version": "0.3.3",
+  "version": "0.4.3",
   "tags": [
     "draggable",
     "slider",
@@ -17,6 +17,7 @@
     "ui",
     "widget"
   ],
+  "dependencies": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -30,55 +31,19 @@
           "fullName": "",
           "functionType": "Action",
           "name": "doStepPostEvents",
+          "private": false,
           "sentence": "",
           "events": [
             {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Move slider when being dragged",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "MouseX(Object.Layer())-Object.X()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
+              "name": "Slider logic",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
                   "disabled": false,
@@ -92,7 +57,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Enforce left boundry",
+                  "comment": "Move slider when being dragged",
                   "comment2": ""
                 },
                 {
@@ -103,14 +68,11 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "SourisX"
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
                       },
                       "parameters": [
-                        "",
-                        "<",
-                        "Object.X()",
-                        "Object.Layer()",
-                        ""
+                        "Object",
+                        "Behavior"
                       ],
                       "subInstructions": []
                     }
@@ -125,761 +87,227 @@
                         "Object",
                         "Behavior",
                         "=",
-                        "0"
+                        "MouseX(Object.Layer())-Object.X()"
                       ],
                       "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Enforce right boundry",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                    },
                     {
                       "type": {
                         "inverted": false,
-                        "value": "SourisX"
-                      },
-                      "parameters": [
-                        "",
-                        ">",
-                        "Object.X() +  Object.Behavior::PropertyTrackWidth()",
-                        "Object.Layer()",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
-                        "=",
-                        "Object.Behavior::PropertyTrackWidth()"
+                        "yes"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Use darker halo while being dragged",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
+                  "events": [
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::FillOpacity"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
                       },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Behavior::PropertyHaloOpacityClick()"
-                      ],
-                      "subInstructions": []
+                      "comment": "Enforce left boundry",
+                      "comment2": ""
                     },
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::OutlineOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "0"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "Object.X()",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
                     },
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::Circle"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
                       },
-                      "parameters": [
-                        "Object",
-                        "Object.Behavior::PropertyThumbOffset()",
-                        "Object.Behavior::PropertyTrackHeight()/2",
-                        "Object.Behavior::PropertyHaloRadius()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "End sliding and update variables",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "MouseButtonReleased"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "no"
-                      ],
-                      "subInstructions": []
+                      "comment": "Enforce right boundry",
+                      "comment2": ""
                     },
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DraggableSliderBehavior.SlideInProgress",
-                        "=",
-                        "0"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "Object.X() +  Object.Behavior::PropertyTrackWidth()",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Behavior::PropertyTrackWidth()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "End sliding and update variables",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseButtonReleased"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__DraggableSliderBehavior.SlideInProgress",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Update \"Value\" based on the location of the thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
                     }
-                  ],
-                  "events": []
-                }
-              ]
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Update \"Value\" based on the location of the thumb",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Set inactive track parameters (by default, use thumb color)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyThumbColor()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyInactiveTrackColor()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "Object.Behavior::PropertyInactiveTrackOpacity()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::OutlineOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw half circle at end (optional)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::Arc"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyTrackWidth()",
-                    "Object.Behavior::PropertyTrackHeight()/2",
-                    "Object.Behavior::PropertyTrackHeight()/2",
-                    "270",
-                    "90",
-                    "",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw inactive track",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::Rectangle"
-                  },
-                  "parameters": [
-                    "Object",
-                    "0",
-                    "0",
-                    "Object.Behavior::PropertyTrackWidth()",
-                    "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Set active track parameters (by default, use thumb color)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyThumbColor()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyActiveTrackColor()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "Object.Behavior::PropertyActiveTrackOpacity()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw half circle at end (optional)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::Arc"
-                  },
-                  "parameters": [
-                    "Object",
-                    "0",
-                    "Object.Behavior::PropertyTrackHeight()/2",
-                    "Object.Behavior::PropertyTrackHeight()/2",
-                    "90",
-                    "270",
-                    "",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw active track (2 pixels bigger than property) ",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::Rectangle"
-                  },
-                  "parameters": [
-                    "Object",
-                    "0",
-                    "-1",
-                    "Object.Behavior::PropertyThumbOffset()",
-                    "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight()) + 1"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Prepare thumb settings",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyThumbColor()"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::FillOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "Object.Behavior::PropertyThumbOpacity()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw Circle thumb",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"circle\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PrimitiveDrawing::Circle"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyThumbOffset()",
-                    "Object.Behavior::PropertyTrackHeight() / 2",
-                    "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Draw Rectangle thumb",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
                 {
                   "disabled": false,
                   "folded": false,
@@ -900,6 +328,19 @@
                   "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "\"rectangle\""
+                      ],
+                      "subInstructions": []
+                    },
                     {
                       "type": {
                         "inverted": false,
@@ -934,98 +375,6 @@
                 {
                   "disabled": false,
                   "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::Rectangle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                        "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
-                        "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
-                        "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ]
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "VarScene"
-                  },
-                  "parameters": [
-                    "__DraggableSliderBehavior.SlideInProgress",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "LayerVisible"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Object.Layer()"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Visible"
-                  },
-                  "parameters": [
-                    "Object"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -1035,7 +384,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Detect mouse clicks near track, start dragging",
+                  "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
                   "comment2": ""
                 },
                 {
@@ -1045,115 +394,463 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "SourisBouton"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisX"
-                      },
-                      "parameters": [
-                        "",
-                        ">=",
-                        "Object.X() - Object.Behavior::PropertyThumbWidth() / 2",
-                        "Object.Layer()",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisX"
-                      },
-                      "parameters": [
-                        "",
-                        "<=",
-                        "Object.X() + Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
-                        "Object.Layer()",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisY"
-                      },
-                      "parameters": [
-                        "",
-                        ">=",
-                        "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
-                        "Object.Layer()",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisY"
-                      },
-                      "parameters": [
-                        "",
-                        "<=",
-                        "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
-                        "Object.Layer()",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                        "inverted": true,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
                       },
                       "parameters": [
                         "Object",
-                        "Behavior",
-                        "yes"
+                        "Behavior"
                       ],
                       "subInstructions": []
                     },
                     {
                       "type": {
                         "inverted": false,
-                        "value": "ModVarScene"
+                        "value": "VarScene"
                       },
                       "parameters": [
                         "__DraggableSliderBehavior.SlideInProgress",
                         "=",
-                        "1"
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "LayerVisible"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Object.Layer()"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Visible"
+                      },
+                      "parameters": [
+                        "Object"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Draw halo when the mouse is hovering over thumb ",
-                  "comment2": ""
-                },
+                  "actions": [],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Detect mouse clicks near track, start dragging",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisBouton"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.X() - Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.X() + Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__DraggableSliderBehavior.SlideInProgress",
+                            "=",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Detect when the mouse is hovering over thumb ",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Slider drawing",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
                 {
                   "disabled": false,
                   "folded": false,
@@ -1162,56 +859,11 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "SourisX"
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyNeedRedraw"
                       },
                       "parameters": [
-                        "",
-                        ">=",
-                        "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                        "Object.Layer()",
-                        ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisX"
-                      },
-                      "parameters": [
-                        "",
-                        "<=",
-                        "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                        "Object.Layer()",
-                        ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisY"
-                      },
-                      "parameters": [
-                        "",
-                        ">=",
-                        "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
-                        "Object.Layer()",
-                        ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisY"
-                      },
-                      "parameters": [
-                        "",
-                        "<=",
-                        "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
-                        "Object.Layer()",
-                        ""
+                        "Object",
+                        "Behavior"
                       ],
                       "subInstructions": []
                     }
@@ -1220,44 +872,746 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "PrimitiveDrawing::FillOpacity"
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
                       },
                       "parameters": [
                         "Object",
-                        "=",
-                        "Object.Behavior::PropertyHaloOpacityHover()"
+                        "Behavior",
+                        "no"
                       ],
                       "subInstructions": []
                     },
                     {
                       "type": {
                         "inverted": false,
-                        "value": "PrimitiveDrawing::OutlineOpacity"
+                        "value": "PrimitiveDrawing::Drawer::ClearShapes"
                       },
                       "parameters": [
-                        "Object",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::Circle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Object.Behavior::PropertyThumbOffset()",
-                        "Object.Behavior::PropertyTrackHeight()/2",
-                        "Object.Behavior::PropertyHaloRadius()"
+                        "Object"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "MouseX(Object.Layer())-Object.X()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Use darker halo while being dragged",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityClick()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyTrackHeight()/2",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ]
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set inactive track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyInactiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyInactiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "270",
+                            "90",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw inactive track",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "0",
+                            "Object.Behavior::PropertyTrackWidth()",
+                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set active track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyActiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyActiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "90",
+                            "270",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw active track (2 pixels bigger than property) ",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "-1",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight()) + 1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Circle thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"circle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight() / 2",
+                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Prepare thumb settings",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyThumbOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Rectangle thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"rectangle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                                "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ]
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyHaloOpacityHover()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
                 }
-              ]
+              ],
+              "parameters": []
             }
           ],
           "parameters": [
@@ -1289,6 +1643,7 @@
           "fullName": "Is being dragged",
           "functionType": "Condition",
           "name": "IsBeingDragged",
+          "private": false,
           "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
           "events": [
             {
@@ -1352,6 +1707,7 @@
           "fullName": "",
           "functionType": "Action",
           "name": "onCreated",
+          "private": false,
           "sentence": "",
           "events": [
             {
@@ -1366,7 +1722,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure object gets re-drawn every frame",
+              "comment": "Make sure object dosn't get re-drawn every frame",
               "comment2": ""
             },
             {
@@ -1382,7 +1738,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "yes"
+                    "no"
                   ],
                   "subInstructions": []
                 }
@@ -1419,6 +1775,7 @@
           "fullName": "Change height of track",
           "functionType": "Action",
           "name": "SetTrackHeight",
+          "private": false,
           "sentence": "Set track height of _PARAM0_ to _PARAM2_px",
           "events": [
             {
@@ -1437,6 +1794,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1483,6 +1852,7 @@
           "fullName": "Change height of thumb",
           "functionType": "Action",
           "name": "SetThumbHeight",
+          "private": false,
           "sentence": "Set thumb height of _PARAM0_ to _PARAM2_px",
           "events": [
             {
@@ -1501,6 +1871,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1547,6 +1929,7 @@
           "fullName": "Change opacity of thumb",
           "functionType": "Action",
           "name": "SetThumbOpacity",
+          "private": false,
           "sentence": "Set thumb opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -1565,6 +1948,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1611,6 +2006,7 @@
           "fullName": "Change opacity of inactive track",
           "functionType": "Action",
           "name": "SetInactiveTrackOpacity",
+          "private": false,
           "sentence": "Set inactive track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -1629,6 +2025,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1675,6 +2083,7 @@
           "fullName": "Change opacity of active track",
           "functionType": "Action",
           "name": "SetActiveTrackOpacity",
+          "private": false,
           "sentence": "Set active track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -1693,6 +2102,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1739,6 +2160,7 @@
           "fullName": "Change width of track",
           "functionType": "Action",
           "name": "SetTrackWidth",
+          "private": false,
           "sentence": "Set track width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
@@ -1757,6 +2179,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1803,6 +2237,7 @@
           "fullName": "Change width of thumb",
           "functionType": "Action",
           "name": "SetThumbWidth",
+          "private": false,
           "sentence": "Set thumb width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
@@ -1821,6 +2256,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1867,6 +2314,7 @@
           "fullName": "Change shape of thumb (circle or rectangle)",
           "functionType": "Action",
           "name": "SetThumbShape",
+          "private": false,
           "sentence": "Set shape of _PARAM0_ to _PARAM2_.",
           "events": [
             {
@@ -1885,6 +2333,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsString(\"Shape\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1931,6 +2391,7 @@
           "fullName": "Change radius of halo",
           "functionType": "Action",
           "name": "SetHaloRadius",
+          "private": false,
           "sentence": "Set halo radius of _PARAM0_ to _PARAM2_px",
           "events": [
             {
@@ -1949,6 +2410,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -1995,6 +2468,7 @@
           "fullName": "Change color of active track",
           "functionType": "Action",
           "name": "SetActiveTrackColor",
+          "private": false,
           "sentence": "Set active track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -2013,6 +2487,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -2059,6 +2545,7 @@
           "fullName": "Change color of inactive track",
           "functionType": "Action",
           "name": "SetInactiveTrackColor",
+          "private": false,
           "sentence": "Set inactive track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -2077,6 +2564,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -2123,6 +2622,7 @@
           "fullName": "Make track use rounded ends.",
           "functionType": "Action",
           "name": "SetRoundedTrack",
+          "private": false,
           "sentence": "Draw _PARAM0_ with a rounded track? _PARAM2_",
           "events": [
             {
@@ -2192,6 +2692,27 @@
                 }
               ],
               "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
             }
           ],
           "parameters": [
@@ -2233,6 +2754,7 @@
           "fullName": "Change color of thumb",
           "functionType": "Action",
           "name": "SetThumbColor",
+          "private": false,
           "sentence": "Set thumb color of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -2251,6 +2773,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -2297,6 +2831,7 @@
           "fullName": "Change value of slider",
           "functionType": "Action",
           "name": "SetValue",
+          "private": false,
           "sentence": "Set value of _PARAM0_ to _PARAM2_",
           "events": [
             {
@@ -2426,6 +2961,18 @@
                     "Object.Behavior::PropertyValue() * Object.Behavior::PropertyTrackWidth()"
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
                 }
               ],
               "events": []
@@ -2470,6 +3017,7 @@
           "fullName": "Value",
           "functionType": "Expression",
           "name": "Value",
+          "private": false,
           "sentence": "",
           "events": [
             {
@@ -2679,6 +3227,33 @@
           "extraInformation": [],
           "hidden": false,
           "name": "RoundedTrack"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Need redraw",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "NeedRedraw"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Is hovered",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsHovered"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Was Hovered",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "WasHovered"
         }
       ]
     }


### PR DESCRIPTION
This uses the new "Clear" action of the ShapePainter indroduced in GDevelop 5.0.0-beta115.
It avoid to rebuild the shapes at every frame.

An example, to test: https://www.dropbox.com/s/pwwtqds56e5048f/MarchingSquares.zip?dl=1
and its build: https://games.gdevelop-app.com/game-b6f7ae43-151b-4cd1-95fe-fc30cadcb56c/index.html