### PR TITLE
Create key remapper extension

### DIFF
--- a/Extensions/BehaviorRemapper.json
+++ b/Extensions/BehaviorRemapper.json
@@ -1,18 +1,21 @@
 {
   "author": "",
-  "description": "Make sure to disable default controls unless you want two keys to do the same action.\n\nAdditionally, actions have two versions. `custom` allow the movement keys to be changed to what ever you would like. `presets` provide a common key-bindings that can be selected from a list.\n\nPreset Options:\n`WASD`\n-\tW: Up\n-\tA: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`ZQSD`\n-\tZ: Up\n-\tQ: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`Numpad` (Num lock must be disabled)\n-\tNumpad Up: Up\n-\tNumpad Left: Left\n-\tNumpad Down: Down\n-\tNumpad Right: Right\n-\tNumpad Return/Enter: Jump\n\n`IJKL`\n-\tI: Up\n-\tJ: Left\n-\tK: Down\n-\tL: Right\n-\tReturn/Enter: Jump\n",
+  "description": "Make sure to disable default controls unless you want two keys to do the same action.\n\nActions have two versions. `custom` allow the movement keys to be changed to what ever you would like. `presets` provide a common key-bindings that can be selected from a list.\n\n### Available Presets:\n\n##### `WASD`\n-\tW: Up\n-\tA: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n##### `ZQSD`\n-\tZ: Up\n-\tQ: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n##### `Numpad` (Num lock must be disabled)\n-\tNumpad Up: Up\n-\tNumpad Left: Left\n-\tNumpad Down: Down\n-\tNumpad Right: Right\n-\tNumpad Return/Enter: Jump\n\n##### `IJKL`\n-\tI: Up\n-\tJ: Left\n-\tK: Down\n-\tL: Right\n-\tReturn/Enter: Jump\n",
   "extensionNamespace": "",
-  "fullName": "Key Remapper",
+  "fullName": "Behavior Remapper",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWFscGhhLXctYm94LW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNOSwxN0EyLDIgMCAwLDEgNywxNVY3SDlWMTVIMTFWOEgxM1YxNUgxNVY3SDE3VjE1QTIsMiAwIDAsMSAxNSwxN0g5TTUsM0gxOUEyLDIgMCAwLDEgMjEsNVYxOUEyLDIgMCAwLDEgMTksMjFINUEyLDIgMCAwLDEgMywxOVY1QTIsMiAwIDAsMSA1LDNNNSw1VjE5SDE5VjVINVoiIC8+PC9zdmc+",
-  "name": "KeyRemapper",
+  "name": "BehaviorRemapper",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/alpha-w-box-outline.svg",
-  "shortDescription": "Quickly map keyboard controls to different keys. ",
+  "shortDescription": "Quickly remap Behavior controls to different keys. ",
   "version": "1.0.0",
   "tags": [
     "remapper",
-    "key-bindings",
-    "presets"
+    "key",
+    "bindings",
+    "presets",
+    "platformer",
+    "top-down"
   ],
   "authorIds": [
     "AlZ3D1xkH0QDao7T37VZZUeYNpn1"
@@ -21,8 +24,8 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Allows for the controls of a top-down object to be re-mapped",
-      "fullName": "Remap Top-down Object",
+      "description": "Allows for the controls of a Top-Down behavior to be re-mapped via a single action.",
+      "fullName": "Remap Top-down",
       "name": "RemapForTopdown",
       "objectType": "",
       "eventsFunctions": [
@@ -181,19 +184,19 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "supplementaryInformation": "BehaviorRemapper::RemapForTopdown",
               "type": "behavior"
             }
           ],
           "objectGroups": []
         },
         {
-          "description": "Remap controls to a custom control scheme",
-          "fullName": "Remap controls of a top-down object to a custom scheme",
+          "description": "Remaps Top-Down behavior controls to a custom control scheme.",
+          "fullName": "Remap Top-Down controls to a custom scheme",
           "functionType": "Action",
           "name": "SetCustom",
           "private": false,
-          "sentence": "Remap controls Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, and Right: _PARAM5_ of _PARAM0_ with _PARAM1_",
+          "sentence": "Remap controls of _PARAM0_: Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, Right: _PARAM5_",
           "events": [
             {
               "disabled": false,
@@ -213,7 +216,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -226,7 +229,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -239,7 +242,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -252,7 +255,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -284,13 +287,13 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "supplementaryInformation": "BehaviorRemapper::RemapForTopdown",
               "type": "behavior"
             },
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Up",
+              "description": "Up key",
               "longDescription": "",
               "name": "up",
               "optional": false,
@@ -300,7 +303,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Left",
+              "description": "Left key",
               "longDescription": "",
               "name": "left",
               "optional": false,
@@ -310,7 +313,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Down",
+              "description": "Down key",
               "longDescription": "",
               "name": "down",
               "optional": false,
@@ -320,7 +323,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Right",
+              "description": "Right key",
               "longDescription": "",
               "name": "right",
               "optional": false,
@@ -331,12 +334,12 @@
           "objectGroups": []
         },
         {
-          "description": "Remap controls to a preset control scheme",
-          "fullName": "Remap controls of a top-down object to a preset control scheme",
+          "description": "Remaps Top-Down behavior controls to a preset control scheme.",
+          "fullName": "Remap Top-Down controls to a preset",
           "functionType": "Action",
           "name": "SetPreset",
           "private": false,
-          "sentence": "Remap controls of _PARAM0_ with _PARAM1_ to _PARAM2_",
+          "sentence": "Remap controls of _PARAM0_ to preset _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -375,7 +378,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -388,7 +391,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -401,7 +404,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -414,7 +417,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -464,7 +467,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -477,7 +480,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -490,7 +493,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -503,7 +506,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -553,7 +556,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -566,7 +569,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -579,7 +582,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -592,7 +595,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -642,7 +645,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -655,7 +658,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -668,7 +671,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -681,7 +684,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForTopdown::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -713,13 +716,13 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "supplementaryInformation": "BehaviorRemapper::RemapForTopdown",
               "type": "behavior"
             },
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Preset controls",
+              "description": "Preset name",
               "longDescription": "",
               "name": "options",
               "optional": false,
@@ -781,8 +784,8 @@
       ]
     },
     {
-      "description": "Allows for the controls of a platformer object to be re-mapped",
-      "fullName": "Remap Platformer Object",
+      "description": "Allows for the controls of a platformer behavior to be re-mapped via a single action.",
+      "fullName": "Remap Platformer controls",
       "name": "RemapForPlatformer",
       "objectType": "",
       "eventsFunctions": [
@@ -822,42 +825,20 @@
                     "Platformer"
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLadderKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Platformer"
+                  ],
+                  "subInstructions": []
                 }
               ],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "PlatformBehavior::IsOnLadder"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Platformer"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PlatformBehavior::SimulateLadderKey"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Platformer"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ]
