### PR TITLE
[Flip3D] Duration instead of speed, trigo, revert at any time.

### DIFF
--- a/Extensions/ThreeDFlip.json
+++ b/Extensions/ThreeDFlip.json
@@ -308,7 +308,7 @@
           "objectGroups": []
         },
         {
-          "description": "Start a flipping animation on the object.",
+          "description": "Start a flipping animation on the object",
           "fullName": "Flip the object",
           "functionType": "Action",
           "name": "Flip",
@@ -649,7 +649,7 @@
           "objectGroups": []
         },
         {
-          "description": "Stops flipping the object.",
+          "description": "Stops flipping the object",
           "fullName": "Stop the flip",
           "functionType": "Action",
           "name": "StopFlip",
@@ -779,7 +779,7 @@
           "objectGroups": []
         },
         {
-          "description": "Checks if a flipping animation is currently playing.",
+          "description": "Checks if a flipping animation is currently playing",
           "fullName": "Flipping is playing",
           "functionType": "Condition",
           "name": "IsFlipping",
@@ -843,7 +843,7 @@
           "objectGroups": []
         },
         {
-          "description": "Checks if the object has been flipped.",
+          "description": "Checks if the object has been flipped",
           "fullName": "Is flipped",
           "functionType": "Condition",
           "name": "IsFlipped",
@@ -907,7 +907,7 @@
           "objectGroups": []
         },
         {
-          "description": "Flips the object to one specific side.",
+          "description": "Flips the object to one specific side",
           "fullName": "Flip to a side",
           "functionType": "Action",
           "name": "FlipTo",
@@ -1168,7 +1168,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "duration (in milliseconds)",
+              "description": "Duration (in milliseconds)",
               "longDescription": "",
               "name": "Duration",
               "optional": false,

--- a/Extensions/ThreeDFlip.json
+++ b/Extensions/ThreeDFlip.json
@@ -1,24 +1,24 @@
 {
-  "author": "VegeTato",
-  "description": "Helpful to give the feeling of 3D to your object character and your game.\nThe origin point must be at the center for the best results.",
+  "author": "VegeTato, D8H",
+  "description": "Helpful to make a 3D rotation effect on objects.\n\nNote that the X origin point must be at the center for the best results.",
   "extensionNamespace": "",
-  "fullName": "3D Flip your object",
+  "fullName": "3D Flip",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZsaXAtaG9yaXpvbnRhbCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xNSAyMUgxN1YxOUgxNU0xOSA5SDIxVjdIMTlNMyA1VjE5QzMgMjAuMSAzLjkgMjEgNSAyMUg5VjE5SDVWNUg5VjNINUMzLjkgMyAzIDMuOSAzIDVNMTkgM1Y1SDIxQzIxIDMuOSAyMC4xIDMgMTkgM00xMSAyM0gxM1YxSDExTTE5IDE3SDIxVjE1SDE5TTE1IDVIMTdWM0gxNU0xOSAxM0gyMVYxMUgxOU0xOSAyMUMyMC4xIDIxIDIxIDIwLjEgMjEgMTlIMTlaIiAvPjwvc3ZnPg==",
   "name": "ThreeDFlip",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flip-horizontal.svg",
-  "shortDescription": "Flip sprite with a 3D effect.",
-  "version": "0.1.2",
+  "shortDescription": "Flip sprites with a 3D effect.",
+  "version": "1.0.0",
   "tags": [
-    "3D",
+    "3d",
     "flip"
   ],
   "dependencies": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Flips a Sprite with a 3D effect.",
-      "fullName": "3D flip",
+      "description": "Flip a Sprite with a 3D effect.",
+      "fullName": "3D Flip",
       "name": "ThreeDFlip",
       "objectType": "Sprite",
       "eventsFunctions": [
@@ -38,49 +38,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::SetPropertywidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Width()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipping"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipped"
+                    "value": "ThreeDFlip::ThreeDFlip::PropertyIsFlipping"
                   },
                   "parameters": [
                     "Object",
@@ -95,93 +53,30 @@
                   "disabled": false,
                   "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "FlippedX"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
+                  "conditions": [],
                   "actions": [
                     {
                       "type": {
                         "inverted": false,
-                        "value": "ChangeWidth"
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyElapsedTime"
                       },
                       "parameters": [
                         "Object",
-                        "-",
-                        "Object.Behavior::Propertyspeed()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "FlippedX"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ChangeWidth"
-                      },
-                      "parameters": [
-                        "Object",
+                        "Behavior",
                         "+",
-                        "Object.Behavior::Propertyspeed()"
+                        "TimeDelta() * 1000"
                       ],
                       "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                    },
                     {
                       "type": {
                         "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "Object.Width()",
-                        "<=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "FlipX"
+                        "value": "ChangeWidth"
                       },
                       "parameters": [
                         "Object",
-                        "no"
+                        "=",
+                        "Object.Behavior::PropertyWidth() * abs(cos(3.141592 * Object.Behavior::PropertyElapsedTime() / Object.Behavior::PropertyDuration()))"
                       ],
                       "subInstructions": []
                     }
@@ -199,9 +94,95 @@
                         "value": "Egal"
                       },
                       "parameters": [
-                        "Object.Width()",
+                        "Object.Behavior::PropertyElapsedTime()",
                         ">=",
-                        "Object.Behavior::Propertywidth()"
+                        "Object.Behavior::PropertyDuration() / 2"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::PropertyIsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "FlipX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "ThreeDFlip::ThreeDFlip::PropertyIsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "FlipX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyElapsedTime()",
+                        ">=",
+                        "Object.Behavior::PropertyDuration()"
                       ],
                       "subInstructions": []
                     }
@@ -215,26 +196,14 @@
                       "parameters": [
                         "Object",
                         "=",
-                        "Object.Behavior::Propertywidth()"
+                        "Object.Behavior::PropertyWidth()"
                       ],
                       "subInstructions": []
                     },
                     {
                       "type": {
                         "inverted": false,
-                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipping"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "no"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipped"
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipping"
                       },
                       "parameters": [
                         "Object",
@@ -244,194 +213,72 @@
                       "subInstructions": []
                     }
                   ],
-                  "events": []
-                }
-              ]
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipping"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipped"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                  "events": [
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "FlippedX"
-                      },
-                      "parameters": [
-                        "Object"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "FlippedX"
+                          },
+                          "parameters": [
+                            "Object"
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ChangeWidth"
-                      },
-                      "parameters": [
-                        "Object",
-                        "+",
-                        "Object.Behavior::Propertyspeed()"
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "FlippedX"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ChangeWidth"
-                      },
-                      "parameters": [
-                        "Object",
-                        "-",
-                        "Object.Behavior::Propertyspeed()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "Object.Width()",
-                        "<=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "FlipX"
-                      },
-                      "parameters": [
-                        "Object",
-                        "yes"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "Object.Width()",
-                        ">=",
-                        "Object.Behavior::Propertywidth()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ChangeWidth"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Behavior::Propertywidth()"
-                      ],
-                      "subInstructions": []
+                      "events": []
                     },
                     {
-                      "type": {
-                        "inverted": false,
-                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipping"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "no"
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "FlippedX"
+                          },
+                          "parameters": [
+                            "Object"
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipped"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
                       ],
-                      "subInstructions": []
+                      "events": []
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -461,13 +308,277 @@
           "objectGroups": []
         },
         {
-          "description": "Starts flipping the object.",
+          "description": "Start a flipping animation on the object.",
           "fullName": "Flip the object",
           "functionType": "Action",
           "name": "Flip",
           "private": false,
-          "sentence": "Flip _PARAM0_",
+          "sentence": "Flip _PARAM0_ over _PARAM2_ms",
           "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "The previous animation is not yet finished, flip the other way aroud starting from there.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyElapsedTime"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyDuration() - Object.Behavior::PropertyElapsedTime() * GetArgumentAsNumber(\"Duration\") / Object.Behavior::PropertyDuration()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Set the flipped property as if the previous animation has finished.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyToggle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "ThreeDFlip::ThreeDFlip::PropertyToggle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyToggle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "ThreeDFlip::ThreeDFlip::PropertyToggle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ThreeDFlip::ThreeDFlip::SetPropertyToggle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Start a new flipping animation.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Width()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyElapsedTime"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
             {
               "disabled": false,
               "folded": false,
@@ -477,24 +588,25 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::StopFlip"
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipping"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    ""
+                    "yes"
                   ],
                   "subInstructions": []
                 },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipping"
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyDuration"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "yes"
+                    "=",
+                    "GetArgumentAsNumber(\"Duration\")"
                   ],
                   "subInstructions": []
                 }
