### PR TITLE
correction in sentence of the extension FlashTransitionPainter

### DIFF
--- a/Extensions/FlashTransitionPainter.json
+++ b/Extensions/FlashTransitionPainter.json
@@ -1388,7 +1388,7 @@
           "functionType": "Action",
           "name": "PaintEffect",
           "private": false,
-          "sentence": "Paint effect type _PARAM4_ of _PARAM0_ with direction _PARAM4_ and color _PARAM2_ for _PARAM3_ seconds",
+          "sentence": "Paint effect type _PARAM4_ of _PARAM0_ with direction _PARAM5_ and color _PARAM2_ for _PARAM3_ seconds",
           "events": [
             {
               "disabled": false,


### PR DESCRIPTION
Change PARAM4 by PARAM5 (which refers to direction) in the sentence of the action PaintEffect