### PR TITLE
[Slider] Value range and tick spacing

### DIFF
--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -1,14 +1,14 @@
 {
-  "author": "Tristan Rhodes (https://victrisgames.itch.io/)",
-  "description": "The `Value` expression will return the position of the slider on the bar, from 0 to 1, where 0 is the left-side, and 1 is the right-side.\n\nYou can [watch this tutorial](https://youtu.be/iiTUwdAT_hs) showing how to use this extension - remember to attach it to a **Shape Painter** object.",
+  "author": "Tristan Rhodes (https://victrisgames.itch.io/), D8H",
+  "description": "This extension provides a behavior that draws a horizontal slider that can be dragged by the users. The value range and the tick spacing can be defined with properties.\nNote that this behavior can only be attached to a **Shape Painter** object.\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
   "extensionNamespace": "",
   "fullName": "Draggable Slider Control",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSI3IiByPSIzIi8+DQo8bGluZSBjbGFzcz0ic3QwIiB4MT0iMyIgeTE9IjciIHgyPSIyMCIgeTI9IjciLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjciIHgyPSIyNiIgeTI9IjciLz4NCjxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjEyIiBjeT0iMTYiIHI9IjMiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIzIiB5MT0iMTYiIHgyPSI5IiB5Mj0iMTYiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjE2IiB4Mj0iMTUiIHkyPSIxNiIvPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSIyNSIgcj0iMyIvPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjMiIHkxPSIyNSIgeDI9IjIwIiB5Mj0iMjUiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjI1IiB4Mj0iMjYiIHkyPSIyNSIvPg0KPC9zdmc+DQo=",
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
-  "shortDescription": "Use a shape-painter object to draw a horizontal slider that can be dragged by the users. ",
-  "version": "0.4.4",
+  "shortDescription": "A horizontal slider that can be dragged by the users. ",
+  "version": "0.5.4",
   "tags": [
     "draggable",
     "slider",
@@ -21,7 +21,7 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Use a shape-painter object to draw a horizontal slider that can be dragged by the users. \n\nThe `Value` expression will return the position of the slider on the bar, from 0 to 1, where 0 is the left-side, and 1 is the right-side.",
+      "description": "Draw a horizontal slider that can be dragged by the users. \n\nThe value range and the tick spacing can be defined with properties.",
       "fullName": "Draggable Slider Control",
       "name": "DraggableSliderControl",
       "objectType": "PrimitiveDrawing::Drawer",
@@ -30,7 +30,7 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
-          "name": "doStepPostEvents",
+          "name": "doStepPreEvents",
           "private": false,
           "sentence": "",
           "events": [
@@ -117,110 +117,6 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Enforce left boundry",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            "<",
-                            "Object.X()",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Enforce right boundry",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            ">",
-                            "Object.X() +  Object.Behavior::PropertyTrackWidth()",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "Object.Behavior::PropertyTrackWidth()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
                       "comment": "End sliding and update variables",
                       "comment2": ""
                     },
@@ -293,13 +189,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "=",
-                            "Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()"
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
+                            ""
                           ],
                           "subInstructions": []
                         }