+              "events": []
             },
             {
               "disabled": false,
@@ -951,42 +932,20 @@
                     "Platformer"
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateReleaseLadderKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Platformer"
+                  ],
+                  "subInstructions": []
                 }
               ],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PlatformBehavior::IsOnLadder"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Platformer"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PlatformBehavior::SimulateReleaseLadderKey"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Platformer"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ]
+              "events": []
             },
             {
               "disabled": false,
@@ -1039,19 +998,19 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "supplementaryInformation": "BehaviorRemapper::RemapForPlatformer",
               "type": "behavior"
             }
           ],
           "objectGroups": []
         },
         {
-          "description": "Remap controls to a custom control scheme",
-          "fullName": "Remap controls of a platformer object to a custom scheme",
+          "description": "Remaps Platformer behavior controls to a custom control scheme.",
+          "fullName": "Remap Platformer controls to a custom scheme",
           "functionType": "Action",
           "name": "SetCustom",
           "private": false,
-          "sentence": "Remap controls Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, Right: _PARAM5_, and Jump: _PARAM6_ of _PARAM0_ with _PARAM1_",
+          "sentence": "Remap controls of _PARAM0_: Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, Right: _PARAM5_, Jump: _PARAM6_",
           "events": [
             {
               "disabled": false,
@@ -1071,7 +1030,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -1084,7 +1043,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -1097,7 +1056,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -1110,7 +1069,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -1123,7 +1082,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyJump"
                   },
                   "parameters": [
                     "Object",
@@ -1155,13 +1114,13 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "supplementaryInformation": "BehaviorRemapper::RemapForPlatformer",
               "type": "behavior"
             },
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Up",
+              "description": "Up key",
               "longDescription": "",
               "name": "up",
               "optional": false,
@@ -1171,7 +1130,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Left",
+              "description": "Left key",
               "longDescription": "",
               "name": "left",
               "optional": false,
@@ -1181,7 +1140,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Down",
+              "description": "Down key",
               "longDescription": "",
               "name": "down",
               "optional": false,
@@ -1191,7 +1150,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Right",
+              "description": "Right key",
               "longDescription": "",
               "name": "right",
               "optional": false,
@@ -1201,7 +1160,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Jump",
+              "description": "Jump key",
               "longDescription": "",
               "name": "jump",
               "optional": false,
@@ -1212,12 +1171,12 @@
           "objectGroups": []
         },
         {
-          "description": "Remap controls to a preset control scheme",
-          "fullName": "Remap controls of a platformer object to a preset control scheme",
+          "description": "Remaps Platformer behavior controls to a preset control scheme.",
+          "fullName": "Remap Platformer controls to a preset",
           "functionType": "Action",
           "name": "SetPreset",
           "private": false,
-          "sentence": "Remap controls of _PARAM0_ with _PARAM1_ to _PARAM2_",
+          "sentence": "Remap controls of _PARAM0_ to preset _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1256,7 +1215,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -1269,7 +1228,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -1282,7 +1241,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -1295,7 +1254,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -1308,7 +1267,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyJump"
                   },
                   "parameters": [
                     "Object",
@@ -1358,7 +1317,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -1371,7 +1330,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -1384,7 +1343,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -1397,7 +1356,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -1410,7 +1369,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyJump"
                   },
                   "parameters": [
                     "Object",
@@ -1460,7 +1419,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -1473,7 +1432,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -1486,7 +1445,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -1499,7 +1458,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -1512,7 +1471,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyJump"
                   },
                   "parameters": [
                     "Object",
@@ -1562,7 +1521,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
@@ -1575,7 +1534,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
@@ -1588,7 +1547,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
@@ -1601,7 +1560,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
@@ -1614,7 +1573,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                    "value": "BehaviorRemapper::RemapForPlatformer::SetPropertyJump"
                   },
                   "parameters": [
                     "Object",
@@ -1646,13 +1605,13 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "supplementaryInformation": "BehaviorRemapper::RemapForPlatformer",
               "type": "behavior"
             },
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Preset controls",
+              "description": "Preset name",
               "longDescription": "",
               "name": "options",
               "optional": false,

--- a/Extensions/KeyRemapper.json
+++ b/Extensions/KeyRemapper.json
@@ -1,6 +1,6 @@
 {
   "author": "",
-  "description": "For key-bindings to stay in affect the function should be run every frame. Preferably near the top of the event sheet. Also, make sure to disable default controls unless you want two keys to do the same action.\n\nAdditionally, functions have two versions. `custom` allow the movement keys to be changed to what ever you would like. `presets` provide a common key-bindings that can be selected from a list.\n\nPreset Options:\n`WASD`\n-\tW: Up\n-\tA: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`ZQSD`\n-\tZ: Up\n-\tQ: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`Numpad` (Num lock must be disabled)\n-\tNumpad Up: Up\n-\tNumpad Left: Left\n-\tNumpad Down: Down\n-\tNumpad Right: Right\n-\tNumpad Return/Enter: Jump\n\n`IJKL`\n-\tI: Up\n-\tJ: Left\n-\tK: Down\n-\tL: Right\n-\tReturn/Enter: Jump\n",
+  "description": "Make sure to disable default controls unless you want two keys to do the same action.\n\nAdditionally, actions have two versions. `custom` allow the movement keys to be changed to what ever you would like. `presets` provide a common key-bindings that can be selected from a list.\n\nPreset Options:\n`WASD`\n-\tW: Up\n-\tA: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`ZQSD`\n-\tZ: Up\n-\tQ: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`Numpad` (Num lock must be disabled)\n-\tNumpad Up: Up\n-\tNumpad Left: Left\n-\tNumpad Down: Down\n-\tNumpad Right: Right\n-\tNumpad Return/Enter: Jump\n\n`IJKL`\n-\tI: Up\n-\tJ: Left\n-\tK: Down\n-\tL: Right\n-\tReturn/Enter: Jump\n",
   "extensionNamespace": "",
   "fullName": "Key Remapper",
   "helpPath": "",
@@ -18,303 +18,21 @@
     "AlZ3D1xkH0QDao7T37VZZUeYNpn1"
   ],
   "dependencies": [],
-  "eventsFunctions": [
+  "eventsFunctions": [],
+  "eventsBasedBehaviors": [
     {
-      "description": "Remap controls to a custom control scheme",
-      "fullName": "Remap controls of a platformer object to a custom scheme",
-      "functionType": "Action",
-      "name": "PlatformerCustom",
-      "private": false,
-      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, Right: _PARAM6_, and Jump: _PARAM7_ of object _PARAM1_  _PARAM2_",
-      "events": [
+      "description": "Allows for the controls of a top-down object to be re-mapped",
+      "fullName": "Remap Top-down Object",
+      "name": "RemapForTopdown",
+      "objectType": "",
+      "eventsFunctions": [
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"up\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateUpKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateLadderKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"left\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateLeftKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"down\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateDownKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"right\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateRightKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"jump\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "PlatformBehavior::SimulateJumpKey"
-              },
-              "parameters": [
-                "Object",
-                "PlatformerObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Platformer object",
-          "longDescription": "",
-          "name": "Object",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "objectList"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Platformer object behavior",
-          "longDescription": "",
-          "name": "PlatformerObject",
-          "optional": false,
-          "supplementaryInformation": "PlatformBehavior::PlatformerObjectBehavior",
-          "type": "behavior"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Up",
-          "longDescription": "",
-          "name": "up",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Left",
-          "longDescription": "",
-          "name": "left",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Down",
-          "longDescription": "",
-          "name": "down",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Right",
-          "longDescription": "",
-          "name": "right",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Jump",
-          "longDescription": "",
-          "name": "jump",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "Remap controls to a preset control scheme",
-      "fullName": "Remap controls of a platformer object",
-      "functionType": "Action",
-      "name": "PlatformerPresets",
-      "private": false,
-      "sentence": "Remap controls of _PARAM1_ _PARAM2_ to _PARAM3_",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "QWERTY bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"WASD\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [],
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "private": false,
+          "sentence": "",
           "events": [
             {
               "disabled": false,
@@ -324,11 +42,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "w"
+                    "Object.Behavior::PropertyUp()"
                   ],
                   "subInstructions": []
                 }
@@ -337,22 +55,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateUpKey"
+                    "value": "TopDownMovementBehavior::SimulateUpKey"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateLadderKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
+                    "Topdown"
                   ],
                   "subInstructions": []
                 }
@@ -367,11 +74,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "a"
+                    "Object.Behavior::PropertyLeft()"
                   ],
                   "subInstructions": []
                 }
@@ -380,11 +87,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateLeftKey"
+                    "value": "TopDownMovementBehavior::SimulateLeftKey"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Topdown"
                   ],
                   "subInstructions": []
                 }
