### PR TITLE
Fixed floating-point rounding errors that caused drifting on ShakeObject

### DIFF
--- a/Extensions/ShakeObject.json
+++ b/Extensions/ShakeObject.json
@@ -8,7 +8,7 @@
   "name": "ShakeObject",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/arrow-all.svg",
   "shortDescription": "Shake an object, using one or more ways to shake (position, angle, scale)",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "tags": [
     "shaking",
     "object",
@@ -39,617 +39,6 @@
           "private": false,
           "sentence": "Shake object _PARAM0_ for _PARAM2_ seconds. Modify position amplitude _PARAM3_ on X axis and _PARAM4_ on Y axis, angle rotation amplitude _PARAM5_.  Wait _PARAM6_ seconds between shakes. Keep shaking until stopped: _PARAM7_",
           "events": [
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": true,
-              "folded": true,
-              "name": "Shake Object",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Pass input parameters to object variables so that doStepPostEvents can use them",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_Duration",
-                        "=",
-                        "GetArgumentAsNumber(\"Duration\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerX",
-                        "=",
-                        "GetArgumentAsNumber(\"PowerX\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerY",
-                        "=",
-                        "GetArgumentAsNumber(\"PowerY\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerAngle",
-                        "=",
-                        "GetArgumentAsNumber(\"PowerAngle\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_TimeBetweenShakes",
-                        "=",
-                        "GetArgumentAsNumber(\"TimeBetweenShakes\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetObjectVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "Object",
-                        "ShakeObject_ShakeForever",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "GetArgumentAsBoolean"
-                      },
-                      "parameters": [
-                        "\"ShakeForever\""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetObjectVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "Object",
-                        "ShakeObject_ShakeForever",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Start/Reset duration timer",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"__ShakeObject_DurationTimer\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"__ShakeObject_ShakeTimer\""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Add default values if none were provided",
-                  "comment2": ""
-                },
-                {
-                  "disabled": true,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerX",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerX",
-                        "=",
-                        "5"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": true,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerY",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerY",
-                        "=",
-                        "5"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": true,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerAngle",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_PowerAngle",
-                        "=",
-                        "20"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_Duration",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_Duration",
-                        "=",
-                        "0.5"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_TimeBetweenShakes",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_TimeBetweenShakes",
-                        "=",
-                        "0.08"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "If a shake is not in progress, save initial values.",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__ShakeObject_ShakeInProgress",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Save initial object rotation",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Variable(__ShakeObject_PowerAngle)",
-                            ">",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_InitialAngle",
-                            "=",
-                            "Object.Angle()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Reset temp variables",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_DisplacementX",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_DisplacementY",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_DisplacementTravelledX",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_DisplacementTravelledY",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Initiate the onScenePostEvents function",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_ShakeInProgress",
-                            "=",
-                            "1"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarObjet"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__ShakeObject_InitialShake",
-                            "=",
-                            "1"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            },
             {
               "colorB": 228,
               "colorG": 176,
@@ -813,7 +202,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "ShakeObject_ShakeForever",
+                        "__ShakeObject_ShakeForever",
                         "False"
                       ],
                       "subInstructions": []
@@ -845,7 +234,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "ShakeObject_ShakeForever",
+                        "__ShakeObject_ShakeForever",
                         "True"
                       ],
                       "subInstructions": []
@@ -1245,7 +634,7 @@
                               },
                               "parameters": [
                                 "Object",
-                                "ShakeObject_ShakeForever",
+                                "__ShakeObject_ShakeForever",
                                 "True"
                               ],
                               "subInstructions": []