@@ -775,7 +671,40 @@
                 }
               ],
               "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
             },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
             {
               "colorB": 228,
               "colorG": 176,
@@ -1740,11 +1669,11 @@
         },
         {
           "description": "Change height of track",
-          "fullName": "Change height of track",
+          "fullName": "Track height",
           "functionType": "Action",
           "name": "SetTrackHeight",
           "private": false,
-          "sentence": "Set track height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -1869,7 +1798,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New track height (px)",
+              "description": "Track height",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -1881,11 +1810,11 @@
         },
         {
           "description": "Change height of thumb",
-          "fullName": "Change height of thumb",
+          "fullName": "Thumb height",
           "functionType": "Action",
           "name": "SetThumbHeight",
           "private": false,
-          "sentence": "Set thumb height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -1946,7 +1875,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New thumb height (px)",
+              "description": "Thumb height",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -1958,11 +1887,11 @@
         },
         {
           "description": "Change opacity of thumb",
-          "fullName": "Change opacity of thumb",
+          "fullName": "Thumb opacity",
           "functionType": "Action",
           "name": "SetThumbOpacity",
           "private": false,
-          "sentence": "Set thumb opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2023,7 +1952,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New thumb opacity",
+              "description": "Thumb opacity",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2035,11 +1964,11 @@
         },
         {
           "description": "Change opacity of inactive track",
-          "fullName": "Change opacity of inactive track",
+          "fullName": "Inactive track opacity",
           "functionType": "Action",
           "name": "SetInactiveTrackOpacity",
           "private": false,
-          "sentence": "Set inactive track opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2100,7 +2029,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New inactive track opacity",
+              "description": "Inactive track opacity",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2112,11 +2041,11 @@
         },
         {
           "description": "Change opacity of active track",
-          "fullName": "Change opacity of active track",
+          "fullName": "Active track opacity",
           "functionType": "Action",
           "name": "SetActiveTrackOpacity",
           "private": false,
-          "sentence": "Set active track opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2177,7 +2106,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New active track opacity",
+              "description": "Active track opacity",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2189,11 +2118,11 @@
         },
         {
           "description": "Change width of track",
-          "fullName": "Change width of track",
+          "fullName": "Track width",
           "functionType": "Action",
           "name": "SetTrackWidth",
           "private": false,
-          "sentence": "Set track width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -2254,7 +2183,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New track width (px)",
+              "description": "Track width",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2266,11 +2195,11 @@
         },
         {
           "description": "Change width of thumb",
-          "fullName": "Change width of thumb",
+          "fullName": "Thumb width",
           "functionType": "Action",
           "name": "SetThumbWidth",
           "private": false,
-          "sentence": "Set thumb width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -2395,7 +2324,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New thumb width (px)",
+              "description": "Thumb width",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2407,11 +2336,11 @@
         },
         {
           "description": "Change shape of thumb (circle or rectangle)",
-          "fullName": "Change shape of thumb (circle or rectangle)",
+          "fullName": "Thumb shape",
           "functionType": "Action",
           "name": "SetThumbShape",
           "private": false,
-          "sentence": "Set shape of _PARAM0_ to _PARAM2_.",
+          "sentence": "Change shape of _PARAM0_ to _PARAM2_.",
           "events": [
             {
               "disabled": false,
@@ -2548,11 +2477,11 @@
         },
         {
           "description": "Change the radius of halo",
-          "fullName": "Change radius of halo",
+          "fullName": "Halo Radius",
           "functionType": "Action",
           "name": "SetHaloRadius",
           "private": false,
-          "sentence": "Set halo radius of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -2613,7 +2542,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New halo radius (px)",
+              "description": "Halo radius",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2625,11 +2554,11 @@
         },
         {
           "description": "Change the color of the track that is LEFT of the thumb.",
-          "fullName": "Change color of active track",
+          "fullName": "Active track color ",
           "functionType": "Action",
           "name": "SetActiveTrackColor",
           "private": false,
-          "sentence": "Set active track color of _PARAM0_ to _PARAM2_",
+          "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2690,7 +2619,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New color for active track",
+              "description": "Active track color",
               "longDescription": "",
               "name": "Color",
               "optional": false,
@@ -2702,11 +2631,11 @@
         },
         {
           "description": "Change the color of the track that is RIGHT of the thumb.",
-          "fullName": "Change color of inactive track",
+          "fullName": "Inactive track color",
           "functionType": "Action",
           "name": "SetInactiveTrackColor",
           "private": false,
-          "sentence": "Set inactive track color of _PARAM0_ to _PARAM2_",
+          "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2767,7 +2696,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New color for inactive track",
+              "description": "Inactive track color",
               "longDescription": "",
               "name": "Color",
               "optional": false,
@@ -2779,11 +2708,11 @@
         },
         {
           "description": "Make track use rounded ends.",
-          "fullName": "Make track use rounded ends.",
+          "fullName": "Rounded track ends",
           "functionType": "Action",
           "name": "SetRoundedTrack",
           "private": false,
-          "sentence": "Draw _PARAM0_ with a rounded track? _PARAM2_",
+          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2899,7 +2828,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "",
+              "description": "Ronded track",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2910,12 +2839,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change the color of thumb to a specific value.",
-          "fullName": "Change color of thumb",
+          "description": "Change the thumb color to a specific value.",
+          "fullName": "Thumb color",
           "functionType": "Action",
           "name": "SetThumbColor",
           "private": false,
-          "sentence": "Set thumb color of _PARAM0_ to _PARAM2_",
+          "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2976,7 +2905,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New thumb color",
+              "description": "Thumb color",
               "longDescription": "",
               "name": "Color",
               "optional": false,
@@ -2988,7 +2917,7 @@
         },
         {
           "description": "Change the value of a slider to a specific value (this will move the thumb to the correct position).",
-          "fullName": "Change value of slider",
+          "fullName": "Slider value",
           "functionType": "Action",
           "name": "SetValue",
           "private": false,
@@ -2998,7 +2927,21 @@
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
               "actions": [
                 {
                   "type": {
@@ -3024,12 +2967,12 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "<",
+                    ">",
                     "0"
                   ],
                   "subInstructions": []
@@ -3045,7 +2988,43 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "0"
+                    "round(GetArgumentAsNumber(\"Value\") / Object.Behavior::PropertyTickSpacing()) * Object.Behavior::PropertyTickSpacing()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyValueMin()"
                   ],
                   "subInstructions": []
                 }
@@ -3066,7 +3045,7 @@
                     "Object",
                     "Behavior",
                     ">",
-                    "1"
+                    "Object.Behavior::PropertyValueMax()"
                   ],
                   "subInstructions": []
                 }
@@ -3081,7 +3060,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "1"
+                    "Object.Behavior::PropertyValueMax()"
                   ],
                   "subInstructions": []
                 }
