### PR TITLE
Fixed floating-point rounding errors that caused drifting on CameraShake

### DIFF
--- a/Extensions/CameraShake.json
+++ b/Extensions/CameraShake.json
@@ -8,7 +8,7 @@
   "name": "CameraShake",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-difference-ab.svg",
   "shortDescription": "Shake the camera on the specified layer using one or more methods of shaking (position, angle, zoom)",
-  "version": "2.6.3",
+  "version": "2.6.5",
   "tags": [
     "shaking",
     "camera",
@@ -1110,7 +1110,7 @@
                                 },
                                 {
                                   "disabled": false,
-                                  "folded": true,
+                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
@@ -1215,7 +1215,7 @@
                                 },
                                 {
                                   "disabled": false,
-                                  "folded": true,
+                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
@@ -1731,7 +1731,7 @@
                               "parameters": [
                                 "__CameraShake_PercentTimeElapsedThisFrame",
                                 "=",
-                                "TimeDelta()/GlobalVariable(__CameraShake_TimeBetweenShakes)"
+                                "min(1,TimeDelta()/GlobalVariable(__CameraShake_TimeBetweenShakes))"
                               ],
                               "subInstructions": []
                             }
@@ -1836,7 +1836,7 @@
                                   "parameters": [
                                     "",
                                     "-",
-                                    "GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)",
+                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -1850,7 +1850,7 @@
                                   "parameters": [
                                     "",
                                     "-",
-                                    "GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)",
+                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -1887,7 +1887,7 @@
                                       "parameters": [
                                         "__CameraShake_DisplacementTravelledX",
                                         "-",
-                                        "GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -1899,7 +1899,7 @@
                                       "parameters": [
                                         "__CameraShake_DisplacementTravelledY",
                                         "-",
-                                        "GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -1950,7 +1950,7 @@
                                   "parameters": [
                                     "",
                                     "+",
-                                    "(GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))",
+                                    "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024",
                                     "",
                                     ""
                                   ],
@@ -1987,7 +1987,7 @@
                                       "parameters": [
                                         "__CameraShake_AngleTravelled",
                                         "+",
-                                        "(GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))"
+                                        "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2037,7 +2037,7 @@
                                   },
                                   "parameters": [
                                     "",
-                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) + (GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame))",
+                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) + round(1024 * GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -2074,7 +2074,7 @@
                                       "parameters": [
                                         "__CameraShake_ZoomTravelled",
                                         "+",
-                                        "(GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame))"
+                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2183,7 +2183,7 @@
                                   "parameters": [
                                     "",
                                     "+",
-                                    "GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)",
+                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -2197,7 +2197,7 @@
                                   "parameters": [
                                     "",
                                     "+",
-                                    "GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)",
+                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -2234,7 +2234,7 @@
                                       "parameters": [
                                         "__CameraShake_DisplacementTravelledX",
                                         "+",
-                                        "GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     },
@@ -2246,7 +2246,7 @@
                                       "parameters": [
                                         "__CameraShake_DisplacementTravelledY",
                                         "+",
-                                        "GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)"
+                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2297,7 +2297,7 @@
                                   "parameters": [
                                     "",
                                     "-",
-                                    "(GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))",
+                                    "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024",
                                     "",
                                     ""
                                   ],
@@ -2334,7 +2334,7 @@
                                       "parameters": [
                                         "__CameraShake_AngleTravelled",
                                         "-",
-                                        "(GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))"
+                                        "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024"
                                       ],
                                       "subInstructions": []
                                     }
@@ -2384,7 +2384,7 @@
                                   },
                                   "parameters": [
                                     "",
-                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) - (GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame))",
+                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) - round(1024 *  GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
                                     "GlobalVariableString(__CameraShake_Layer)",
                                     "GlobalVariable(__CameraShake_Camera)"
                                   ],
@@ -2421,7 +2421,7 @@
                                       "parameters": [
                                         "__CameraShake_ZoomTravelled",
                                         "-",
-                                        "(GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame))"
+                                        "round(1024 *  GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
                                       ],
                                       "subInstructions": []
                                     }


### PR DESCRIPTION
Testing can be done here (source files available):

https://victrisgames.itch.io/gdevelop-camera-shake-example

Thank you to everyone who reported this issue!