@@ -522,6 +634,16 @@
               "optional": false,
               "supplementaryInformation": "ThreeDFlip::ThreeDFlip",
               "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Duration (in milliseconds)",
+              "longDescription": "",
+              "name": "Duration",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
             }
           ],
           "objectGroups": []
@@ -543,12 +665,24 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipping"
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipping"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ChangeWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "=",
+                    "Object.Behavior::PropertyWidth()"
                   ],
                   "subInstructions": []
                 }
@@ -575,7 +709,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipped"
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
                   },
                   "parameters": [
                     "Object",
@@ -607,7 +741,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyisFlipped"
+                    "value": "ThreeDFlip::ThreeDFlip::SetPropertyIsFlipped"
                   },
                   "parameters": [
                     "Object",
@@ -645,8 +779,8 @@
           "objectGroups": []
         },
         {
-          "description": "Checks if the object is in the process of being flipped.",
-          "fullName": "Is flipping?",
+          "description": "Checks if a flipping animation is currently playing.",
+          "fullName": "Flipping is playing",
           "functionType": "Condition",
           "name": "IsFlipping",
           "private": false,
@@ -660,7 +794,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipping"
+                    "value": "ThreeDFlip::ThreeDFlip::PropertyIsFlipping"
                   },
                   "parameters": [
                     "Object",
@@ -710,7 +844,7 @@
         },
         {
           "description": "Checks if the object has been flipped.",
-          "fullName": "Is flipped?",
+          "fullName": "Is flipped",
           "functionType": "Condition",
           "name": "IsFlipped",
           "private": false,
@@ -724,7 +858,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::PropertyisFlipped"
+                    "value": "ThreeDFlip::ThreeDFlip::PropertyIsFlipped"
                   },
                   "parameters": [
                     "Object",
@@ -778,61 +912,22 @@
           "functionType": "Action",
           "name": "FlipTo",
           "private": false,
-          "sentence": "Flip _PARAM0_ to the _PARAM2_",
+          "sentence": "Flip _PARAM0_ reverse side: _PARAM2_ over _PARAM3_ms",
           "events": [
             {
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "StrEqual"
-                  },
-                  "parameters": [
-                    "GetArgumentAsString(\"direction\")",
-                    "=",
-                    "\"Left\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::Flip"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "When the object is flipping, the \"is flipped\" parameter is not yet set,\nso it's value is the opposite of the animation goal.",
+              "comment2": ""
             },
             {
               "disabled": false,
@@ -842,34 +937,183 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "StrEqual"
-                  },
-                  "parameters": [
-                    "GetArgumentAsString(\"direction\")",
-                    "=",
-                    "\"Right\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
+                    "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
-                  "subInstructions": []
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Flip\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Flip\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Flip\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipping"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Flip\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ThreeDFlip::ThreeDFlip::IsFlipped"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    }
+                  ]
                 }
               ],
               "actions": [
@@ -881,6 +1125,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
+                    "GetArgumentAsNumber(\"Duration\")",
                     ""
                   ],
                   "subInstructions": []