@@ -399,11 +106,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "s"
+                    "Object.Behavior::PropertyRight()"
                   ],
                   "subInstructions": []
                 }
@@ -412,11 +119,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateDownKey"
+                    "value": "TopDownMovementBehavior::SimulateRightKey"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Topdown"
                   ],
                   "subInstructions": []
                 }
@@ -431,11 +138,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "d"
+                    "Object.Behavior::PropertyDown()"
                   ],
                   "subInstructions": []
                 }
@@ -444,85 +151,49 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateRightKey"
+                    "value": "TopDownMovementBehavior::SimulateDownKey"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Topdown"
                   ],
                   "subInstructions": []
                 }
               ],
               "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "Space"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateJumpKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "AZERTY bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"ZQSD\""
-              ],
-              "subInstructions": []
             }
           ],
-          "actions": [],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Remap controls to a custom control scheme",
+          "fullName": "Remap controls of a top-down object to a custom scheme",
+          "functionType": "Action",
+          "name": "SetCustom",
+          "private": false,
+          "sentence": "Remap controls Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, and Right: _PARAM5_ of _PARAM0_ with _PARAM1_",
           "events": [
             {
               "disabled": false,
@@ -532,12 +203,9 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [
-                    "",
-                    "z"
-                  ],
+                  "parameters": [],
                   "subInstructions": []
                 }
               ],
