### PR TITLE
Add pop-up extension

### DIFF
--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "Input",
-  "description": "This extension gives access to three pop-ups. Those are Alert, Comfirm and prompt (text entry).\n## Alert\n- Gives user can alert which they can accept and close.\n- User can respond with `Ok`.\n\n## Confirmation\n- Gives user a confirmation message.\n- User can respond with `Ok` or `Cancel`.\n\n## Prompt\n**Prompt only works in browsers**.\n- Gives user a prompt with a textbox to type in .\n- User can type in the textbox (The typed string is considered the response) and click `Ok` or `Cancel`.\n",
+  "description": "This extension adds actions to display three kinds of pop-ups.\n\n## Alert\n - Pops-up a message that will pause the game until dismissed by the player.\n\n## Confirmation\n - Pops-up a dialogue containing a message with the option to either confirm or cancel.\n\n## Prompt\n**Note that this pop-up type is unsupported on previews and PC exports.**\n - Displays a message to the player with a text field to write an answer in. The player will also have the option to either confirm or discard their input.\n\n### Usage to save a value from a popup box:\n![Screenshot of the way to use the extension to save a value in a variable](https://i.imgur.com/2iR5ofz.png)\n",
   "extensionNamespace": "",
   "fullName": "Pop-up",
   "helpPath": "",
@@ -19,41 +19,31 @@
     "dialog"
   ],
   "authorIds": [
-    "HBp2oDKV87gKFbdd1wyV1jRYRC13"
+    "HBp2oDKV87gKFbdd1wyV1jRYRC13",
+    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92"
   ],
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "The response to a pop-up message is valid or not empty. ",
-      "fullName": "Valid response",
+      "description": "The response to a pop-up message is filled.",
+      "fullName": "Existing prompt response",
       "functionType": "Condition",
       "group": "",
       "name": "PromptValidResponse",
       "private": false,
-      "sentence": "Response from the pop-up message with identifier: _PARAM1_ is valid or not empty",
+      "sentence": "Response from the pop-up prompt is filled",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsBoolean()\n",
+          "inlineCode": "const promptResponse = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();\n\nif (promptResponse != \"\") {\n    eventsFunctionContext.returnValue = true;\n} else {\n    eventsFunctionContext.returnValue = false;\n}",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
         }
       ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Pop-up identifier",
-          "longDescription": "",
-          "name": "ID",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        }
-      ],
+      "parameters": [],
       "objectGroups": []
     },
     {
@@ -69,24 +59,13 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\r\n\r\neventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(id).getAsString();\r\n",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
         }
       ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Pop-up identifier",
-          "longDescription": "",
-          "name": "ID",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        }
-      ],
+      "parameters": [],
       "objectGroups": []
     },
     {
@@ -96,13 +75,13 @@
       "group": "Web browsers",
       "name": "Prompt",
       "private": false,
-      "sentence": "Open a prompt pop-up box with message: _PARAM1_ (placeholder: _PARAM2_, identifier: _PARAM3_)",
+      "sentence": "Open a prompt pop-up box with message: _PARAM1_ (placeholder: _PARAM2_)",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\nconst message = eventsFunctionContext.getArgument(\"Message\");\nconst defaultText = eventsFunctionContext.getArgument(\"DefaultText\");\n\nconst response = window.prompt(message, defaultText);\n\nif (response !== null){\n    runtimeScene.getGame().getVariables().get(id).setString(response);\n}else{\n    runtimeScene.getGame().getVariables().get(id).setBoolean(false);\n}",
+          "inlineCode": "const message = eventsFunctionContext.getArgument(\"Message\");\nconst defaultText = eventsFunctionContext.getArgument(\"DefaultText\");\n\nconst response = window.prompt(message, defaultText);\n\nconst childVar = new gdjs.Variable();\n\nif (response !== null) {\n    childVar.setString(response);\n} else {\n    childVar.setString(\"\");\n}\n\nruntimeScene.getVariables().get(\"__PopUp\").addChild(\"Prompt\", childVar);\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": true
@@ -128,16 +107,6 @@
           "optional": false,
           "supplementaryInformation": "",
           "type": "string"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Pop-up identifier",
-          "longDescription": "",
-          "name": "ID",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
         }
       ],
       "objectGroups": []