@@ -913,12 +1158,22 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "The direction to flip to",
+              "description": "Reverse side",
               "longDescription": "",
-              "name": "direction",
+              "name": "Flip",
               "optional": false,
-              "supplementaryInformation": "[\"Left\",\"Right\"]",
-              "type": "stringWithSelector"
+              "supplementaryInformation": "[\"Flipped\",\"Unflipped\"]",
+              "type": "yesorno"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "duration (in milliseconds)",
+              "longDescription": "",
+              "name": "Duration",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
             }
           ],
           "objectGroups": []
@@ -926,13 +1181,22 @@
       ],
       "propertyDescriptors": [
         {
+          "value": "500",
+          "type": "Number",
+          "label": "Rotation duration (in milliseconds)",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Duration"
+        },
+        {
           "value": "",
           "type": "Boolean",
           "label": "",
           "description": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "isFlipped"
+          "name": "IsFlipped"
         },
         {
           "value": "\"r\"",
@@ -941,7 +1205,7 @@
           "description": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "isFlipping"
+          "name": "IsFlipping"
         },
         {
           "value": "",
@@ -950,16 +1214,25 @@
           "description": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "width"
+          "name": "Width"
         },
         {
-          "value": "100",
+          "value": "",
           "type": "Number",
-          "label": "The speed of the rotation (in pixel per second)",
+          "label": "Elapse time",
           "description": "",
           "extraInformation": [],
-          "hidden": false,
-          "name": "speed"
+          "hidden": true,
+          "name": "ElapsedTime"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Toggle"
         }
       ]
     }


### PR DESCRIPTION
Changes
* The speed property is replaced by a duration parameter to use it like Tweens.
  This is a breaking change so the version is incremented to 1.0.0
* The flipping uses a cosinus to make it more realistic.
* A flipping animation can be revert at any time.

* An example of animation on cards (position tween + flipping)
  https://www.dropbox.com/s/0v113sqm2vi9kds/Klondike.zip?dl=1
* A comparison with the previous version on the original example (the flip duration is long to let see what happens)
  https://www.dropbox.com/s/3xh24b5bnmbgi4d/3D%20Flip%20extension%20Example.zip?dl=1

Extension thread: https://github.com/GDevelopApp/GDevelop-extensions/issues/184