@@ -545,206 +213,160 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateUpKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"up\")"
                   ],
                   "subInstructions": []
                 },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateLadderKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"left\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"right\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"down\")"
                   ],
                   "subInstructions": []
                 }
               ],
               "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "q"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateLeftKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "s"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "d"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "Space"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateJumpKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Numpad bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"Numpad\""
-              ],
-              "subInstructions": []
             }
           ],
-          "actions": [],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Up",
+              "longDescription": "",
+              "name": "up",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Left",
+              "longDescription": "",
+              "name": "left",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Down",
+              "longDescription": "",
+              "name": "down",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Right",
+              "longDescription": "",
+              "name": "right",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Remap controls to a preset control scheme",
+          "fullName": "Remap controls of a top-down object to a preset control scheme",
+          "functionType": "Action",
+          "name": "SetPreset",
+          "private": false,
+          "sentence": "Remap controls of _PARAM0_ with _PARAM1_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
               "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "QWERTY bindings",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "StrEqual"
                   },
                   "parameters": [
-                    "",
-                    "NumpadUp"
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"WASD\""
                   ],
                   "subInstructions": []
                 }
@@ -753,118 +375,52 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateUpKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "\"w\""
                   ],
                   "subInstructions": []
                 },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateLadderKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "\"a\""
                   ],
                   "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
+                },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadLeft"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateLeftKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "\"s\""
                   ],
                   "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
+                },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadDown"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateDownKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadRight"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "\"d\""
                   ],
                   "subInstructions": []
                 }
@@ -883,7 +439,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "ignore red underline this still works",
+              "comment": "AZERTY bindings",
               "comment2": ""
             },
             {
@@ -894,11 +450,12 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "StrEqual"
                   },
                   "parameters": [
-                    "",
-                    "NumpadReturn"
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"ZQSD\""
                   ],
                   "subInstructions": []
                 }
@@ -907,53 +464,335 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PlatformBehavior::SimulateJumpKey"
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Behavior",
+                    "=",
+                    "\"z\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"q\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"s\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"d\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Numpad bindings",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"Numpad\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadUp\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadLeft\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadDown\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadRight\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "QWERTY player 2 bindings ",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"IJKL\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"i\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"j\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"k\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForTopdown::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"l\""
                   ],
                   "subInstructions": []
                 }
               ],
               "events": []
             }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "QWERTY player 2 bindings ",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
+          ],
+          "parameters": [
             {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"IJKL\""
-              ],
-              "subInstructions": []
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForTopdown",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Preset controls",
+              "longDescription": "",
+              "name": "options",
+              "optional": false,
+              "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
+              "type": "stringWithSelector"
             }
           ],