@@ -149,34 +118,16 @@
       "group": "",
       "name": "Confirm",
       "private": false,
-      "sentence": "Open a confirmation pop-up box with message: _PARAM1__ (identifier: _PARAM2_)",
+      "sentence": "Open a confirmation pop-up box with message: _PARAM1_",
       "events": [
         {
           "disabled": false,
           "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Once"
-              },
-              "parameters": [],
-              "subInstructions": []
-            }
-          ],
-          "actions": [],
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\nconst isConfirmed = confirm(eventsFunctionContext.getArgument(\"Message\"));\n\nruntimeScene.getGame().getVariables().get(id).setBoolean(isConfirmed);\n\n",
-              "parameterObjects": "",
-              "useStrict": true,
-              "eventsSheetExpanded": false
-            }
-          ]
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const isConfirmed = confirm(eventsFunctionContext.getArgument(\"Message\"));\n\nconst childVar = new gdjs.Variable();\nchildVar.setBoolean(isConfirmed);\n\nruntimeScene.getVariables().get(\"__PopUp\").addChild(\"Confirm\", childVar);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
         }
       ],
       "parameters": [
@@ -186,16 +137,6 @@
           "description": "Confirmation message",
           "longDescription": "The text to display in the confirm box.",
           "name": "Message",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Pop-up identifier",
-          "longDescription": "",
-          "name": "ID",
           "optional": false,
           "supplementaryInformation": "",
           "type": "string"
@@ -210,13 +151,13 @@
       "group": "",
       "name": "ConfimationResponse",
       "private": false,
-      "sentence": "Pop-up message with identifier _PARAM1_ is confirmed",
+      "sentence": "Pop-up message is confirmed",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\n\neventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(id).getAsBoolean();",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Confirm\").getAsBoolean();",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -230,18 +171,7 @@
           "events": []
         }
       ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Pop-up identifier",