@@ -3118,7 +3097,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "Object.Behavior::PropertyValue() * Object.Behavior::PropertyTrackWidth()"
+                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
                   ],
                   "subInstructions": []
                 },
@@ -3162,7 +3141,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "New slider value",
+              "description": "Slider value",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -3174,7 +3153,7 @@
         },
         {
           "description": "The value of the slider (based on position of the thumb).",
-          "fullName": "Value",
+          "fullName": "Slider value",
           "functionType": "Expression",
           "name": "Value",
           "private": false,
@@ -3227,9 +3206,36 @@
       ],
       "propertyDescriptors": [
         {
+          "value": "0",
+          "type": "Number",
+          "label": "Minimal value",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ValueMin"
+        },
+        {
+          "value": "1",
+          "type": "Number",
+          "label": "Maximal value",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ValueMax"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Tick spacing",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "TickSpacing"
+        },
+        {
           "value": "circle",
           "type": "String",
-          "label": "Shape of the thumb. Either \"circle\" or \"rectangle\".",
+          "label": "Thumb shape (\"circle\" or \"rectangle\")",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3238,7 +3244,7 @@
         {
           "value": "20",
           "type": "Number",
-          "label": "Width of the thumb (px) Example: 20",
+          "label": "Thumb width",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3247,7 +3253,7 @@
         {
           "value": "20",
           "type": "Number",
-          "label": "Height of the thumb (px) Example: 20",
+          "label": "Thumb height",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3256,7 +3262,7 @@
         {
           "value": " 24;119;211",
           "type": "String",
-          "label": "Color string for the thumb. Example:  24;119;211",
+          "label": "Thumb Color",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3265,7 +3271,7 @@
         {
           "value": "255",
           "type": "Number",
-          "label": "Opacity of the thumb. Example: 255",
+          "label": "Thumb opacity",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3274,7 +3280,7 @@
         {
           "value": "200",
           "type": "Number",
-          "label": "Width of the track (px) Example: 200",
+          "label": "Track width",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3283,7 +3289,7 @@
         {
           "value": "4",
           "type": "Number",
-          "label": "Height of the track (px) Example: 4",
+          "label": "Track height",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3292,7 +3298,7 @@
         {
           "value": "",
           "type": "String",
-          "label": "Color string for the track that is RIGHT of the thumb. Example:  24;119;211  (Leave blank to use thumb color)",
+          "label": "Inactive track color (thumb color by default)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3301,7 +3307,7 @@
         {
           "value": "96",
           "type": "Number",
-          "label": "Opacity of the track that is RIGHT of the thumb.  Example: 96",
+          "label": "Inactive track opacity",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3310,7 +3316,7 @@
         {
           "value": " ",
           "type": "String",
-          "label": "Color string for the track that is LEFT of the thumb. Example:  24;119;211 (Leave blank to use thumb color)",
+          "label": "Active track color (thumb color by default)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3319,7 +3325,7 @@
         {
           "value": "255",
           "type": "Number",
-          "label": "Opacity of the track that is LEFT of the thumb.  Example: 255",
+          "label": "Active track opacity",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3328,7 +3334,7 @@
         {
           "value": "24",
           "type": "Number",
-          "label": "Size of halo when the mouse hovers and clicks on the thumb. Example: 24",
+          "label": "Hover halo size",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3337,7 +3343,7 @@
         {
           "value": "32",
           "type": "Number",
-          "label": "Opacity of halo when the mouse hovers on the thumb. Example: 32",
+          "label": "Hover halo opacity",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3346,16 +3352,25 @@
         {
           "value": "64",
           "type": "Number",
-          "label": "Opacity of the halo that appears when the mouse clicks on the thumb. Example: 64",
+          "label": "Pressed halo opacity",
           "description": "",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloOpacityClick"
         },
         {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Rounded track ends",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "RoundedTrack"
+        },
+        {
           "value": "",
           "type": "Boolean",
-          "label": "True if the thumb is being dragged",
+          "label": "Is being dragged",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3364,7 +3379,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Range (0,1) based on the thumb position on the track.  0=left, 1=right",
+          "label": "Value",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3373,20 +3388,11 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Number of pixels the thumb is from the left side of the track.",
+          "label": "Thumb offset (thumb position on the track)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
           "name": "ThumbOffset"
-        },
-        {
-          "value": "true",
-          "type": "Boolean",
-          "label": "If true, round the ends of the track.",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "RoundedTrack"
         },
         {
           "value": "true",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A horizontal slider that can be dragged by the users. ",
-  "version": "0.5.5",
+  "version": "0.5.0",
   "tags": [
     "draggable",
     "slider",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -3208,7 +3208,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Minimal value",
+          "label": "Minimum value",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3217,7 +3217,7 @@
         {
           "value": "1",
           "type": "Number",
-          "label": "Maximal value",
+          "label": "Maximum value",
           "description": "",
           "extraInformation": [],
           "hidden": false,

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A horizontal slider that can be dragged by the users. ",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "tags": [
     "draggable",
     "slider",
@@ -1245,6 +1245,53 @@
                         "textG": 0,
                         "textR": 0
                       },
+                      "comment": "Prepare thumb settings",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyThumbOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
                       "comment": "Draw Circle thumb",
                       "comment2": ""
                     },
@@ -1278,53 +1325,6 @@
                             "Object.Behavior::PropertyThumbOffset()",
                             "Object.Behavior::PropertyTrackHeight() / 2",
                             "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Prepare thumb settings",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyThumbOpacity()"
                           ],
                           "subInstructions": []
                         }

--- a/extensions-registry.json
+++ b/extensions-registry.json
@@ -453,11 +453,12 @@
       "eventsFunctionsCount": 4
     },
     {
-      "shortDescription": "Revert the last drag and drop with an animation",
+      "authorIds": [],
+      "shortDescription": "Allow to cancel the drag of an object (having the Draggable behavior) and return it smoothly to its previous position.",
       "extensionNamespace": "",
-      "fullName": "Cancellable draggable",
+      "fullName": "Cancellable draggable object",
       "name": "CancellableDraggable",
-      "version": "0.1.1",
+      "version": "0.1.0",
       "url": "https://resources.gdevelop-app.com/extensions/CancellableDraggable.json",
       "headerUrl": "https://resources.gdevelop-app.com/extensions/CancellableDraggable-header.json",
       "tags": "drag,drop",
@@ -622,11 +623,11 @@
       "eventsFunctionsCount": 1
     },
     {
-      "shortDescription": "Use a shape-painter object to draw a horizontal slider that can be dragged by the users. ",
+      "shortDescription": "A horizontal slider that can be dragged by the users. ",
       "extensionNamespace": "",
       "fullName": "Draggable Slider Control",
       "name": "DraggableSliderControl",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "url": "https://resources.gdevelop-app.com/extensions/DraggableSliderControl.json",
       "headerUrl": "https://resources.gdevelop-app.com/extensions/DraggableSliderControl-header.json",
       "tags": "draggable,slider,control,shape painter,ui,widget",


### PR DESCRIPTION
This add 3 properties (it doesn't break compatibility)
* Minimum value (0 by default)
* Maximum value (1 by default)
* Tick spacing (0 = none by default)

Properties, actions and parameters name now better follow recommendations.

User input handling has been moved from post to pre (it was already separated from drawing in the previous update)

* Fog of war example: https://www.dropbox.com/s/jt7b2qmp5di33ny/marching-square-fog-of-war.zip?dl=1