-          "actions": [],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "w",
+          "type": "String",
+          "label": "Up key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Up"
+        },
+        {
+          "value": "a",
+          "type": "String",
+          "label": "Left key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Left"
+        },
+        {
+          "value": "d",
+          "type": "String",
+          "label": "Right key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Right"
+        },
+        {
+          "value": "s",
+          "type": "String",
+          "label": "Down key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Down"
+        },
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "",
+          "description": "",
+          "extraInformation": [
+            "TopDownMovementBehavior::TopDownMovementBehavior"
+          ],
+          "hidden": false,
+          "name": "Topdown"
+        }
+      ]
+    },
+    {
+      "description": "Allows for the controls of a platformer object to be re-mapped",
+      "fullName": "Remap Platformer Object",
+      "name": "RemapForPlatformer",
+      "objectType": "",
+      "eventsFunctions": [
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "private": false,
+          "sentence": "",
           "events": [
             {
               "disabled": false,
@@ -963,11 +802,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "i"
+                    "Object.Behavior::PropertyUp()"
                   ],
                   "subInstructions": []
                 }
@@ -980,23 +819,45 @@
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateLadderKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
+                    "Platformer"
                   ],
                   "subInstructions": []
                 }
               ],
-              "events": []
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "PlatformBehavior::IsOnLadder"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Platformer"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PlatformBehavior::SimulateLadderKey"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Platformer"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
             },
             {
               "disabled": false,
@@ -1006,11 +867,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "j"
+                    "Object.Behavior::PropertyLeft()"
                   ],
                   "subInstructions": []
                 }
@@ -1023,7 +884,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Platformer"
                   ],
                   "subInstructions": []
                 }
@@ -1038,43 +899,11 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "k"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "PlatformBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "PlatformerObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "l"
+                    "Object.Behavior::PropertyRight()"
                   ],
                   "subInstructions": []
                 }
@@ -1087,7 +916,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Platformer"
                   ],
                   "subInstructions": []
                 }
@@ -1102,11 +931,76 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "KeyFromTextPressed"
                   },
                   "parameters": [
                     "",
-                    "Return"
+                    "Object.Behavior::PropertyDown()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Platformer"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PlatformBehavior::IsOnLadder"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Platformer"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PlatformBehavior::SimulateReleaseLadderKey"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Platformer"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyFromTextPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyJump()"
                   ],
                   "subInstructions": []
                 }
@@ -1119,293 +1013,45 @@
                   },
                   "parameters": [
                     "Object",
-                    "PlatformerObject"
+                    "Platformer"
                   ],
                   "subInstructions": []
                 }
               ],
               "events": []
             }
-          ]
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Platformer object",
-          "longDescription": "",
-          "name": "Object",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "objectList"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Platformer object behavior",
-          "longDescription": "",
-          "name": "PlatformerObject",
-          "optional": false,
-          "supplementaryInformation": "PlatformBehavior::PlatformerObjectBehavior",
-          "type": "behavior"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Preset controls",
-          "longDescription": "",
-          "name": "options",
-          "optional": false,
-          "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
-          "type": "stringWithSelector"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "Remap controls to a custom control scheme",
-      "fullName": "Remap controls of a top down object to a custom scheme",
-      "functionType": "Action",
-      "name": "TopDownCustom",
-      "private": false,
-      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, and Right: _PARAM6_, of object _PARAM1_ _PARAM2_",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
+          ],
+          "parameters": [
             {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"up\")"
-              ],
-              "subInstructions": []
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "type": "behavior"
             }
           ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "TopDownMovementBehavior::SimulateUpKey"
-              },
-              "parameters": [
-                "Object",
-                "TopDownObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
+          "objectGroups": []
         },
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"left\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "TopDownMovementBehavior::SimulateLeftKey"
-              },
-              "parameters": [
-                "Object",
-                "TopDownObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"down\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "TopDownMovementBehavior::SimulateDownKey"
-              },
-              "parameters": [
-                "Object",
-                "TopDownObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "KeyFromTextPressed"
-              },
-              "parameters": [
-                "",
-                "GetArgumentAsString(\"right\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "TopDownMovementBehavior::SimulateRightKey"
-              },
-              "parameters": [
-                "Object",
-                "TopDownObject"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Top-down object",
-          "longDescription": "",
-          "name": "Object",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "objectList"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Top-down object behavior",
-          "longDescription": "",
-          "name": "TopDownObject",
-          "optional": false,
-          "supplementaryInformation": "TopDownMovementBehavior::TopDownMovementBehavior",
-          "type": "behavior"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Up",
-          "longDescription": "",
-          "name": "up",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Left",
-          "longDescription": "",
-          "name": "left",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Down",
-          "longDescription": "",
-          "name": "down",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Right",
-          "longDescription": "",
-          "name": "right",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "key"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "Remap controls to a preset control scheme",
-      "fullName": "Remap controls of a top down object",
-      "functionType": "Action",
-      "name": "TopDownPresets",
-      "private": false,
-      "sentence": "Remap controls of _PARAM1_  _PARAM2_ to _PARAM3_",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "QWERTY bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"WASD\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [],
+          "description": "Remap controls to a custom control scheme",
+          "fullName": "Remap controls of a platformer object to a custom scheme",
+          "functionType": "Action",
+          "name": "SetCustom",
+          "private": false,
+          "sentence": "Remap controls Up: _PARAM2_, Left: _PARAM3_, Down: _PARAM4_, Right: _PARAM5_, and Jump: _PARAM6_ of _PARAM0_ with _PARAM1_",
           "events": [
             {
               "disabled": false,
@@ -1415,12 +1061,9 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "KeyPressed"
+                    "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [
-                    "",
-                    "w"
-                  ],
+                  "parameters": [],
                   "subInstructions": []
                 }
               ],
