### PR TITLE
Add In-App Purchase extension

### DIFF
--- a/Extensions/InAppPurchase.json
+++ b/Extensions/InAppPurchase.json
@@ -1,0 +1,286 @@
+{
+  "author": "",
+  "description": "> To set up In App Purchase, you'll need a developer account on Google Play Console or Apple App Store Connect. You will also need **real phones/devices** to test IAP, because emulators are not supported.\n\nIt's highly recommended to **read the [help page](http://wiki.compilgames.net/doku.php/gdevelop5/extensions/in-app-purchase) to begin**. \n\n> ⚠️ In-App Purchase **will only work after you exported your game and uploaded it to Google Play Console or Apple App Store Connect**, at least in a testing track.\n\nThe general worflow is the following:\n\n- Register your products on the Google Play Console or App Store Connect,\n- In your game, register the same products using the action *\"Register an item\"*,\n- Call the action to finalize the store registration,\n- Wait for \"the store is ready\" condition to be true,\n- Get the items data to know what to display (in particular the *price* of each items),\n- Display the price and available items in your game,\n- Register a variable that will be updated when an item purchase is approved (and other variables for when other things happen),\n- When the player clicks on an item, use the action to order it,\n- If the purchase is approved (the variable you set up is set to true), give the user what they bought,\n- Mark the purchase as completed for the user to be charged the money\n",
+  "extensionNamespace": "",
+  "fullName": "Mobile In-App Purchase (experimental)",
+  "helpPath": "http://wiki.compilgames.net/doku.php/gdevelop5/extensions/in-app-purchase",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8Zz4NCgk8cGF0aCBkPSJNMjcsMTBINmMtMS4xLDAtMi0wLjktMi0yczAuOS0yLDItMmg0YzAuNiwwLDEtMC40LDEtMXMtMC40LTEtMS0xSDZDMy44LDQsMiw1LjgsMiw4djE2YzAsMi4yLDEuOCw0LDQsNGgyMQ0KCQljMS43LDAsMy0xLjMsMy0zVjEzQzMwLDExLjMsMjguNywxMCwyNywxMHogTTI4LDE1Ljh2Ni40Yy0wLjMtMC4xLTAuNi0wLjItMS0wLjJoLTRjLTEuNywwLTMtMS4zLTMtM3MxLjMtMywzLTNoNA0KCQlDMjcuNCwxNiwyNy43LDE1LjksMjgsMTUuOHoiLz4NCgk8cGF0aCBkPSJNNyw3QzYuNCw3LDYsNy40LDYsOHMwLjQsMSwxLDFoNGMwLDAsMCwwLDAsMHMwLDAsMCwwaDE1YzAuMywwLDAuNi0wLjIsMC44LTAuNGMwLjItMC4zLDAuMi0wLjYsMC4xLTAuOWwtMi01DQoJCWMtMC4yLTAuNS0wLjgtMC44LTEuMy0wLjZMMTAuOCw3SDd6Ii8+DQoJPHBhdGggZD0iTTI1LDE4aC0yYy0wLjYsMC0xLDAuNC0xLDFzMC40LDEsMSwxaDJjMC42LDAsMS0wLjQsMS0xUzI1LjYsMTgsMjUsMTh6Ii8+DQo8L2c+DQo8L3N2Zz4NCg==",
+  "name": "InAppPurchase",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Shopping and Ecommerce/Shopping and Ecommerce_wallet_money_cash.svg",
+  "shortDescription": "Add items to buy directly in your game (\"In-App Purchase\"), for games published on Android or iOS.",
+  "version": "0.0.1",
+  "tags": [
+    "purchase",
+    "iap",
+    "android",
+    "ios",
+    "monetization"
+  ],
+  "authorIds": [
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1",
+    "wWP8BSlAW0UP4NeaHa2LcmmDzmH2"
+  ],
+  "dependencies": [
+    {
+      "exportName": "cordova-plugin-purchase",
+      "name": "Purchase plugin",
+      "type": "cordova",
+      "version": "10.6.1"
+    }
+  ],
+  "eventsFunctions": [
+    {
+      "description": "Register an item of your store. This is required to do for all items you want to display or order from the app. \n\nMake sure you register them all and finalize registration before ordering an item.",
+      "fullName": "Register an item",
+      "functionType": "Action",
+      "name": "RegisterItem",
+      "private": false,
+      "sentence": "Register item _PARAM1_ as a _PARAM2_ (alias: _PARAM3_)",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\nstore.register({\n    id: eventsFunctionContext.getArgument(\"id\"),\n    type: eventsFunctionContext.getArgument(\"type\"),\n    alias: eventsFunctionContext.getArgument(\"alias\"),\n});\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The internal ID of the item",
+          "longDescription": "Use the ID of the item you entered on the IAP provider (Google play, Apple store...)",
+          "name": "id",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The type of item",
+          "longDescription": "",
+          "name": "type",
+          "optional": false,
+          "supplementaryInformation": "[\"free subscription\",\"paid subscription\",\"non renewing subscription\",\"consumable\",\"non consumable\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "(Optional) Alias name for the item",
+          "longDescription": "",
+          "name": "alias",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Finalize store registration. Do this after registering every product and before ordering or getting information about a product.",
+      "fullName": "Finalize registration",
+      "functionType": "Action",
+      "name": "FinalizeRegistration",
+      "private": false,
+      "sentence": "Finalize store registration",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\nstore.refresh();\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Opens the purchase menu to let the user buy an item.\n\nBe sure to have registered the item ID before and finalized the registration. You also need to use the condition to check if the store is ready before using this action.",
+      "fullName": "Order an item",
+      "functionType": "Action",
+      "name": "OrderItem",
+      "private": false,
+      "sentence": "Order item _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\nstore.order(eventsFunctionContext.getArgument(\"id\"));\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The id or alias of the item to buy",
+          "longDescription": "",
+          "name": "id",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Get all the data about an item from the IAP provider and store it into a structure variable.",
+      "fullName": "Load item data in a variable",
+      "functionType": "Action",
+      "name": "GetProduct",
+      "private": false,
+      "sentence": "Store data of _PARAM1_ in scene variable named _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\nruntimeScene.getVariables().get(eventsFunctionContext.getArgument(\"variableName\")).fromJSObject(\n    store.get(eventsFunctionContext.getArgument(\"id\"))\n);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The id or alias of the item to get info about",
+          "longDescription": "",
+          "name": "id",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the scene variable to store the item data in",
+          "longDescription": "The variable will be a structure, see [this page](https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#storeproduct-public-attributes) to know what child variables are accessible.",
+          "name": "variableName",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "When an event is triggered for an item (item loaded, approved, already owned, etc..), this sets a scene variable to true. \nYou can then compare the value of the variable in a condition, and have actions launched to react to the changes.",
+      "fullName": "Update a variable when an item is updated",
+      "functionType": "Action",
+      "name": "WatchItemEvent",
+      "private": false,
+      "sentence": "Watch the event _PARAM3_ for item _PARAM1_ and set scene variable named _PARAM2_ to true when it happens",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\n\nstore.when(eventsFunctionContext.getArgument(\"id\"), eventsFunctionContext.getArgument(\"event\"), () => {\n    const variable = runtimeScene.getVariables().get(eventsFunctionContext.getArgument(\"variableName\"));\n    variable.setBoolean(true);\n});\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The id or alias of the item to watch",
+          "longDescription": "You can also type in `\"order\"` to make it apply to any item",
+          "name": "id",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The name of the scene variable to set to \"true\" when the event happens.",
+          "longDescription": "",
+          "name": "variableName",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The event to listen to",
+          "longDescription": "",
+          "name": "event",
+          "optional": false,
+          "supplementaryInformation": "[\"loaded\",\"updated\",\"error\",\"approved\",\"owned\",\"cancelled\",\"refunded\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Triggers after finalizing the registration, when items can be used (you can get data of an item like the price, you can use the action to order an item...).",
+      "fullName": "Store is ready",
+      "functionType": "Condition",
+      "name": "StoreReady",
+      "private": false,
+      "sentence": "Store is ready",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = window.store && store.ready();\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Mark a purchase as delivered, after you delivered the goods the user has paid for. Until you do so, the user will not be charged and keep on getting the event triggered each time the app starts.",
+      "fullName": "Finalize a purchase",
+      "functionType": "Action",
+      "name": "FinalizePurchase",
+      "private": false,
+      "sentence": "Mark purchase of _PARAM1_ as delivered",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if(!window.store) return;\nstore.get(eventsFunctionContext.getArgument(\"id\")).finish();\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The id or alias of the item to finalize",
+          "longDescription": "",
+          "name": "id",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}


### PR DESCRIPTION
* This allows to sell items or premium features in games published on the stores on Android (Google Play) and iOS (App Store).
* This extension is still **experimental** - and more complex than other things to set up. Be sure to read the [explanation page on the wiki](http://wiki.compilgames.net/doku.php/gdevelop5/extensions/in-app-purchase).

Thanks @arthuro555 for this extension! :)