### PR TITLE
[LinkTools] Fix pathfinding movement

### DIFF
--- a/Extensions/LinkTools.json
+++ b/Extensions/LinkTools.json
@@ -7,8 +7,8 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWdyYXBoLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTkuNSAxN0MxOS4zNiAxNyAxOS4yNCAxNyAxOS4xMSAxNy4wNEwxNy41IDEzLjhDMTcuOTUgMTMuMzUgMTguMjUgMTIuNzEgMTguMjUgMTJDMTguMjUgMTAuNjIgMTcuMTMgOS41IDE1Ljc1IDkuNUMxNS42MSA5LjUgMTUuNSA5LjUgMTUuMzUgOS41NEwxMy43NCA2LjNDMTQuMjEgNS44NCAxNC41IDUuMjEgMTQuNSA0LjVDMTQuNSAzLjEyIDEzLjM4IDIgMTIgMlM5LjUgMy4xMiA5LjUgNC41QzkuNSA1LjIgOS43OSA1Ljg0IDEwLjI2IDYuMjlMOC42NSA5LjU0QzguNSA5LjUgOC4zOSA5LjUgOC4yNSA5LjVDNi44NyA5LjUgNS43NSAxMC42MiA1Ljc1IDEyQzUuNzUgMTIuNzEgNi4wNCAxMy4zNCA2LjUgMTMuNzlMNC44OSAxNy4wNEM0Ljc2IDE3IDQuNjQgMTcgNC41IDE3QzMuMTIgMTcgMiAxOC4xMiAyIDE5LjVDMiAyMC44OCAzLjEyIDIyIDQuNSAyMlM3IDIwLjg4IDcgMTkuNUM3IDE4LjggNi43MSAxOC4xNiA2LjI0IDE3LjcxTDcuODYgMTQuNDZDOCAxNC41IDguMTIgMTQuNSA4LjI1IDE0LjVDOC4zOCAxNC41IDguNSAxNC41IDguNjMgMTQuNDZMMTAuMjYgMTcuNzFDOS43OSAxOC4xNiA5LjUgMTguOCA5LjUgMTkuNUM5LjUgMjAuODggMTAuNjIgMjIgMTIgMjJTMTQuNSAyMC44OCAxNC41IDE5LjVDMTQuNSAxOC4xMiAxMy4zOCAxNyAxMiAxN0MxMS44NyAxNyAxMS43NCAxNyAxMS42MSAxNy4wNEwxMCAxMy44QzEwLjQ1IDEzLjM1IDEwLjc1IDEyLjcxIDEwLjc1IDEyQzEwLjc1IDExLjMgMTAuNDYgMTAuNjcgMTAgMTAuMjFMMTEuNjEgNi45NkMxMS43NCA3IDExLjg3IDcgMTIgN0MxMi4xMyA3IDEyLjI2IDcgMTIuMzkgNi45NkwxNCAxMC4yMUMxMy41NCAxMC42NiAxMy4yNSAxMS4zIDEzLjI1IDEyQzEzLjI1IDEzLjM4IDE0LjM3IDE0LjUgMTUuNzUgMTQuNUMxNS44OCAxNC41IDE2IDE0LjUgMTYuMTMgMTQuNDZMMTcuNzYgMTcuNzFDMTcuMjkgMTguMTYgMTcgMTguOCAxNyAxOS41QzE3IDIwLjg4IDE4LjEyIDIyIDE5LjUgMjJTMjIgMjAuODggMjIgMTkuNUMyMiAxOC4xMiAyMC44OCAxNyAxOS41IDE3TTQuNSAyMC41QzMuOTUgMjAuNSAzLjUgMjAuMDUgMy41IDE5LjVTMy45NSAxOC41IDQuNSAxOC41IDUuNSAxOC45NSA1LjUgMTkuNSA1LjA1IDIwLjUgNC41IDIwLjVNMTMgMTkuNUMxMyAyMC4wNSAxMi41NSAyMC41IDEyIDIwLjVTMTEgMjAuMDUgMTEgMTkuNSAxMS40NSAxOC41IDEyIDE4LjUgMTMgMTguOTUgMTMgMTkuNU03LjI1IDEyQzcuMjUgMTEuNDUgNy43IDExIDguMjUgMTFTOS4yNSAxMS40NSA5LjI1IDEyIDguOCAxMyA4LjI1IDEzIDcuMjUgMTIuNTUgNy4yNSAxMk0xMSA0LjVDMTEgMy45NSAxMS40NSAzLjUgMTIgMy41UzEzIDMuOTUgMTMgNC41IDEyLjU1IDUuNSAxMiA1LjUgMTEgNS4wNSAxMSA0LjVNMTQuNzUgMTJDMTQuNzUgMTEuNDUgMTUuMiAxMSAxNS43NSAxMVMxNi43NSAxMS40NSAxNi43NSAxMiAxNi4zIDEzIDE1Ljc1IDEzIDE0Ljc1IDEyLjU1IDE0Ljc1IDEyTTE5LjUgMjAuNUMxOC45NSAyMC41IDE4LjUgMjAuMDUgMTguNSAxOS41UzE4Ljk1IDE4LjUgMTkuNSAxOC41IDIwLjUgMTguOTUgMjAuNSAxOS41IDIwLjA1IDIwLjUgMTkuNSAyMC41WiIgLz48L3N2Zz4=",
   "name": "LinkTools",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/graph-outline.svg",
-  "shortDescription": "Conditions to use Linked Objects as a graph and a path finding movement behavior",
-  "version": "1.2.0",
+  "shortDescription": "Conditions to use Linked Objects as a graph and a path finding movement behavior.",
+  "version": "1.2.1",
   "tags": [
     "link",
     "graph",
@@ -1352,35 +1352,8 @@
                   "disabled": false,
                   "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "Object.SqDistanceToPosition(Object.Behavior::PropertyNextNodeX(), Object.Behavior::PropertyNextNodeY())",
-                        ">",
-                        "Object.Behavior::PropertySpeed() * TimeDelta()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
+                  "conditions": [],
                   "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "AddForceVersPos"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Object.Behavior::PropertyNextNodeX()",
-                        "Object.Behavior::PropertyNextNodeY()",
-                        "Object.Behavior::PropertySpeed()",
-                        ""
-                      ],
-                      "subInstructions": []
-                    },
                     {
                       "type": {
                         "inverted": false,
@@ -1409,7 +1382,7 @@
                       "parameters": [
                         "Object.SqDistanceToPosition(Object.Behavior::PropertyNextNodeX(), Object.Behavior::PropertyNextNodeY())",
                         "<=",
-                        "Object.Behavior::PropertySpeed() * TimeDelta()"
+                        "Object.Behavior::PropertySpeed() * TimeDelta() * Object.Behavior::PropertySpeed() * TimeDelta()"
                       ],
                       "subInstructions": []
                     }
@@ -1450,6 +1423,41 @@
                         "Object",
                         "Behavior",
                         "Object.Behavior::PropertyNextNodeIndex() + 1",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "LinkTools::LinkPathFinding::PropertyIsAtNode"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "AddForceVersPos"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Object.Behavior::PropertyNextNodeX()",
+                        "Object.Behavior::PropertyNextNodeY()",
+                        "Object.Behavior::PropertySpeed()",
                         ""
                       ],
                       "subInstructions": []


### PR DESCRIPTION
Objects could freeze at node because of the distance check (square distance against distance).

See the tactical relative example update for reproducing steps:
https://github.com/GDevelopApp/GDevelop-examples/pull/124