@@ -1428,645 +1071,656 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateUpKey"
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
                   },
                   "parameters": [
                     "Object",
-                    "TopDownObject"
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"up\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"left\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"right\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"down\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"jump\")"
                   ],
                   "subInstructions": []
                 }
               ],
               "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "a"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateLeftKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "s"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "d"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "AZERTY bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"ZQSD\""
-              ],
-              "subInstructions": []
             }
           ],
-          "actions": [],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Up",
+              "longDescription": "",
+              "name": "up",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Left",
+              "longDescription": "",
+              "name": "left",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Down",
+              "longDescription": "",
+              "name": "down",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Right",
+              "longDescription": "",
+              "name": "right",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Jump",
+              "longDescription": "",
+              "name": "jump",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "key"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Remap controls to a preset control scheme",
+          "fullName": "Remap controls of a platformer object to a preset control scheme",
+          "functionType": "Action",
+          "name": "SetPreset",
+          "private": false,
+          "sentence": "Remap controls of _PARAM0_ with _PARAM1_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "z"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateUpKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "q"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateLeftKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "s"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "d"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Numpad bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
               },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"Numpad\""
+              "comment": "QWERTY bindings",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"WASD\""
+                  ],
+                  "subInstructions": []
+                }
               ],
-              "subInstructions": []
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"w\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"a\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"s\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"d\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Space\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "AZERTY bindings",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"ZQSD\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"z\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"q\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"s\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"d\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Space\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Numpad bindings",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"Numpad\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadUp\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadLeft\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadDown\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadRight\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"NumpadReturn\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "QWERTY player 2 bindings ",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"options\")",
+                    "=",
+                    "\"IJKL\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyUp"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"i\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"j\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyDown"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"k\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"l\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyRemapper::RemapForPlatformer::SetPropertyJump"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Return\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
             }
           ],
-          "actions": [],
-          "events": [
+          "parameters": [
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadUp"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateUpKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadLeft"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateLeftKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "KeyRemapper::RemapForPlatformer",
+              "type": "behavior"
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadDown"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "NumpadRight"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "QWERTY player 2 bindings",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "StrEqual"
-              },
-              "parameters": [
-                "GetArgumentAsString(\"options\")",
-                "=",
-                "\"IJKL\""
-              ],
-              "subInstructions": []
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Preset controls",
+              "longDescription": "",
+              "name": "options",
+              "optional": false,
+              "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
+              "type": "stringWithSelector"
             }
           ],
-          "actions": [],
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "i"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateUpKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "j"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateLeftKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "k"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateDownKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "KeyPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "l"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TopDownMovementBehavior::SimulateRightKey"
-                  },
-                  "parameters": [
-                    "Object",
-                    "TopDownObject"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ]
+          "objectGroups": []
         }
       ],
-      "parameters": [
+      "propertyDescriptors": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Top-down object",
-          "longDescription": "",
-          "name": "Object",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "objectList"
+          "value": "",
+          "type": "String",
+          "label": "Up key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Up"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Top-down object behavior",
-          "longDescription": "",
-          "name": "TopDownObject",
-          "optional": false,
-          "supplementaryInformation": "TopDownMovementBehavior::TopDownMovementBehavior",
-          "type": "behavior"
+          "value": "",
+          "type": "String",
+          "label": "Left key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Left"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Preset controls",
-          "longDescription": "",
-          "name": "options",
-          "optional": false,
-          "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
-          "type": "stringWithSelector"
+          "value": "",
+          "type": "String",
+          "label": "Down key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Down"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Right key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Right"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Jump key",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Jump"
+        },
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "",
+          "description": "",
+          "extraInformation": [
+            "PlatformBehavior::PlatformerObjectBehavior"
+          ],
+          "hidden": false,
+          "name": "Platformer"
         }
-      ],
-      "objectGroups": []
+      ]
     }
-  ],
-  "eventsBasedBehaviors": []
+  ]
 }

--- a/Extensions/KeyRemapper.json
+++ b/Extensions/KeyRemapper.json
@@ -25,7 +25,7 @@
       "functionType": "Action",
       "name": "PlatformerCustom",
       "private": false,
