### PR TITLE
[Mask] Make it explicit that a shape painters can be used as a mask on any objects

### DIFF
--- a/Extensions/SpriteMasking.json
+++ b/Extensions/SpriteMasking.json
@@ -1,14 +1,14 @@
 {
   "author": "Arthur Pacaud (arthuro555)",
-  "description": "When masked, the masked sprite is only visible through the mask.",
+  "description": "When masked, the masked object is only visible through the mask.",
   "extensionNamespace": "",
-  "fullName": "Sprite Masking",
+  "fullName": "Object Masking",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXRyYW5zaXRpb24tbWFza2VkIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE1LDJDMTYuOTQsMiAxOC41OSwyLjcgMTkuOTUsNC4wNUMyMS4zLDUuNDEgMjIsNy4wNiAyMiw5QzIyLDEwLjU2IDIxLjUsMTEuOTYgMjAuNTgsMTMuMkMxOS42NCwxNC40MyAxOC40NCwxNS4yNyAxNi45NywxNS43TDE3LDE1LjM4VjE1QzE3LDEyLjgxIDE2LjIzLDEwLjkzIDE0LjY1LDkuMzVDMTMuMDcsNy43NyAxMS4xOSw3IDksN0g4LjYzTDguMyw3LjAzQzguNzMsNS41NiA5LjU3LDQuMzYgMTAuOCwzLjQyQzEyLjA0LDIuNSAxMy40NCwyIDE1LDJNOSw4QTcsNyAwIDAsMSAxNiwxNUE3LDcgMCAwLDEgOSwyMkE3LDcgMCAwLDEgMiwxNUE3LDcgMCAwLDEgOSw4TTksMTBBNSw1IDAgMCwwIDQsMTVBNSw1IDAgMCwwIDksMjBBNSw1IDAgMCwwIDE0LDE1QTUsNSAwIDAsMCA5LDEwWiIgLz48L3N2Zz4=",
   "name": "SpriteMasking",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/transition-masked.svg",
-  "shortDescription": "Allow to use a sprite object to mask another.",
-  "version": "2.0.0",
+  "shortDescription": "Use a sprite or a shape painter to mask another object.",
+  "version": "2.1.0",
   "tags": [
     "masking",
     "javascript",
@@ -18,8 +18,50 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Defines a sprite as a mask of another.",
-      "fullName": "Mask a Sprite with another",
+      "description": "Define a shape painter as a mask of an object.",
+      "fullName": "Mask an object with a shape painter",
+      "functionType": "Action",
+      "name": "MaskWithShapePainter",
+      "private": false,
+      "sentence": "Mask _PARAM1_ with mask _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const maskObject = eventsFunctionContext.getObjects(\"Mask\")[0];\nif (!maskObject) return;\n\nconst maskedObjects = eventsFunctionContext.getObjects(\"Masked\");\nfor (const maskedObject of maskedObjects) {\n    const maskedRenderer = maskedObject.getRendererObject(); \n    maskedRenderer.mask = maskObject.getRendererObject();\n}\n\n",
+          "parameterObjects": "masked",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Object to mask",
+          "longDescription": "",
+          "name": "Masked",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Shape painter to use as a mask",
+          "longDescription": "",
+          "name": "Mask",
+          "optional": false,
+          "supplementaryInformation": "PrimitiveDrawing::Drawer",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Define a sprite as a mask of an object.",
+      "fullName": "Mask an object with a sprite",
       "functionType": "Action",
       "name": "Mask",
       "private": false,
@@ -39,11 +81,11 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Sprite object to mask",
+          "description": "Object to mask",
           "longDescription": "",
           "name": "Masked",
           "optional": false,
-          "supplementaryInformation": "Sprite",
+          "supplementaryInformation": "",
           "type": "objectList"
         },
         {
@@ -81,7 +123,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Sprite object with a mask to remove",
+          "description": "Object with a mask to remove",
           "longDescription": "",
           "name": "Masked",
           "optional": false,


### PR DESCRIPTION
Changes
* Add an action to mask with a shape painter
* Make the the masked object parameter any object type instead of only Sprite
* Reword the description according to these changes

The JS code is an exact copy of the other mask action.

* Example : paint a textured shape with the mouse.
https://www.dropbox.com/s/pwwtqds56e5048f/MarchingSquares.zip?dl=1