-          "longDescription": "",
-          "name": "ID",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        }
-      ],
+      "parameters": [],
       "objectGroups": []
     },
     {

--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -232,7 +232,7 @@
     },
     {
       "description": "Alert user with a message in a pop-up window.",
-      "fullName": "",
+      "fullName": "Alert",
       "functionType": "Action",
       "name": "Alert",
       "private": false,

--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -1,5 +1,6 @@
 {
   "author": "",
+  "category": "Input",
   "description": "This extension gives access to three pop-ups. Those are Alert, Comfirm and prompt (text entry).\n## Alert\n- Gives user can alert which they can accept and close.\n- User can respond with `Ok`.\n\n## Confirmation\n- Gives user a confirmation message.\n- User can respond with `Ok` or `Cancel`.\n\n## Prompt\n**Prompt only works in browsers**.\n- Gives user a prompt with a textbox to type in .\n- User can type in the textbox (The typed string is considered the response) and click `Ok` or `Cancel`.\n",
   "extensionNamespace": "",
   "fullName": "Pop-up",
@@ -23,12 +24,13 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Valid response was given by user (The response wasn't empty). ",
-      "fullName": "Valid Response",
+      "description": "The response to a pop-up message is valid or not empty. ",
+      "fullName": "Valid response",
       "functionType": "Condition",
+      "group": "",
       "name": "PromptValidResponse",
       "private": false,
-      "sentence": "A valid response was given by user to prompt with ID: _PARAM1_",
+      "sentence": "Response from the pop-up message with identifier: _PARAM1_ is valid or not empty",
       "events": [
         {
           "disabled": false,
@@ -44,7 +46,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Prompt ID",
+          "description": "Pop-up identifier",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -55,9 +57,10 @@
       "objectGroups": []
     },
     {
-      "description": "Response by user to prompt.",
+      "description": "Return the text response by user to prompt.",
       "fullName": "Response to prompt",
       "functionType": "StringExpression",
+      "group": "",
       "name": "PromptResponse",
       "private": false,
       "sentence": "Open prompt with message : _PARAM1_ with ID: _PARAM2_",
@@ -66,7 +69,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsString();",
+          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\r\n\r\neventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(id).getAsString();\r\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -76,7 +79,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Prompt ID",
+          "description": "Pop-up identifier",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -87,28 +90,29 @@
       "objectGroups": []
     },
     {
-      "description": "Prompt user with the pop-up with a text box where they can type (Only works in browsers).",
+      "description": "Displays a prompt in a pop-up that prompts the user for input. This action return the text input or the false boolean if canceled.",
       "fullName": "Prompt",
       "functionType": "Action",
+      "group": "Web browsers",
       "name": "Prompt",
       "private": false,
-      "sentence": "Open prompt with message : _PARAM1_ with ID: _PARAM3_, Default text for textbox: _PARAM2_",
+      "sentence": "Open a prompt pop-up box with message: _PARAM1_ (placeholder: _PARAM2_, identifier: _PARAM3_)",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "var response;\nresponse = window.prompt(eventsFunctionContext.getArgument(\"Message\"),eventsFunctionContext.getArgument(\"DefaultText\"));\nif (response !== null)\n    runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setString(response)\nelse\n    runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setBoolean(false)",
+          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\nconst message = eventsFunctionContext.getArgument(\"Message\");\nconst defaultText = eventsFunctionContext.getArgument(\"DefaultText\");\n\nconst response = window.prompt(message, defaultText);\n\nif (response !== null){\n    runtimeScene.getGame().getVariables().get(id).setString(response);\n}else{\n    runtimeScene.getGame().getVariables().get(id).setBoolean(false);\n}",
           "parameterObjects": "",
           "useStrict": true,
-          "eventsSheetExpanded": false
+          "eventsSheetExpanded": true
         }
       ],
       "parameters": [
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Prompt Message",
+          "description": "Prompt message",
           "longDescription": "",
           "name": "Message",
           "optional": false,
@@ -118,7 +122,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Default Text",
+          "description": "Input placeholder",
           "longDescription": "",
           "name": "DefaultText",
           "optional": false,
@@ -128,7 +132,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Pop-up ID",
+          "description": "Pop-up identifier",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -139,12 +143,13 @@
       "objectGroups": []
     },
     {
-      "description": "Ask confirmation of user with a message in a pop-up window.",
-      "fullName": "Comfirm",
+      "description": "Ask confirmation of user with a message in a dialog box with an OK button, and a Cancel button.",
+      "fullName": "Confirm",
       "functionType": "Action",
+      "group": "",
       "name": "Confirm",
       "private": false,
-      "sentence": "Comfirm user about: _PARAM1_, Confirmation ID: _PARAM2_",
+      "sentence": "Open a confirmation pop-up box with message: _PARAM1__ (identifier: _PARAM2_)",
       "events": [
         {
           "disabled": false,
@@ -166,7 +171,7 @@
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setBoolean(confirm(eventsFunctionContext.getArgument(\"Message\")))\n",
+              "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\nconst isConfirmed = confirm(eventsFunctionContext.getArgument(\"Message\"));\n\nruntimeScene.getGame().getVariables().get(id).setBoolean(isConfirmed);\n\n",
               "parameterObjects": "",
               "useStrict": true,
               "eventsSheetExpanded": false
@@ -178,8 +183,8 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Confirmation Message",
-          "longDescription": "",
+          "description": "Confirmation message",
+          "longDescription": "The text to display in the confirm box.",
           "name": "Message",
           "optional": false,
           "supplementaryInformation": "",
@@ -188,7 +193,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Confirmation ID",
+          "description": "Pop-up identifier",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -199,28 +204,37 @@
       "objectGroups": []
     },
     {
-      "description": "Check if the confirmation was accepted.",
-      "fullName": "Comfirmed",
+      "description": "Check if a confirmation was accepted.",
+      "fullName": "Pop-up message confirmed",
       "functionType": "Condition",
-      "name": "ComfimationResponse",
+      "group": "",
+      "name": "ConfimationResponse",
       "private": false,
-      "sentence": "Message with ID _PARAM1_ confirmed",
+      "sentence": "Pop-up message with identifier _PARAM1_ is confirmed",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "if (runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsBoolean() === true)\n    eventsFunctionContext.returnValue = true;\nelse\n    eventsFunctionContext.returnValue = false;",
+          "inlineCode": "const id = eventsFunctionContext.getArgument(\"ID\");\n\neventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(id).getAsBoolean();",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [],
+          "events": []
         }
       ],
       "parameters": [
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Pop-up ID",
+          "description": "Pop-up identifier",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -231,18 +245,19 @@
       "objectGroups": []
     },
     {
-      "description": "Alert user with a message in a pop-up window.",
+      "description": "Displays an alert box with a message and an OK button in a pop-up window.",
       "fullName": "Alert",
       "functionType": "Action",
+      "group": "",
       "name": "Alert",
       "private": false,
-      "sentence": "Alert user with message: _PARAM1_",
+      "sentence": "Open an alert pop-up box with message: _PARAM1_",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "alert(eventsFunctionContext.getArgument(\"Message\"))",
+          "inlineCode": "alert(eventsFunctionContext.getArgument(\"Message\"));",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -252,7 +267,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Alert Message",
+          "description": "Alert message",
           "longDescription": "",
           "name": "Message",
           "optional": false,

--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -1,0 +1,235 @@
+{
+  "author": "",
+  "description": "This extension gives access to three pop-ups. Those are Alert, Comfirm and prompt (text entry)\n## Alert\n- Gives user can alert which they can accept and close\n- User can respond with `Ok`\n\n## Confirmation\n- Gives user a confirmation message\n- User can respond with `Ok` or `Cancel`\n\n## Prompt\n**Prompt only works in browsers**\n- Gives user a prompt with a textbox to type in \n- User can type in the textbox (The typed string is considered the response) and click `Ok` or `Cancel`\n",
+  "extensionNamespace": "",
+  "fullName": "Pop ups",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLW1lc3NhZ2UtYWxlcnQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTMgMTFIMTFWNUgxM00xMyAxNUgxMVYxM0gxM00yMCAySDRDMi45IDIgMiAyLjkgMiA0VjIyTDYgMThIMjBDMjEuMSAxOCAyMiAxNy4xIDIyIDE2VjRDMjIgMi45IDIxLjEgMiAyMCAyWiIgLz48L3N2Zz4=",
+  "name": "PopUp",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/message-alert.svg",
+  "shortDescription": "Display pop-ups to alert, ask confirmation, and let user type a response in text box.",
+  "version": "1.0.0",
+  "tags": [
+    "pop up",
+    "alert",
+    "message",
+    "prompt",
+    "confirm",
+    "dialog"
+  ],
+  "authorIds": [
+    "HBp2oDKV87gKFbdd1wyV1jRYRC13"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Response by user to prompt",
+      "fullName": "Response to prompt",
+      "functionType": "StringExpression",
+      "name": "PromptResponse",
+      "private": false,
+      "sentence": "Open prompt with message : _PARAM1_ with ID: _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsString();",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "ID of prompt",
+          "longDescription": "",
+          "name": "ID",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Prompt user with the pop-up with a text box where they can type (Only works in browsers)",
+      "fullName": "Prompt",
+      "functionType": "Action",
+      "name": "Prompt",
+      "private": false,
+      "sentence": "Open prompt with message : _PARAM1_ with ID: _PARAM3_, Default text for textbox: _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setString(window.prompt(eventsFunctionContext.getArgument(\"Message\"),eventsFunctionContext.getArgument(\"DefaultText\")))",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Prompt Message",
+          "longDescription": "",
+          "name": "Message",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Default Text",
+          "longDescription": "",
+          "name": "DefaultText",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Pop-up ID",
+          "longDescription": "",
+          "name": "ID",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Ask confirmation of user with a message in a pop-up window",
+      "fullName": "Comfirm",
+      "functionType": "Action",
+      "name": "Confirm",
+      "private": false,
+      "sentence": "Comfirm user about: _PARAM1_, Confirmation ID: _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": [],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::JsCode",
+              "inlineCode": "runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setBoolean(confirm(eventsFunctionContext.getArgument(\"Message\")))\n",
+              "parameterObjects": "",
+              "useStrict": true,
+              "eventsSheetExpanded": false
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Confirmation Message",
+          "longDescription": "",
+          "name": "Message",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Confirmation ID",
+          "longDescription": "",
+          "name": "ID",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the confirmation was accepted",
+      "fullName": "Comfirmed",
+      "functionType": "Condition",
+      "name": "ComfimationResponse",
+      "private": false,
+      "sentence": "Message with ID _PARAM1_ confirmed",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if (runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsBoolean() === true)\n    eventsFunctionContext.returnValue = true;\nelse\n    eventsFunctionContext.returnValue = false;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Pop-up ID",
+          "longDescription": "",
+          "name": "ID",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Alert user with a message in a pop-up window",
+      "fullName": "",
+      "functionType": "Action",
+      "name": "Alert",
+      "private": false,
+      "sentence": "Alert user with message: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "alert(eventsFunctionContext.getArgument(\"Message\"))",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Alert Message",
+          "longDescription": "",
+          "name": "Message",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -1,8 +1,8 @@
 {
   "author": "",
-  "description": "This extension gives access to three pop-ups. Those are Alert, Comfirm and prompt (text entry)\n## Alert\n- Gives user can alert which they can accept and close\n- User can respond with `Ok`\n\n## Confirmation\n- Gives user a confirmation message\n- User can respond with `Ok` or `Cancel`\n\n## Prompt\n**Prompt only works in browsers**\n- Gives user a prompt with a textbox to type in \n- User can type in the textbox (The typed string is considered the response) and click `Ok` or `Cancel`\n",
+  "description": "This extension gives access to three pop-ups. Those are Alert, Comfirm and prompt (text entry).\n## Alert\n- Gives user can alert which they can accept and close.\n- User can respond with `Ok`.\n\n## Confirmation\n- Gives user a confirmation message.\n- User can respond with `Ok` or `Cancel`.\n\n## Prompt\n**Prompt only works in browsers**.\n- Gives user a prompt with a textbox to type in .\n- User can type in the textbox (The typed string is considered the response) and click `Ok` or `Cancel`.\n",
   "extensionNamespace": "",
-  "fullName": "Pop ups",
+  "fullName": "Pop-up",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLW1lc3NhZ2UtYWxlcnQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTMgMTFIMTFWNUgxM00xMyAxNUgxMVYxM0gxM00yMCAySDRDMi45IDIgMiAyLjkgMiA0VjIyTDYgMThIMjBDMjEuMSAxOCAyMiAxNy4xIDIyIDE2VjRDMjIgMi45IDIxLjEgMiAyMCAyWiIgLz48L3N2Zz4=",
   "name": "PopUp",
@@ -23,7 +23,39 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Response by user to prompt",
+      "description": "Valid response was given by user (The response wasn't empty). ",
+      "fullName": "Valid Response",
+      "functionType": "Condition",
+      "name": "PromptValidResponse",
+      "private": false,
+      "sentence": "A valid response was given by user to prompt with ID: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getGame().getVariables().get(eventsFunctionContext.getArgument(\"ID\")).getAsBoolean()\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Prompt ID",
+          "longDescription": "",
+          "name": "ID",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Response by user to prompt.",
       "fullName": "Response to prompt",
       "functionType": "StringExpression",
       "name": "PromptResponse",
@@ -44,7 +76,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "ID of prompt",
+          "description": "Prompt ID",
           "longDescription": "",
           "name": "ID",
           "optional": false,
@@ -55,7 +87,7 @@
       "objectGroups": []
     },
     {
-      "description": "Prompt user with the pop-up with a text box where they can type (Only works in browsers)",
+      "description": "Prompt user with the pop-up with a text box where they can type (Only works in browsers).",
       "fullName": "Prompt",
       "functionType": "Action",
       "name": "Prompt",
@@ -66,7 +98,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setString(window.prompt(eventsFunctionContext.getArgument(\"Message\"),eventsFunctionContext.getArgument(\"DefaultText\")))",
+          "inlineCode": "var response;\nresponse = window.prompt(eventsFunctionContext.getArgument(\"Message\"),eventsFunctionContext.getArgument(\"DefaultText\"));\nif (response !== null)\n    runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setString(response)\nelse\n    runtimeScene.getGame()._variables.get(eventsFunctionContext.getArgument(\"ID\")).setBoolean(false)",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -107,7 +139,7 @@
       "objectGroups": []
     },
     {
-      "description": "Ask confirmation of user with a message in a pop-up window",
+      "description": "Ask confirmation of user with a message in a pop-up window.",
       "fullName": "Comfirm",
       "functionType": "Action",
       "name": "Confirm",
@@ -167,7 +199,7 @@
       "objectGroups": []
     },
     {
-      "description": "Check if the confirmation was accepted",
+      "description": "Check if the confirmation was accepted.",
       "fullName": "Comfirmed",
       "functionType": "Condition",
       "name": "ComfimationResponse",
@@ -199,7 +231,7 @@
       "objectGroups": []
     },
     {
-      "description": "Alert user with a message in a pop-up window",
+      "description": "Alert user with a message in a pop-up window.",
       "fullName": "",
       "functionType": "Action",
       "name": "Alert",

--- a/Extensions/PopUp.json
+++ b/Extensions/PopUp.json
@@ -20,7 +20,8 @@
   ],
   "authorIds": [
     "HBp2oDKV87gKFbdd1wyV1jRYRC13",
-    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92"
+    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92",
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -37,7 +38,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const promptResponse = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();\n\nif (promptResponse != \"\") {\n    eventsFunctionContext.returnValue = true;\n} else {\n    eventsFunctionContext.returnValue = false;\n}",
+          "inlineCode": "const promptResponse = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();\neventsFunctionContext.returnValue = promptResponse !== \"\";\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -59,7 +60,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Prompt\").getAsString();\r\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -81,7 +82,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const message = eventsFunctionContext.getArgument(\"Message\");\nconst defaultText = eventsFunctionContext.getArgument(\"DefaultText\");\n\nconst response = window.prompt(message, defaultText);\n\nconst childVar = new gdjs.Variable();\n\nif (response !== null) {\n    childVar.setString(response);\n} else {\n    childVar.setString(\"\");\n}\n\nruntimeScene.getVariables().get(\"__PopUp\").addChild(\"Prompt\", childVar);\n",
+          "inlineCode": "const message = eventsFunctionContext.getArgument(\"Message\");\nconst defaultText = eventsFunctionContext.getArgument(\"DefaultText\");\n\nconst response = prompt(message, defaultText);\nruntimeScene\n    .getVariables()\n    .get(\"__PopUp\")\n    .getChild(\"Prompt\")\n    .setString(response || \"\");\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": true
@@ -124,7 +125,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const isConfirmed = confirm(eventsFunctionContext.getArgument(\"Message\"));\n\nconst childVar = new gdjs.Variable();\nchildVar.setBoolean(isConfirmed);\n\nruntimeScene.getVariables().get(\"__PopUp\").addChild(\"Confirm\", childVar);\n",
+          "inlineCode": "const isConfirmed = confirm(eventsFunctionContext.getArgument(\"Message\"));\nruntimeScene\n    .getVariables()\n    .get(\"__PopUp\")\n    .getChild(\"Confirm\")\n    .setBoolean(isConfirmed);\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": true
@@ -157,7 +158,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Confirm\").getAsBoolean();",
+          "inlineCode": "eventsFunctionContext.returnValue = runtimeScene.getVariables().get(\"__PopUp\").getChild(\"Confirm\").getAsBoolean();\r\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -187,7 +188,7 @@
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "alert(eventsFunctionContext.getArgument(\"Message\"));",
+          "inlineCode": "alert(eventsFunctionContext.getArgument(\"Message\"));\r\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false


### PR DESCRIPTION

Extension to open pop ups.
The extension uses the methods given by javascript (`alert()`, `confirm()`, `prompt()`)

### Alert
Alert the user which the user can respond with `OK`

### Confirm
Ask confirmation of the user. The user can respond with `OK` or `Cancel`

### Prompt
Gives a pop-up in which the user can enter text
**⚠ Prompt only works in a browser**

### Try it out
https://games.gdevelop-app.com/game-9d2c6973-1a11-49f8-9b38-70eb7a35c5da/index.html

[Prompt.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/7696654/Prompt.zip)