-      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, Right: _PARAM6_, and Jump: _PARAM7_ of object _PARAM1_ with behavior _PARAM2_",
+      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, Right: _PARAM6_, and Jump: _PARAM7_ of object _PARAM1_  _PARAM2_",
       "events": [
         {
           "disabled": false,
@@ -49,6 +49,17 @@
               "type": {
                 "inverted": false,
                 "value": "PlatformBehavior::SimulateUpKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateLadderKey"
               },
               "parameters": [
                 "Object",
@@ -268,7 +279,7 @@
       "functionType": "Action",
       "name": "PlatformerPresets",
       "private": false,
-      "sentence": "Remap controls of _PARAM1_ with behavior _PARAM2_ to _PARAM3_",
+      "sentence": "Remap controls of _PARAM1_ _PARAM2_ to _PARAM3_",
       "events": [
         {
           "disabled": false,
@@ -327,6 +338,17 @@
                   "type": {
                     "inverted": false,
                     "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLadderKey"
                   },
                   "parameters": [
                     "Object",
@@ -530,6 +552,17 @@
                     "PlatformerObject"
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLadderKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
                 }
               ],
               "events": []
@@ -721,6 +754,17 @@
                   "type": {
                     "inverted": false,
                     "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLadderKey"
                   },
                   "parameters": [
                     "Object",
@@ -939,6 +983,17 @@
                     "PlatformerObject"
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLadderKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
                 }
               ],
               "events": []
@@ -1114,7 +1169,7 @@
       "functionType": "Action",
       "name": "TopDownCustom",
       "private": false,
-      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, and Right: _PARAM6_, of object _PARAM1_ with behavior _PARAM2_",
+      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, and Right: _PARAM6_, of object _PARAM1_ _PARAM2_",
       "events": [
         {
           "disabled": false,
@@ -1249,7 +1304,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Platformer object",
+          "description": "Top-down object",
           "longDescription": "",
           "name": "Object",
           "optional": false,
@@ -1259,7 +1314,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Platformer object behavior",
+          "description": "Top-down object behavior",
           "longDescription": "",
           "name": "TopDownObject",
           "optional": false,
@@ -1315,7 +1370,7 @@
       "functionType": "Action",
       "name": "TopDownPresets",
       "private": false,
-      "sentence": "Remap controls of _PARAM1_ with behavior _PARAM2_ to _PARAM3_",
+      "sentence": "Remap controls of _PARAM1_  _PARAM2_ to _PARAM3_",
       "events": [
         {
           "disabled": false,
@@ -1982,7 +2037,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Platformer object",
+          "description": "Top-down object",
           "longDescription": "",
           "name": "Object",
           "optional": false,
@@ -1992,7 +2047,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Platformer object behavior",
+          "description": "Top-down object behavior",
           "longDescription": "",
           "name": "TopDownObject",
           "optional": false,

--- a/Extensions/KeyRemapper.json
+++ b/Extensions/KeyRemapper.json
@@ -1,0 +1,2017 @@
+{
+  "author": "",
+  "description": "For key-bindings to stay in affect the function should be run every frame. Preferably near the top of the event sheet. Also, make sure to disable default controls unless you want two keys to do the same action.\n\nAdditionally, functions have two versions. `custom` allow the movement keys to be changed to what ever you would like. `presets` provide a common key-bindings that can be selected from a list.\n\nPreset Options:\n`WASD`\n-\tW: Up\n-\tA: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`ZQSD`\n-\tZ: Up\n-\tQ: Left\n-\tS: Down\n-\tD: Right\n-\tSpace: Jump\n\n`Numpad` (Num lock must be disabled)\n-\tNumpad Up: Up\n-\tNumpad Left: Left\n-\tNumpad Down: Down\n-\tNumpad Right: Right\n-\tNumpad Return/Enter: Jump\n\n`IJKL`\n-\tI: Up\n-\tJ: Left\n-\tK: Down\n-\tL: Right\n-\tReturn/Enter: Jump\n",
+  "extensionNamespace": "",
+  "fullName": "Key Remapper",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWFscGhhLXctYm94LW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNOSwxN0EyLDIgMCAwLDEgNywxNVY3SDlWMTVIMTFWOEgxM1YxNUgxNVY3SDE3VjE1QTIsMiAwIDAsMSAxNSwxN0g5TTUsM0gxOUEyLDIgMCAwLDEgMjEsNVYxOUEyLDIgMCAwLDEgMTksMjFINUEyLDIgMCAwLDEgMywxOVY1QTIsMiAwIDAsMSA1LDNNNSw1VjE5SDE5VjVINVoiIC8+PC9zdmc+",
+  "name": "KeyRemapper",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/alpha-w-box-outline.svg",
+  "shortDescription": "Quickly map keyboard controls to different keys. ",
+  "version": "1.0.0",
+  "tags": [
+    "remapper",
+    "key-bindings",
+    "presets"
+  ],
+  "authorIds": [
+    "AlZ3D1xkH0QDao7T37VZZUeYNpn1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Remap controls to a custom control scheme",
+      "fullName": "Remap controls of a platformer object to a custom scheme",
+      "functionType": "Action",
+      "name": "PlatformerCustom",
+      "private": false,
+      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, Right: _PARAM6_, and Jump: _PARAM7_ of object _PARAM1_ with behavior _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"up\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateUpKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"left\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateLeftKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"down\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateDownKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"right\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateRightKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"jump\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "PlatformBehavior::SimulateJumpKey"
+              },
+              "parameters": [
+                "Object",
+                "PlatformerObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object behavior",
+          "longDescription": "",
+          "name": "PlatformerObject",
+          "optional": false,
+          "supplementaryInformation": "PlatformBehavior::PlatformerObjectBehavior",
+          "type": "behavior"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Up",
+          "longDescription": "",
+          "name": "up",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Left",
+          "longDescription": "",
+          "name": "left",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Down",
+          "longDescription": "",
+          "name": "down",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Right",
+          "longDescription": "",
+          "name": "right",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Jump",
+          "longDescription": "",
+          "name": "jump",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Remap controls to a preset control scheme",
+      "fullName": "Remap controls of a platformer object",
+      "functionType": "Action",
+      "name": "PlatformerPresets",
+      "private": false,
+      "sentence": "Remap controls of _PARAM1_ with behavior _PARAM2_ to _PARAM3_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "QWERTY bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"WASD\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "w"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "a"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "s"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "d"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Space"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateJumpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "AZERTY bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"ZQSD\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "z"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "q"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "s"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "d"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Space"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateJumpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Numpad bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"Numpad\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadUp"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadLeft"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadDown"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadRight"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "ignore red underline this still works",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadReturn"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateJumpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "QWERTY player 2 bindings ",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"IJKL\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "i"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "j"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "k"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "l"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Return"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PlatformBehavior::SimulateJumpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object behavior",
+          "longDescription": "",
+          "name": "PlatformerObject",
+          "optional": false,
+          "supplementaryInformation": "PlatformBehavior::PlatformerObjectBehavior",
+          "type": "behavior"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Preset controls",
+          "longDescription": "",
+          "name": "options",
+          "optional": false,
+          "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Remap controls to a custom control scheme",
+      "fullName": "Remap controls of a top down object to a custom scheme",
+      "functionType": "Action",
+      "name": "TopDownCustom",
+      "private": false,
+      "sentence": "Remap controls Up: _PARAM3_, Left: _PARAM4_, Down: _PARAM5_, and Right: _PARAM6_, of object _PARAM1_ with behavior _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"up\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "TopDownMovementBehavior::SimulateUpKey"
+              },
+              "parameters": [
+                "Object",
+                "TopDownObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"left\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "TopDownMovementBehavior::SimulateLeftKey"
+              },
+              "parameters": [
+                "Object",
+                "TopDownObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"down\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "TopDownMovementBehavior::SimulateDownKey"
+              },
+              "parameters": [
+                "Object",
+                "TopDownObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "KeyFromTextPressed"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"right\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "TopDownMovementBehavior::SimulateRightKey"
+              },
+              "parameters": [
+                "Object",
+                "TopDownObject"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object behavior",
+          "longDescription": "",
+          "name": "TopDownObject",
+          "optional": false,
+          "supplementaryInformation": "TopDownMovementBehavior::TopDownMovementBehavior",
+          "type": "behavior"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Up",
+          "longDescription": "",
+          "name": "up",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Left",
+          "longDescription": "",
+          "name": "left",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Down",
+          "longDescription": "",
+          "name": "down",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Right",
+          "longDescription": "",
+          "name": "right",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Remap controls to a preset control scheme",
+      "fullName": "Remap controls of a top down object",
+      "functionType": "Action",
+      "name": "TopDownPresets",
+      "private": false,
+      "sentence": "Remap controls of _PARAM1_ with behavior _PARAM2_ to _PARAM3_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "QWERTY bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"WASD\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "w"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "a"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "s"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "d"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "AZERTY bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"ZQSD\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "z"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "q"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "s"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "d"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Numpad bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"Numpad\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadUp"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadLeft"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadDown"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "NumpadRight"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "QWERTY player 2 bindings",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "StrEqual"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"options\")",
+                "=",
+                "\"IJKL\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "i"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "j"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "k"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "KeyPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "l"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TopDownMovementBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownObject"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Platformer object behavior",
+          "longDescription": "",
+          "name": "TopDownObject",
+          "optional": false,
+          "supplementaryInformation": "TopDownMovementBehavior::TopDownMovementBehavior",
+          "type": "behavior"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Preset controls",
+          "longDescription": "",
+          "name": "options",
+          "optional": false,
+          "supplementaryInformation": "[\"WASD\",\"ZQSD\",\"Numpad\",\"IJKL\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}


### PR DESCRIPTION
### Description
A simple extension that aims to simplify the process of changing control schemes. By making it possible to change the control scheme in a single action. 

### How to use the extension
1.  Attach top-down or platform character behavior to an object.
2.  Use the corresponding action to set the controls of the object. 

### Checklist
- [x] I've followed all of the best practices. *
- [x] I confirm that this extension can be integrated to this GitHub repository, distributed and MIT licensed. * 