@@ -1585,7 +974,7 @@
                                 },
                                 {
                                   "disabled": false,
-                                  "folded": true,
+                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
@@ -1658,7 +1047,7 @@
                                     },
                                     {
                                       "disabled": false,
-                                      "folded": true,
+                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [
                                         {
@@ -1768,7 +1157,7 @@
                                     },
                                     {
                                       "disabled": false,
-                                      "folded": true,
+                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [
                                         {
@@ -1880,7 +1269,7 @@
                                 },
                                 {
                                   "disabled": false,
-                                  "folded": true,
+                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
@@ -2114,7 +1503,7 @@
                                     "Object",
                                     "__ShakeObject_PercentTimeElapsedThisFrame",
                                     "=",
-                                    "TimeDelta()/Object.Variable(__ShakeObject_TimeBetweenShakes)"
+                                    "min(1,TimeDelta()/Object.Variable(__ShakeObject_TimeBetweenShakes))"
                                   ],
                                   "subInstructions": []
                                 }
@@ -2221,7 +1610,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -2233,7 +1622,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2269,7 +1658,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledX",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         },
@@ -2282,7 +1671,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledY",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -2333,7 +1722,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2369,7 +1758,7 @@
                                             "Object",
                                             "__ShakeObject_AngleTravelled",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -2480,7 +1869,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -2492,7 +1881,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2528,7 +1917,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledX",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         },
@@ -2541,7 +1930,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledY",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -2592,7 +1981,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2628,7 +2017,7 @@
                                             "Object",
                                             "__ShakeObject_AngleTravelled",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -3306,7 +2695,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "ShakeObject_ShakeForever",
+                        "__ShakeObject_ShakeForever",
                         "False"
                       ],
                       "subInstructions": []
@@ -3338,7 +2727,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "ShakeObject_ShakeForever",
+                        "__ShakeObject_ShakeForever",
                         "True"
                       ],
                       "subInstructions": []
@@ -3748,7 +3137,7 @@
                               },
                               "parameters": [
                                 "Object",
-                                "ShakeObject_ShakeForever",
+                                "__ShakeObject_ShakeForever",
                                 "True"
                               ],
                               "subInstructions": []
@@ -4209,7 +3598,7 @@
                                     },
                                     {
                                       "disabled": false,
-                                      "folded": true,
+                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [
                                         {
@@ -4319,7 +3708,7 @@
                                     },
                                     {
                                       "disabled": false,
-                                      "folded": true,
+                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [
                                         {
@@ -4848,7 +4237,7 @@
                                     "Object",
                                     "__ShakeObject_PercentTimeElapsedThisFrame",
                                     "=",
-                                    "TimeDelta()/Object.Variable(__ShakeObject_TimeBetweenShakes)"
+                                    "min(1,TimeDelta()/Object.Variable(__ShakeObject_TimeBetweenShakes))"
                                   ],
                                   "subInstructions": []
                                 }
@@ -4955,7 +4344,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -4967,7 +4356,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5003,7 +4392,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledX",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         },
@@ -5016,7 +4405,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledY",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5067,7 +4456,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5103,7 +4492,7 @@
                                             "Object",
                                             "__ShakeObject_AngleTravelled",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5154,7 +4543,7 @@
                                       "parameters": [
                                         "Object",
                                         "+",
-                                        "Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5190,7 +4579,7 @@
                                             "Object",
                                             "__ShakeObject_ScaleTravelled",
                                             "+",
-                                            "Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5301,7 +4690,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -5313,7 +4702,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5349,7 +4738,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledX",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementX) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         },
@@ -5362,7 +4751,7 @@
                                             "Object",
                                             "__ShakeObject_DisplacementTravelledY",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementY) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5413,7 +4802,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5449,7 +4838,7 @@
                                             "Object",
                                             "__ShakeObject_AngleTravelled",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementAngle) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5500,7 +4889,7 @@
                                       "parameters": [
                                         "Object",
                                         "-",
-                                        "Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -5536,7 +4925,7 @@
                                             "Object",
                                             "__ShakeObject_ScaleTravelled",
                                             "-",
-                                            "Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)"
+                                            "round(1024 * Object.Variable(__ShakeObject_DisplacementScale) * Object.Variable(__ShakeObject_PercentTimeElapsedThisFrame)) / 1024"
                                           ],
                                           "subInstructions": []
                                         }
@@ -5664,7 +5053,7 @@
                           "colorR": 74,
                           "creationTime": 0,
                           "disabled": false,
-                          "folded": true,
+                          "folded": false,
                           "name": "Correct for drift and reset drift tracking variables",
                           "source": "",
                           "type": "BuiltinCommonInstructions::Group",


### PR DESCRIPTION
Testing can be done here (source files available):

https://victrisgames.itch.io/gdevelop-camera-shake-example

Thank you to everyone who reported this issue!