### PR TITLE
Added vertical slider

### DIFF
--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.10",
+  "version": "1.0.0",
   "tags": [
     "draggable",
     "slider",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A horizontal or vertical slider that can be dragged by the users. ",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "tags": [
     "draggable",
     "slider",
@@ -72,7 +72,7 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
                       },
                       "parameters": [
                         "Object",
@@ -197,8 +197,8 @@
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()"
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()"
                           ],
                           "subInstructions": []
                         }
@@ -269,6 +269,17 @@
                         "Object"
                       ],
                       "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
                     }
                   ],
                   "actions": [],
@@ -285,7 +296,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Detect mouse clicks near track, start dragging",
+                      "comment": "Detect mouse clicks near track, start dragging.  A scene variable is used so that only one slider can be dragged at once.",
                       "comment2": ""
                     },
                     {
@@ -312,7 +323,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.X() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.X() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -326,7 +337,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.X() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.X() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -340,7 +351,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.Y() - Object.Behavior::PropertyTrackWidth() - Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Y() - Object.Behavior::PropertyTrackLength() - Object.Behavior::PropertyThumbWidth() / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -515,7 +526,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.X() + Object.Behavior::PropertyTrackThickness() / 2 - max(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -529,7 +540,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.X() + Object.Behavior::PropertyTrackThickness() / 2 + max(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -543,7 +554,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() - Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -557,7 +568,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() - Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -725,7 +736,7 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyNeedRedraw"
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyNeedRedraw"
                       },
                       "parameters": [
                         "Object",
@@ -738,7 +749,7 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                       },
                       "parameters": [
                         "Object",
@@ -782,7 +793,7 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                           },
                           "parameters": [
                             "Object",
@@ -795,7 +806,7 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                           },
                           "parameters": [
                             "Object",
@@ -810,7 +821,7 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetThumbShape"
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetThumbShape"
                           },
                           "parameters": [
                             "Object",
@@ -824,722 +835,781 @@
                       "events": []
                     },
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
                       "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Use a more opaque halo while being dragged",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "name": "Pressed halo",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityClick()"
-                          ],
-                          "subInstructions": []
+                          "comment": "Use a more opaque halo while being dragged",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityClick()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "-Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Inactive track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Set inactive track parameters (by default, use thumb color)",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "-Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyHaloRadius()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyInactiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set inactive track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": true,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyInactiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyInactiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyInactiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyInactiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "-Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "180",
-                            "360",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw inactive track",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "0",
-                            "-Object.Behavior::PropertyTrackWidth()",
-                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())",
-                            "-Object.Behavior::PropertyThumbOffset()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set active track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyActiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyActiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "0",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "0",
-                            "180",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw active track (2 pixels bigger than property) ",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "-1",
-                            "-Object.Behavior::PropertyThumbOffset()",
-                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())+1",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Prepare thumb settings",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyThumbOpacity()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyInactiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Circle thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Circle\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackHeight() / 2",
-                            "-Object.Behavior::PropertyThumbOffset()",
-                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Rectangle thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Rectangle\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
-                            "-Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
-                            "-Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw hover",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityHover()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
+                          "comment": "Draw half circle at inactive end (optional)",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "-Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyHaloRadius()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "-Object.Behavior::PropertyTrackLength()",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "180",
+                                "360",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw inactive track",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "0",
+                                "-Object.Behavior::PropertyTrackLength()",
+                                "min(Object.Behavior::PropertyTrackThickness(), Object.Behavior::PropertyThumbHeight())",
+                                "-Object.Behavior::PropertyThumbOffset()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
                       ],
-                      "events": []
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Active track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Set active track parameters (by default, use thumb color)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"0;0;0\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"0;0;0\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyActiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyActiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw half circle at active end (optional)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "0",
+                                "1 + Object.Behavior::PropertyTrackThickness() / 2",
+                                "0",
+                                "180",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw active track (2 pixels bigger than property) ",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "-1",
+                                "-Object.Behavior::PropertyThumbOffset()",
+                                "min(Object.Behavior::PropertyTrackThickness(), Object.Behavior::PropertyThumbHeight()) + 1",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Hover",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw hover",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityHover()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "-Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Thumb",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Prepare thumb settings",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyThumbOpacity()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Circle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"Circle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "-Object.Behavior::PropertyThumbOffset()",
+                                "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Rectangle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"Rectangle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
+                                "-Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
+                                "-Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
                     }
                   ]
                 }
@@ -1587,7 +1657,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
                   },
                   "parameters": [
                     "Object",
@@ -1701,7 +1771,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -1714,13 +1784,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -1729,13 +1799,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
+                    "=",
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -1768,12 +1838,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change height of track.",
-          "fullName": "Track height",
+          "description": "Change thickness of track.",
+          "fullName": "Track thickness",
           "functionType": "Action",
-          "name": "SetTrackHeight",
+          "name": "SetTrackThickness",
           "private": false,
-          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track thickness of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -1784,7 +1854,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyTrackThickness"
                   },
                   "parameters": [
                     "Object",
@@ -1797,7 +1867,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -1821,7 +1891,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment": "Make sure thumb width is not smaller than track thickness (to prevent track ends from showing)",
               "comment2": ""
             },
             {
@@ -1832,7 +1902,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -1845,13 +1915,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -1860,13 +1930,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
+                    "=",
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -1914,7 +1984,7 @@
           "functionType": "Action",
           "name": "SetThumbHeight",
           "private": false,
-          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -1925,7 +1995,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbHeight"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbHeight"
                   },
                   "parameters": [
                     "Object",
@@ -1938,7 +2008,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2002,7 +2072,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOpacity"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOpacity"
                   },
                   "parameters": [
                     "Object",
@@ -2015,7 +2085,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2079,7 +2149,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackOpacity"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyInactiveTrackOpacity"
                   },
                   "parameters": [
                     "Object",
@@ -2092,7 +2162,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2156,7 +2226,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackOpacity"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyActiveTrackOpacity"
                   },
                   "parameters": [
                     "Object",
@@ -2169,7 +2239,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2217,12 +2287,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change width of track.",
-          "fullName": "Track width",
+          "description": "Change length of track.",
+          "fullName": "Track length",
           "functionType": "Action",
-          "name": "SetTrackWidth",
+          "name": "SetTrackLength",
           "private": false,
-          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track length of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -2233,7 +2303,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyTrackLength"
                   },
                   "parameters": [
                     "Object",
@@ -2246,7 +2316,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2299,7 +2369,7 @@
           "functionType": "Action",
           "name": "SetThumbWidth",
           "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -2310,7 +2380,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
@@ -2323,7 +2393,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2358,7 +2428,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -2371,13 +2441,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -2386,13 +2456,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
+                    "=",
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -2451,7 +2521,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -2464,7 +2534,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2499,7 +2569,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -2512,13 +2582,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -2527,13 +2597,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
+                    "=",
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -2576,12 +2646,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
+          "description": "Change the opacity of halo when pressed.",
+          "fullName": "Halo opacity when pressed",
           "functionType": "Action",
-          "name": "SetHaloRadius",
+          "name": "SetHaloOpacityClick",
           "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change halo opacity when pressed of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -2592,7 +2662,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloOpacityClick"
                   },
                   "parameters": [
                     "Object",
@@ -2605,7 +2675,161 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo opacity when pressed",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the opacity of halo.",
+          "fullName": "Halo opacity",
+          "functionType": "Action",
+          "name": "SetHaloOpacity",
+          "private": false,
+          "sentence": "Change halo opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloOpacityHover"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the radius of halo.",
+          "fullName": "Halo Radius",
+          "functionType": "Action",
+          "name": "SetHaloRadius",
+          "private": false,
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_ px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloRadius"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2669,7 +2893,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackColor"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyActiveTrackColor"
                   },
                   "parameters": [
                     "Object",
@@ -2681,7 +2905,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2745,7 +2969,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackColor"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyInactiveTrackColor"
                   },
                   "parameters": [
                     "Object",
@@ -2757,7 +2981,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2834,7 +3058,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2868,7 +3092,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2889,7 +3113,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -2953,7 +3177,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbColor"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbColor"
                   },
                   "parameters": [
                     "Object",
@@ -2965,7 +3189,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -3028,7 +3252,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyTickSpacing"
                   },
                   "parameters": [
                     "Object",
@@ -3043,7 +3267,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3064,7 +3288,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyTickSpacing"
                   },
                   "parameters": [
                     "Object",
@@ -3079,7 +3303,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3100,7 +3324,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3115,7 +3339,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3136,7 +3360,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3151,7 +3375,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
                   },
                   "parameters": [
                     "Object",
@@ -3194,14 +3418,14 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
+                    "Object.Behavior::PropertyTrackLength() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
                   ],
                   "subInstructions": []
                 },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
                   },
                   "parameters": [
                     "Object",
@@ -3244,6 +3468,229 @@
               "optional": false,
               "supplementaryInformation": "",
               "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the slider is disabled.",
+          "fullName": "Is disabled",
+          "functionType": "Condition",
+          "name": "IsDisabled",
+          "private": false,
+          "sentence": "_PARAM0_ is disabled",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Disable (or enable) the slider.  Users cannot interact with disabled sliders.",
+          "fullName": "Disable (or enable) the slider",
+          "functionType": "Action",
+          "name": "SetDisabled",
+          "private": false,
+          "sentence": "Disable _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"State\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"State\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Disabled",
+              "longDescription": "",
+              "name": "State",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
             }
           ],
           "objectGroups": []
@@ -3305,7 +3752,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Minimum value",
+          "label": "Minimum value (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3314,7 +3761,7 @@
         {
           "value": "1",
           "type": "Number",
-          "label": "Maximum value",
+          "label": "Maximum value (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3323,7 +3770,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Tick spacing",
+          "label": "Tick spacing (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3332,7 +3779,7 @@
         {
           "value": "circle",
           "type": "Choice",
-          "label": "Thumb shape",
+          "label": "Thumb shape (property)",
           "description": "",
           "extraInformation": [
             "Circle",
@@ -3344,7 +3791,7 @@
         {
           "value": "20",
           "type": "Number",
-          "label": "Thumb width",
+          "label": "Thumb width (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3353,7 +3800,7 @@
         {
           "value": "20",
           "type": "Number",
-          "label": "Thumb height",
+          "label": "Thumb height (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3362,7 +3809,7 @@
         {
           "value": "24;119;211",
           "type": "Color",
-          "label": "Thumb Color",
+          "label": "Thumb Color (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3371,7 +3818,7 @@
         {
           "value": "255",
           "type": "Number",
-          "label": "Thumb opacity",
+          "label": "Thumb opacity (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3380,25 +3827,25 @@
         {
           "value": "200",
           "type": "Number",
-          "label": "Track width",
+          "label": "Track length (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackWidth"
+          "name": "TrackLength"
         },
         {
           "value": "4",
           "type": "Number",
-          "label": "Track height",
+          "label": "Track thickness (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackHeight"
+          "name": "TrackThickness"
         },
         {
           "value": "",
           "type": "Color",
-          "label": "Inactive track color (thumb color by default)",
+          "label": "Inactive track color (thumb color by default) (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3407,7 +3854,7 @@
         {
           "value": "96",
           "type": "Number",
-          "label": "Inactive track opacity",
+          "label": "Inactive track opacity (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3416,7 +3863,7 @@
         {
           "value": " ",
           "type": "Color",
-          "label": "Active track color (thumb color by default)",
+          "label": "Active track color (thumb color by default) (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3425,7 +3872,7 @@
         {
           "value": "255",
           "type": "Number",
-          "label": "Active track opacity",
+          "label": "Active track opacity (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3434,7 +3881,7 @@
         {
           "value": "24",
           "type": "Number",
-          "label": "Hover halo size",
+          "label": "Hover halo size (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3452,7 +3899,7 @@
         {
           "value": "64",
           "type": "Number",
-          "label": "Pressed halo opacity",
+          "label": "Pressed halo opacity (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3461,7 +3908,7 @@
         {
           "value": "true",
           "type": "Boolean",
-          "label": "Rounded track ends",
+          "label": "Rounded track ends (property)",
           "description": "",
           "extraInformation": [],
           "hidden": false,
@@ -3470,7 +3917,7 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "Is being dragged",
+          "label": "Is being dragged (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3479,7 +3926,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Value",
+          "label": "Value (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3488,7 +3935,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Thumb offset (thumb position on the track)",
+          "label": "Thumb offset (thumb position on the track) (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3497,7 +3944,7 @@
         {
           "value": "true",
           "type": "Boolean",
-          "label": "Need redraw",
+          "label": "Need redraw (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3506,7 +3953,7 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "Is hovered",
+          "label": "Is hovered (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
@@ -3515,11 +3962,20 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "Was Hovered",
+          "label": "Was Hovered (property)",
           "description": "",
           "extraInformation": [],
           "hidden": true,
           "name": "WasHovered"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Disabled (property)",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Disabled"
         }
       ]
     },
@@ -3696,7 +4152,7 @@
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
                             ""
                           ],
                           "subInstructions": []
@@ -3768,6 +4224,17 @@
                         "Object"
                       ],
                       "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
                     }
                   ],
                   "actions": [],
@@ -3784,7 +4251,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Detect mouse clicks near track, start dragging",
+                      "comment": "Detect mouse clicks near track, start dragging.  A scene variable is used so that only one slider can be dragged at once.",
                       "comment2": ""
                     },
                     {
@@ -3825,7 +4292,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.X() + Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.X() + Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyThumbWidth() / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -3839,7 +4306,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -3853,7 +4320,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             "0"
                           ],
@@ -4042,7 +4509,7 @@
                           "parameters": [
                             "",
                             ">=",
-                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -4056,7 +4523,7 @@
                           "parameters": [
                             "",
                             "<=",
-                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
                             "Object.Layer()",
                             ""
                           ],
@@ -4323,687 +4790,780 @@
                       "events": []
                     },
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
                       "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Use a more opaque halo while being dragged",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "name": "Pressed halo",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityClick()"
-                          ],
-                          "subInstructions": []
+                          "comment": "Use a more opaque halo while being dragged",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityClick()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyTrackThickness()/2",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Inactive track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Set inactive track parameters (by default, use thumb color)",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "Object.Behavior::PropertyHaloRadius()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyInactiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set inactive track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyInactiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyInactiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "270",
-                            "90",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw inactive track",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "0",
-                            "Object.Behavior::PropertyTrackWidth()",
-                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set active track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0;0;0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyActiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyActiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "0",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "90",
-                            "270",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw active track (2 pixels bigger than property) ",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "0",
-                            "-1",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight()) + 1"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Prepare thumb settings",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyThumbOpacity()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyInactiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Circle thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Circle\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight() / 2",
-                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Rectangle thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Rectangle\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
-                            "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityHover()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
+                          "comment": "Draw half circle at inactive end (optional)",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "Object.Behavior::PropertyHaloRadius()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackLength()",
+                                "Object.Behavior::PropertyTrackThickness()/2",
+                                "Object.Behavior::PropertyTrackThickness()/2",
+                                "270",
+                                "90",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw inactive track",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "0",
+                                "Object.Behavior::PropertyTrackLength()",
+                                "min(Object.Behavior::PropertyTrackThickness(),Object.Behavior::PropertyThumbHeight())"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
                       ],
-                      "events": []
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Active track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Set active track parameters (by default, use thumb color)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"0;0;0\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"0;0;0\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyActiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyActiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw half circle at active end (optional)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "0",
+                                "Object.Behavior::PropertyTrackThickness()/2",
+                                "1 + Object.Behavior::PropertyTrackThickness()/2",
+                                "90",
+                                "270",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw active track (2 pixels bigger than property) ",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "0",
+                                "-1",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "min(Object.Behavior::PropertyTrackThickness(),Object.Behavior::PropertyThumbHeight()) + 1"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Halo",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw halo",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityHover()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyTrackThickness()/2",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "disabled": false,
+                      "folded": false,
+                      "name": "Thumb",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Prepare thumb settings",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyThumbOpacity()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Circle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"Circle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Rectangle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"Rectangle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
+                                "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
                     }
                   ]
                 }
@@ -5184,7 +5744,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -5198,7 +5758,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness()",
                     ""
                   ],
                   "subInstructions": []
@@ -5232,12 +5792,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change height of track.",
-          "fullName": "Track height",
+          "description": "Change thickness of track.",
+          "fullName": "Track thickness",
           "functionType": "Action",
-          "name": "SetTrackHeight",
+          "name": "SetTrackThickness",
           "private": false,
-          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track thickness of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -5248,7 +5808,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackThickness"
                   },
                   "parameters": [
                     "Object",
@@ -5285,7 +5845,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment": "Make sure thumb width is not smaller than track thickness (to prevent track ends from showing)",
               "comment2": ""
             },
             {
@@ -5315,7 +5875,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -5329,7 +5889,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness()",
                     ""
                   ],
                   "subInstructions": []
@@ -5362,7 +5922,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Track height",
+              "description": "Track thickness",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -5378,7 +5938,7 @@
           "functionType": "Action",
           "name": "SetThumbHeight",
           "private": false,
-          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -5681,12 +6241,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change width of track.",
-          "fullName": "Track width",
+          "description": "Change length of track.",
+          "fullName": "Track length",
           "functionType": "Action",
-          "name": "SetTrackWidth",
+          "name": "SetTrackLength",
           "private": false,
-          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track length of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -5697,7 +6257,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackLength"
                   },
                   "parameters": [
                     "Object",
@@ -5747,7 +6307,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Track width",
+              "description": "Track length",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -5763,7 +6323,7 @@
           "functionType": "Action",
           "name": "SetThumbWidth",
           "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -5841,7 +6401,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -5855,7 +6415,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness()",
                     ""
                   ],
                   "subInstructions": []
@@ -5982,7 +6542,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -5996,7 +6556,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness()",
                     ""
                   ],
                   "subInstructions": []
@@ -6040,12 +6600,166 @@
           "objectGroups": []
         },
         {
+          "description": "Change the opacity of halo when pressed.",
+          "fullName": "Halo opacity when pressed",
+          "functionType": "Action",
+          "name": "SetHaloOpacityClick",
+          "private": false,
+          "sentence": "Change halo opacity when pressed of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloOpacityClick"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo opacity when pressed",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the opacity of halo.",
+          "fullName": "Halo opacity",
+          "functionType": "Action",
+          "name": "SetHaloOpacity",
+          "private": false,
+          "sentence": "Change halo opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloOpacityHover"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
+          "fullName": "Halo radius",
           "functionType": "Action",
           "name": "SetHaloRadius",
           "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_ px",
           "events": [
             {
               "disabled": false,
@@ -6658,7 +7372,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
+                    "Object.Behavior::PropertyTrackLength() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
                   ],
                   "subInstructions": []
                 },
@@ -6708,6 +7422,229 @@
               "optional": false,
               "supplementaryInformation": "",
               "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the slider is disabled.",
+          "fullName": "Is disabled",
+          "functionType": "Condition",
+          "name": "IsDisabled",
+          "private": false,
+          "sentence": "_PARAM0_ is disabled",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Disable (or enable) the slider. Users cannot interact with disabled sliders.",
+          "fullName": "Disable (or enable) the slider",
+          "functionType": "Action",
+          "name": "SetDisabled",
+          "private": false,
+          "sentence": "Disable _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"State\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"State\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Disabled",
+              "longDescription": "",
+              "name": "State",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
             }
           ],
           "objectGroups": []
@@ -6848,7 +7785,7 @@
           "description": "",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackWidth"
+          "name": "TrackLength"
         },
         {
           "value": "4",
@@ -6857,7 +7794,7 @@
           "description": "",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackHeight"
+          "name": "TrackThickness"
         },
         {
           "value": "",
@@ -6984,6 +7921,15 @@
           "extraInformation": [],
           "hidden": true,
           "name": "WasHovered"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Disabled",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Disabled"
         }
       ]
     }

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -1,6 +1,6 @@
 {
   "author": "Tristan Rhodes (https://victrisgames.itch.io/), D8H",
-  "description": "Draws a draggable slider that users can move to select a numerical value.\nThe value range, tick spacing, and the appearance of the slider can be defined with properties.\n\nHow to use:\n- Add this behavior a **Shape Painter** object\n- Place an instance of that shape painter on the screen where you want the slider to appear\n- Use the \"Value\" expression to find the Value based on the position of the slider\n\nTips:\n- You can disable the slider to prevent a user from interacting with it\n- You can set the Value of the slider and the slider will move to the correct position\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
+  "description": "Draws a draggable slider that users can move to select a numerical value.\nThe value range, tick spacing, and the appearance of the slider can be defined with properties.\n\nHow to use:\n- Add this behavior a **Shape Painter** object\n- Place an instance of that shape painter on the screen where you want the slider to appear\n- Use the \"Value\" expression to find the Value based on the position of the slider\n\nTips:\n- You can disable the slider to prevent a user from interacting with it\n- You can set the Value of the slider and the slider will move to the correct position\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n\nBreaking changes (1.0.0)\n- Track thickness and length properties replaced track width and height. These 2 properties must be set again if they were different from the default size.\n- Hidden sliders can be dragged. The \"enable\" action must be used to disable them.\n",
   "extensionNamespace": "",
   "fullName": "Draggable slider",
   "helpPath": "",
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.8",
+  "version": "0.7.10",
   "tags": [
     "draggable",
     "slider",
@@ -1561,7 +1561,7 @@
                                 "Object",
                                 "Behavior",
                                 ">",
-                                "min(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight())"
+                                "min(Object.Behavior::PropertyThumbHeight(), Object.Behavior::PropertyThumbWidth()) / 2"
                               ],
                               "subInstructions": []
                             }
@@ -2136,18 +2136,6 @@
                         "Object",
                         "Behavior",
                         "no"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DraggableSliderBehavior.SlideInProgress",
-                        "=",
-                        "0"
                       ],
                       "subInstructions": []
                     }

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "tags": [
     "draggable",
     "slider",
@@ -24,7 +24,7 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "A draggable slider that users can move to select a numerical value.",
+      "description": "Let users select a numerical value by dragging a slider.",
       "fullName": "Draggable slider",
       "name": "DraggableSliderControl",
       "objectType": "PrimitiveDrawing::Drawer",
@@ -449,7 +449,7 @@
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
                             ""
                           ],
                           "subInstructions": []
@@ -614,7 +614,7 @@
                           "parameters": [
                             "Object.Behavior::PropertyMouseX()",
                             "<=",
-                            "Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyHaloRadius()"
+                            "Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
@@ -1081,7 +1081,7 @@
                       "colorR": 74,
                       "creationTime": 0,
                       "disabled": false,
-                      "folded": true,
+                      "folded": false,
                       "name": "Inactive track",
                       "source": "",
                       "type": "BuiltinCommonInstructions::Group",
@@ -1232,7 +1232,7 @@
                                 "Object",
                                 "Object.Behavior::PropertyThumbOffset()",
                                 "-Object.Behavior::PropertyTrackThickness() / 2",
-                                "Object.Behavior::PropertyTrackWidth()",
+                                "Object.Behavior::PropertyTrackLength()",
                                 "Object.Behavior::PropertyTrackThickness() / 2"
                               ],
                               "subInstructions": []
@@ -1280,7 +1280,7 @@
                               },
                               "parameters": [
                                 "Object",
-                                "Object.Behavior::PropertyTrackWidth()",
+                                "Object.Behavior::PropertyTrackLength()",
                                 "0",
                                 "Object.Behavior::PropertyTrackThickness() / 2",
                                 "270",
@@ -1302,7 +1302,7 @@
                       "colorR": 74,
                       "creationTime": 0,
                       "disabled": false,
-                      "folded": true,
+                      "folded": false,
                       "name": "Active track",
                       "source": "",
                       "type": "BuiltinCommonInstructions::Group",
@@ -1884,12 +1884,12 @@
         },
         {
           "description": "Check if the slider is being dragged.",
-          "fullName": "Is being dragged",
+          "fullName": "Being dragged",
           "functionType": "Condition",
-          "group": "",
+          "group": "Slider",
           "name": "IsBeingDragged",
           "private": false,
-          "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
+          "sentence": "_PARAM0_ is being dragged",
           "events": [
             {
               "disabled": false,
@@ -1948,13 +1948,13 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the slider is disabled.",
-          "fullName": "Is disabled",
+          "description": "Check if the slider interations are enabled.",
+          "fullName": "Interactions enabled",
           "functionType": "Condition",
-          "group": "",
-          "name": "IsDisabled",
-          "private": false,
-          "sentence": "_PARAM0_ is disabled",
+          "group": "Slider",
+          "name": "IsEnabled",
+          "private": true,
+          "sentence": "Interactions of _PARAM0_ are enabled",
           "events": [
             {
               "disabled": false,
@@ -1964,7 +1964,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyEnabled"
                   },
                   "parameters": [
                     "Object",
@@ -1981,37 +1981,6 @@
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "False"
                   ],
                   "subInstructions": []
                 }
@@ -2039,6 +2008,124 @@
               "optional": false,
               "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
               "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Enable or disable the slider. Users cannot interact while it is disabled.",
+          "fullName": "Enable interactions",
+          "functionType": "Action",
+          "group": "Slider",
+          "name": "SetEnabled",
+          "private": true,
+          "sentence": "Enable interactions of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyEnabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Enable\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyEnabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Enable",
+              "longDescription": "",
+              "name": "Enable",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
             }
           ],
           "objectGroups": []
@@ -2279,7 +2366,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
+                    "Object.Behavior::PropertyTrackLength() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
                   ],
                   "subInstructions": []
                 },
@@ -2740,6 +2827,133 @@
           "objectGroups": []
         },
         {
+          "description": "Change length of track.",
+          "fullName": "Track length",
+          "functionType": "Action",
+          "group": "Slider track configuration",
+          "name": "SetTrackLength",
+          "private": false,
+          "sentence": "Change track length of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackLength"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Move thumb to correct place (based on new track size)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyValue()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Track width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change thickness of track.",
           "fullName": "Track thickness",
           "functionType": "Action",
@@ -2905,6 +3119,120 @@
           "objectGroups": []
         },
         {
+          "description": "Change width of thumb.",
+          "fullName": "Thumb width",
+          "functionType": "Action",
+          "group": "Slider thumb configuration",
+          "name": "SetThumbWidth",
+          "private": false,
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Thumb cannot be less than track thickness (plus 2 pixels)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(GetArgumentAsNumber(\"Value\"), Object.Behavior::PropertyTrackThickness() + 2)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change height of thumb.",
           "fullName": "Thumb height",
           "functionType": "Action",
@@ -3014,6 +3342,359 @@
               "optional": false,
               "supplementaryInformation": "",
               "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the radius of halo.",
+          "fullName": "Halo Radius",
+          "functionType": "Action",
+          "group": "Slider thumb configuration",
+          "name": "SetHaloRadius",
+          "private": false,
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo radius",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change shape of thumb (circle or rectangle).",
+          "fullName": "Thumb shape",
+          "functionType": "Action",
+          "group": "Slider thumb configuration",
+          "name": "SetThumbShape",
+          "private": false,
+          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"Shape\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackThickness()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackThickness()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "New thumb shape",
+              "longDescription": "",
+              "name": "Shape",
+              "optional": false,
+              "supplementaryInformation": "[\"circle\",\"rectangle\"]",
+              "type": "stringWithSelector"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make track use rounded ends.",
+          "fullName": "Rounded track ends",
+          "functionType": "Action",
+          "group": "Slider track configuration",
+          "name": "SetRoundedTrack",
+          "private": false,
+          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "1"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Rounded track",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
             }
           ],
           "objectGroups": []
@@ -3253,467 +3934,6 @@
           "objectGroups": []
         },
         {
-          "description": "Change width of track.",
-          "fullName": "Track width",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetTrackWidth",
-          "private": false,
-          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Move thumb to correct place (based on new track size)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyValue()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Track width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change width of thumb.",
-          "fullName": "Thumb width",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbWidth",
-          "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Thumb cannot be less than track thickness (plus 2 pixels)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "max(GetArgumentAsNumber(\"Value\"), Object.Behavior::PropertyTrackThickness() + 2)"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change shape of thumb (circle or rectangle).",
-          "fullName": "Thumb shape",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbShape",
-          "private": false,
-          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Shape\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackThickness()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "New thumb shape",
-              "longDescription": "",
-              "name": "Shape",
-              "optional": false,
-              "supplementaryInformation": "[\"circle\",\"rectangle\"]",
-              "type": "stringWithSelector"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetHaloRadius",
-          "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo radius",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
           "description": "Change the color of the track that is LEFT of the thumb.",
           "fullName": "Active track color ",
           "functionType": "Action",
@@ -3868,139 +4088,6 @@
           "objectGroups": []
         },
         {
-          "description": "Make track use rounded ends.",
-          "fullName": "Rounded track ends",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetRoundedTrack",
-          "private": false,
-          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "no"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "1"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Rounded track",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "yesorno"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
           "description": "Change the thumb color to a specific value.",
           "fullName": "Thumb color",
           "functionType": "Action",
@@ -4078,135 +4165,6 @@
           "objectGroups": []
         },
         {
-          "description": "Disable (or enable) the slider. Users cannot interact while it is disabled.",
-          "fullName": "Disable (or enable) the slider",
-          "functionType": "Action",
-          "group": "",
-          "name": "SetDisabled",
-          "private": false,
-          "sentence": "Disable _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "GetArgumentAsBoolean"
-                  },
-                  "parameters": [
-                    "\"State\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "no"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "GetArgumentAsBoolean"
-                  },
-                  "parameters": [
-                    "\"State\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Disabled",
-              "longDescription": "",
-              "name": "State",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "yesorno"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
           "description": "Update the hitbox.",
           "fullName": "Update hitbox",
           "functionType": "Action",
@@ -4228,7 +4186,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTrackWidth() / 2",
+                    "Object.Behavior::PropertyTrackLength() / 2",
                     "Object.Behavior::PropertyTrackThickness() / 2"
                   ],
                   "subInstructions": []
@@ -4242,7 +4200,7 @@
                     "Object",
                     "-Object.Behavior::PropertyThumbWidth() / 2",
                     "-Object.Behavior::PropertyThumbHeight() / 2",
-                    "Object. Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
+                    "Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyThumbWidth() / 2",
                     "Object.Behavior::PropertyThumbHeight() / 2"
                   ],
                   "subInstructions": []
@@ -4310,7 +4268,7 @@
         {
           "value": "circle",
           "type": "Choice",
-          "label": "Thumb shape (\"circle\" or \"rectangle\")",
+          "label": "Thumb shape",
           "description": "",
           "group": "Thumb",
           "extraInformation": [
@@ -4368,7 +4326,7 @@
           "group": "Track",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackWidth"
+          "name": "TrackLength"
         },
         {
           "value": "4",
@@ -4461,6 +4419,16 @@
           "name": "RoundedTrack"
         },
         {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Enable interactions",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Enabled"
+        },
+        {
           "value": "",
           "type": "Boolean",
           "label": "",
@@ -4539,16 +4507,6 @@
           "extraInformation": [],
           "hidden": true,
           "name": "CurrentHaloRadius"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Disabled (users cannot interact while disabled)",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "Disabled"
         },
         {
           "value": "0.2",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "tags": [
     "draggable",
     "slider",
@@ -167,6 +167,27 @@
                     "Object",
                     "Behavior",
                     "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
                     ""
                   ],
                   "subInstructions": []
@@ -1109,7 +1130,7 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
                             "Object.Behavior::PropertyCurrentHaloRadius()"
                           ],
                           "subInstructions": []
@@ -1182,7 +1203,7 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
                             "Object.Behavior::PropertyCurrentHaloRadius()"
                           ],
                           "subInstructions": []
@@ -1403,9 +1424,9 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyThumbOffset()",
-                            "0",
+                            "-Object.Behavior::PropertyTrackHeight() / 2",
                             "Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyTrackHeight()"
+                            "Object.Behavior::PropertyTrackHeight() / 2"
                           ],
                           "subInstructions": []
                         }
@@ -1453,7 +1474,7 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
                             "Object.Behavior::PropertyTrackHeight()/2",
                             "270",
                             "90",
@@ -1666,9 +1687,9 @@
                           "parameters": [
                             "Object",
                             "0",
-                            "-1",
+                            "-(Object.Behavior::PropertyTrackHeight() / 2 + 1)",
                             "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight() + 1"
+                            "Object.Behavior::PropertyTrackHeight() / 2 + 1"
                           ],
                           "subInstructions": []
                         }
@@ -1716,7 +1737,7 @@
                           "parameters": [
                             "Object",
                             "0",
-                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
                             "Object.Behavior::PropertyTrackHeight()/2",
                             "90",
                             "270",
@@ -1818,7 +1839,7 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight() / 2",
+                            "0",
                             "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
                           ],
                           "subInstructions": []
@@ -1869,9 +1890,9 @@
                           "parameters": [
                             "Object",
                             "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "-Object.Behavior::PropertyThumbHeight() / 2",
                             "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
+                            "Object.Behavior::PropertyThumbHeight() / 2"
                           ],
                           "subInstructions": []
                         }
@@ -2938,6 +2959,18 @@
                 {
                   "type": {
                     "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
                   },
                   "parameters": [
@@ -3250,6 +3283,18 @@
                 {
                   "type": {
                     "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
                   },
                   "parameters": [
@@ -3322,6 +3367,18 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::UpdateHitbox"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
                   ],
                   "subInstructions": []
                 },
@@ -4151,6 +4208,75 @@
               "optional": false,
               "supplementaryInformation": "",
               "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Update the hitbox.",
+          "fullName": "Update hitbox",
+          "functionType": "Action",
+          "group": "Private",
+          "name": "UpdateHitbox",
+          "private": true,
+          "sentence": "Update the hitbox of _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PrimitiveDrawing::SetRotationCenter"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Object.Behavior::PropertyTrackWidth() / 2",
+                    "Object.Behavior::PropertyTrackHeight() / 2"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PrimitiveDrawing::SetRectangularCollisionMask"
+                  },
+                  "parameters": [
+                    "Object",
+                    "-Object.Behavior::PropertyThumbWidth() / 2",
+                    "-Object.Behavior::PropertyThumbHeight() / 2",
+                    "Object. Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
+                    "Object.Behavior::PropertyThumbHeight() / 2"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
             }
           ],
           "objectGroups": []

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "tags": [
     "draggable",
     "slider",
@@ -122,52 +122,25 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment": "Set track height function (which enforces valid thumb sizes)",
               "comment2": ""
             },
             {
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
+              "conditions": [],
+              "actions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackThickness"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackHeight()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -236,7 +209,7 @@
               "creationTime": 0,
               "disabled": false,
               "folded": false,
-              "name": "Slider logic",
+              "name": "Slider LOGIC",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
@@ -1019,7 +992,7 @@
               "creationTime": 0,
               "disabled": false,
               "folded": false,
-              "name": "Slider drawing",
+              "name": "Slider DRAWING",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
@@ -1066,838 +1039,758 @@
                   ],
                   "events": [
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw halo (it will grow or shrink as needed)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "folded": true,
+                      "name": "Inactive track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
                         {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityHover()"
-                          ],
-                          "subInstructions": []
+                          "comment": "Set inactive track parameters (by default, use thumb color)",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "0",
-                            "Object.Behavior::PropertyCurrentHaloRadius()"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Use a more opaque halo while being dragged (it will grow or shrink as needed)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyInactiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyHaloOpacityClick()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyInactiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "0",
-                            "Object.Behavior::PropertyCurrentHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set inactive track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": true,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControlTRR::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": true,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControlTRR::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyInactiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyInactiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyInactiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
+                          "comment": "Draw inactive track",
+                          "comment2": ""
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "-Object.Behavior::PropertyTrackThickness() / 2",
+                                "Object.Behavior::PropertyTrackWidth()",
+                                "Object.Behavior::PropertyTrackThickness() / 2"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw inactive track",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "-Object.Behavior::PropertyTrackHeight() / 2",
-                            "Object.Behavior::PropertyTrackWidth()",
-                            "Object.Behavior::PropertyTrackHeight() / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTrackWidth()",
-                            "0",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "270",
-                            "90",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set active track parameters (by default, use thumb color)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": true,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": true,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"0\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyActiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyActiveTrackColor()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyActiveTrackOpacity()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw active track (2 pixels bigger than property) ",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "0",
-                            "-(Object.Behavior::PropertyTrackHeight() / 2 + 1)",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "Object.Behavior::PropertyTrackHeight() / 2 + 1"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw half circle at end (optional)",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Arc"
-                          },
-                          "parameters": [
-                            "Object",
-                            "0",
-                            "0",
-                            "Object.Behavior::PropertyTrackHeight()/2",
-                            "90",
-                            "270",
-                            "",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Prepare thumb settings",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbColor()"
-                          ],
-                          "subInstructions": []
+                          "events": []
                         },
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::FillOpacity"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "Object.Behavior::PropertyThumbOpacity()"
+                          "comment": "Draw half circle at end of track (inactive side)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyTrackWidth()",
+                                "0",
+                                "Object.Behavior::PropertyTrackThickness() / 2",
+                                "270",
+                                "90",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
                       ],
-                      "events": []
+                      "parameters": []
                     },
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Circle thumb",
-                      "comment2": ""
+                      "folded": true,
+                      "name": "Active track",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Set active track parameters (by default, use thumb color)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "\"\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyActiveTrackColor()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyActiveTrackOpacity()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw active track (2 pixels bigger than property) ",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "0",
+                                "-(Object.Behavior::PropertyTrackThickness() / 2 + 1)",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "Object.Behavior::PropertyTrackThickness() / 2 + 1"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw half circle at end of track (active side)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Arc"
+                              },
+                              "parameters": [
+                                "Object",
+                                "0",
+                                "0",
+                                "1 + Object.Behavior::PropertyTrackThickness() / 2",
+                                "90",
+                                "270",
+                                "",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ],
+                      "parameters": []
                     },
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "folded": true,
+                      "name": "Halo",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"circle\""
+                          "comment": "Draw halo (it will grow or shrink as needed)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityHover()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "0",
+                                "Object.Behavior::PropertyCurrentHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Use a more opaque halo while being dragged (it will grow or shrink as needed)",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyHaloOpacityClick()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "0",
+                                "Object.Behavior::PropertyCurrentHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
                       ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Circle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset()",
-                            "0",
-                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
+                      "parameters": []
                     },
                     {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
                       "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Draw Rectangle thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "folded": true,
+                      "name": "Thumb",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"rectangle\""
+                          "comment": "Prepare thumb settings",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "Object.Behavior::PropertyThumbOpacity()"
+                              ],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Circle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"circle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset()",
+                                "0",
+                                "ceil(max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight())/2)"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Draw Rectangle thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "\"rectangle\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "-Object.Behavior::PropertyThumbHeight() / 2",
+                                "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
+                                "Object.Behavior::PropertyThumbHeight() / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
                       ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "-Object.Behavior::PropertyThumbHeight() / 2",
-                            "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
-                            "Object.Behavior::PropertyThumbHeight() / 2"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
+                      "parameters": []
                     }
                   ]
                 }
@@ -2787,13 +2680,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change height of track.",
-          "fullName": "Track height",
+          "description": "Change thickness of track.",
+          "fullName": "Track thickness",
           "functionType": "Action",
           "group": "Slider track configuration",
-          "name": "SetTrackHeight",
+          "name": "SetTrackThickness",
           "private": false,
-          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "sentence": "Change track thickness of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -2804,7 +2697,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackThickness"
                   },
                   "parameters": [
                     "Object",
@@ -2841,7 +2734,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment": "Make sure thumb width is not smaller than track height + 2 pixels (to prevent track ends from showing)",
               "comment2": ""
             },
             {
@@ -2852,26 +2745,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness() + 2"
                   ],
                   "subInstructions": []
                 }
@@ -2885,7 +2765,43 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness() + 2",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackThickness() + 2"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackThickness() + 2",
                     ""
                   ],
                   "subInstructions": []
@@ -2918,7 +2834,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Track height",
+              "description": "Track thickness",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -2940,6 +2856,21 @@
             {
               "disabled": false,
               "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Thumb cannot be less than track thickness (plus 2 pixels)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
@@ -2952,10 +2883,19 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Value\")"
+                    "max(GetArgumentAsNumber(\"Value\"), Object.Behavior::PropertyTrackThickness() + 2)"
                   ],
                   "subInstructions": []
-                },
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
                 {
                   "type": {
                     "inverted": false,
@@ -3306,6 +3246,43 @@
                 }
               ],
               "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Move thumb to correct place (based on new track size)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyValue()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
             }
           ],
           "parameters": [
@@ -3354,6 +3331,21 @@
             {
               "disabled": false,
               "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Thumb cannot be less than track thickness (plus 2 pixels)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
@@ -3366,10 +3358,19 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Value\")"
+                    "max(GetArgumentAsNumber(\"Value\"), Object.Behavior::PropertyTrackThickness() + 2)"
                   ],
                   "subInstructions": []
-                },
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
                 {
                   "type": {
                     "inverted": false,
@@ -3391,70 +3392,6 @@
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackHeight()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
                   ],
                   "subInstructions": []
                 }
@@ -3581,7 +3518,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackHeight()"
+                    "Object.Behavior::PropertyTrackThickness()"
                   ],
                   "subInstructions": []
                 }
@@ -3595,7 +3532,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
+                    "Object.Behavior::PropertyTrackThickness()",
                     ""
                   ],
                   "subInstructions": []
@@ -3739,7 +3676,6 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -3817,7 +3753,6 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -4028,7 +3963,6 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -4235,7 +4169,7 @@
                   "parameters": [
                     "Object",
                     "Object.Behavior::PropertyTrackWidth() / 2",
-                    "Object.Behavior::PropertyTrackHeight() / 2"
+                    "Object.Behavior::PropertyTrackThickness() / 2"
                   ],
                   "subInstructions": []
                 },
@@ -4384,7 +4318,7 @@
           "group": "Track",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackHeight"
+          "name": "TrackThickness"
         },
         {
           "value": "",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "tags": [
     "draggable",
     "slider",
@@ -246,7 +246,7 @@
               "creationTime": 0,
               "disabled": false,
               "folded": false,
-              "name": "Slider LOGIC",
+              "name": "Slider logic",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
@@ -320,6 +320,18 @@
                   "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
                     {
                       "type": {
                         "inverted": false,
@@ -404,18 +416,6 @@
                             "no"
                           ],
                           "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__DraggableSliderBehavior.SlideInProgress",
-                            "=",
-                            "0"
-                          ],
-                          "subInstructions": []
                         }
                       ],
                       "events": []
@@ -481,13 +481,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),1.25 * Object.Behavior::PropertyHaloRadius(),Object.Behavior::PropertyHaloGrowSpeed())"
+                            "1.25 * Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         }
@@ -526,39 +526,6 @@
                         "Behavior"
                       ],
                       "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DraggableSliderBehavior.SlideInProgress",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "LayerVisible"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Object.Layer()"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
                     }
                   ],
                   "actions": [],
@@ -583,6 +550,18 @@
                       "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
                         {
                           "type": {
                             "inverted": false,
@@ -653,18 +632,6 @@
                             "Object",
                             "Behavior",
                             "yes"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__DraggableSliderBehavior.SlideInProgress",
-                            "=",
-                            "1"
                           ],
                           "subInstructions": []
                         },
@@ -804,13 +771,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),Object.Behavior::PropertyHaloRadius(),0.2)"
+                            "Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         }
@@ -853,31 +820,54 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),min(Object.Behavior::PropertyThumbHeight()/2,Object.Behavior::PropertyThumbWidth()/2),Object.Behavior::PropertyHaloGrowSpeed())"
+                            "min(Object.Behavior::PropertyThumbHeight(), Object.Behavior::PropertyThumbWidth()) / 2"
                           ],
                           "subInstructions": []
                         }
                       ],
                       "events": []
+                    }
+                  ]
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
                     },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyCurrentHaloRadius"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "!=",
+                        "Object.Behavior::PropertyTargetHaloRadius()"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
                     {
                       "disabled": false,
                       "folded": false,
@@ -901,28 +891,30 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
                             "value": "Egal"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyCurrentHaloRadius()",
-                            "!=",
-                            "Object.Behavior::PropertyHaloRadius()"
+                            "abs(Object.Behavior::PropertyCurrentHaloRadius() - Object.Behavior::PropertyTargetHaloRadius())",
+                            "<",
+                            "1"
                           ],
                           "subInstructions": []
                         }
                       ],
                       "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Behavior::PropertyTargetHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        },
                         {
                           "type": {
                             "inverted": false,
@@ -945,29 +937,32 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyCurrentHaloRadius"
                           },
                           "parameters": [
                             "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyCurrentHaloRadius()",
+                            "Behavior",
                             "!=",
-                            "0"
+                            "Object.Behavior::PropertyTargetHaloRadius()"
                           ],
                           "subInstructions": []
                         }
                       ],
                       "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(), Object.Behavior::PropertyTargetHaloRadius(), Object.Behavior::PropertyHaloGrowSpeed())"
+                          ],
+                          "subInstructions": []
+                        },
                         {
                           "type": {
                             "inverted": false,
@@ -1029,10 +1024,61 @@
               "creationTime": 0,
               "disabled": false,
               "folded": false,
-              "name": "Slider DRAWING",
+              "name": "Slider drawing",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Visible"
+                      },
+                      "parameters": [
+                        "Object"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "LayerVisible"
+                      },
+                      "parameters": [
+                        "",
+                        "Object.Layer()"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": [],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
                 {
                   "disabled": false,
                   "folded": false,
@@ -1046,6 +1092,27 @@
                       "parameters": [
                         "Object",
                         "Behavior"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Visible"
+                      },
+                      "parameters": [
+                        "Object"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "LayerVisible"
+                      },
+                      "parameters": [
+                        "",
+                        "Object.Layer()"
                       ],
                       "subInstructions": []
                     }
@@ -1070,6 +1137,18 @@
                       },
                       "parameters": [
                         "Object"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DebuggerTools::ConsoleLog"
+                      },
+                      "parameters": [
+                        "\"Redraw\"",
+                        "",
+                        ""
                       ],
                       "subInstructions": []
                     }
@@ -1519,171 +1598,193 @@
                         {
                           "disabled": false,
                           "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Prepare halo",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw halo (it will grow or shrink as needed)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityHover()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "0",
-                                "Object.Behavior::PropertyCurrentHaloRadius()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Use a more opaque halo while being dragged (it will grow or shrink as needed)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
                                 "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                                "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
                               },
                               "parameters": [
                                 "Object",
-                                "Behavior"
+                                "Behavior",
+                                ""
                               ],
                               "subInstructions": []
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
                               },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityClick()"
-                              ],
-                              "subInstructions": []
+                              "comment": "Prepare halo",
+                              "comment2": ""
                             },
                             {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "0",
-                                "Object.Behavior::PropertyCurrentHaloRadius()"
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::FillColor"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Object.Behavior::PropertyThumbColor()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::OutlineOpacity"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "=",
+                                    "0"
+                                  ],
+                                  "subInstructions": []
+                                }
                               ],
-                              "subInstructions": []
+                              "events": []
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Draw halo (it will grow or shrink as needed)",
+                              "comment2": ""
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": true,
+                                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::FillOpacity"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "=",
+                                    "Object.Behavior::PropertyHaloOpacityHover()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::Circle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Object.Behavior::PropertyThumbOffset()",
+                                    "0",
+                                    "Object.Behavior::PropertyCurrentHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Use a more opaque halo while being dragged (it will grow or shrink as needed)",
+                              "comment2": ""
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::FillOpacity"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "=",
+                                    "Object.Behavior::PropertyHaloOpacityClick()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "PrimitiveDrawing::Circle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Object.Behavior::PropertyThumbOffset()",
+                                    "0",
+                                    "Object.Behavior::PropertyCurrentHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ],
                       "parameters": []
@@ -1953,7 +2054,7 @@
           "functionType": "Condition",
           "group": "Slider",
           "name": "IsEnabled",
-          "private": true,
+          "private": false,
           "sentence": "Interactions of _PARAM0_ are enabled",
           "events": [
             {
@@ -2018,7 +2119,7 @@
           "functionType": "Action",
           "group": "Slider",
           "name": "SetEnabled",
-          "private": true,
+          "private": false,
           "sentence": "Enable interactions of _PARAM0_: _PARAM2_",
           "events": [
             {
@@ -3347,8 +3448,8 @@
           "objectGroups": []
         },
         {
-          "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
+          "description": "Change radius of the halo around the thumb.  This size is also used to detect interaction with the slider.",
+          "fullName": "Halo radius",
           "functionType": "Action",
           "group": "Slider thumb configuration",
           "name": "SetHaloRadius",
@@ -4340,7 +4441,7 @@
         },
         {
           "value": "",
-          "type": "Color",
+          "type": "String",
           "label": "Inactive track color (thumb color by default)",
           "description": "",
           "group": "Track",
@@ -4360,7 +4461,7 @@
         },
         {
           "value": " ",
-          "type": "Color",
+          "type": "String",
           "label": "Active track color (thumb color by default)",
           "description": "",
           "group": "Track",
@@ -4425,7 +4526,7 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": true,
+          "hidden": false,
           "name": "Enabled"
         },
         {
@@ -4501,7 +4602,7 @@
         {
           "value": "",
           "type": "Number",
-          "label": "Current halo radius (used to animate halo)",
+          "label": "",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -4511,12 +4612,22 @@
         {
           "value": "0.2",
           "type": "Number",
-          "label": "Halo grow (and shrink) speed (used for animation) Range: 0 to 1",
+          "label": "",
           "description": "",
           "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "HaloGrowSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TargetHaloRadius"
         }
       ]
     }

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.6",
+  "version": "0.7.8",
   "tags": [
     "draggable",
     "slider",
@@ -253,71 +253,6 @@
                 {
                   "disabled": false,
                   "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Track where the mouse is (in relation to object)",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseX"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.ToDrawingX(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseY"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.ToDrawingY(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Move slider when being dragged",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -329,201 +264,6 @@
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.Behavior::PropertyMouseX()"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "End sliding and update variables",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseButtonReleased"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Update \"Value\" based on the location of the thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Grow halo even more when pressed",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "1.25 * Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
                       ],
                       "subInstructions": []
                     }
@@ -542,7 +282,57 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Detect mouse clicks near track, start dragging",
+                      "comment": "Track where the mouse is (in relation to object)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.ToDrawingX(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.ToDrawingY(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Move slider when being dragged",
                       "comment2": ""
                     },
                     {
@@ -553,71 +343,11 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
                           },
                           "parameters": [
                             "Object",
-                            "Behavior",
-                            ""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisBouton"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
-                            ">=",
-                            "-Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
-                            "<=",
-                            "Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
-                            ">=",
-                            "-Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
-                            "<=",
-                            "Object.Behavior::PropertyHaloRadius()"
+                            "Behavior"
                           ],
                           "subInstructions": []
                         }
@@ -626,12 +356,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "yes"
+                            "=",
+                            "Object.Behavior::PropertyMouseX()"
                           ],
                           "subInstructions": []
                         },
@@ -648,7 +379,130 @@
                           "subInstructions": []
                         }
                       ],
-                      "events": []
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "End sliding and update variables",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "MouseButtonReleased"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "no"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Update \"Value\" based on the location of the thumb",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
+                                ""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Grow halo even more when pressed",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "1.25 * Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ]
                     },
                     {
                       "disabled": false,
@@ -662,141 +516,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Reset hover detection ",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Grow halo when hovered",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
-                            ">=",
-                            "Object.Behavior::PropertyThumbOffset() - Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
-                            "<=",
-                            "Object.Behavior::PropertyThumbOffset() + Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
-                            ">=",
-                            "- Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Egal"
-                          },
-                          "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
-                            "<=",
-                            "Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "Object.Behavior::PropertyHaloRadius()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Shrink halo to zero when not hovered",
+                      "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
                       "comment2": ""
                     },
                     {
@@ -807,7 +527,7 @@
                         {
                           "type": {
                             "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
                           },
                           "parameters": [
                             "Object",
@@ -816,22 +536,329 @@
                           "subInstructions": []
                         }
                       ],
-                      "actions": [
+                      "actions": [],
+                      "events": [
                         {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
                           },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "min(Object.Behavior::PropertyThumbHeight(), Object.Behavior::PropertyThumbWidth()) / 2"
+                          "comment": "Detect mouse clicks near track, start dragging",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "SourisBouton"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "BuiltinCommonInstructions::Once"
+                              },
+                              "parameters": [],
+                              "subInstructions": []
+                            }
                           ],
-                          "subInstructions": []
+                          "actions": [],
+                          "events": [
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "Object.Behavior::PropertyMouseX()",
+                                    ">=",
+                                    "-Object.Behavior::PropertyHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "Object.Behavior::PropertyMouseX()",
+                                    "<=",
+                                    "Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "Object.Behavior::PropertyMouseY()",
+                                    ">=",
+                                    "-Object.Behavior::PropertyHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "Object.Behavior::PropertyMouseY()",
+                                    "<=",
+                                    "Object.Behavior::PropertyHaloRadius()"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "yes"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "yes"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            }
+                          ]
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Reset hover detection ",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "no"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Grow halo when hovered",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "SourisBouton"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "Object.Behavior::PropertyMouseX()",
+                                ">=",
+                                "Object.Behavior::PropertyThumbOffset() - Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "Object.Behavior::PropertyMouseX()",
+                                "<=",
+                                "Object.Behavior::PropertyThumbOffset() + Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "Object.Behavior::PropertyMouseY()",
+                                ">=",
+                                "- Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "Object.Behavior::PropertyMouseY()",
+                                "<=",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "yes"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "Object.Behavior::PropertyHaloRadius()"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Shrink halo to zero when not hovered",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "min(Object.Behavior::PropertyThumbHeight(), Object.Behavior::PropertyThumbWidth()) / 2"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
@@ -840,18 +867,6 @@
                   "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ],
-                      "subInstructions": []
-                    },
                     {
                       "type": {
                         "inverted": false,
@@ -1028,57 +1043,6 @@
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "LayerVisible"
-                      },
-                      "parameters": [
-                        "",
-                        "Object.Layer()"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
                 {
                   "disabled": false,
                   "folded": false,
@@ -1591,12 +1555,13 @@
                             {
                               "type": {
                                 "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::IsEnabled"
+                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyCurrentHaloRadius"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior",
-                                ""
+                                ">",
+                                "min(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight())"
                               ],
                               "subInstructions": []
                             }
@@ -2114,7 +2079,18 @@
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Enable\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
               "actions": [
                 {
                   "type": {
@@ -2129,7 +2105,93 @@
                   "subInstructions": []
                 }
               ],
-              "events": []
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Stop dragging (so the slider won't be dragging when it gets enabled)",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsBeingDragged"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__DraggableSliderBehavior.SlideInProgress",
+                        "=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Reset halo size (so halo won't appear when slider gets enabled)",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTargetHaloRadius"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "min(Object.Behavior::PropertyThumbHeight(), Object.Behavior::PropertyThumbWidth()) / 2"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
             },
             {
               "disabled": false,

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -8,7 +8,7 @@
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "tags": [
     "draggable",
     "slider",
@@ -141,6 +141,43 @@
                     "Behavior",
                     "=",
                     "Object.Behavior::PropertyTrackThickness()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Start halo at same size as thumb",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "min(Object.Behavior::PropertyThumbHeight()/2,Object.Behavior::PropertyThumbWidth()/2)"
                   ],
                   "subInstructions": []
                 }
@@ -834,7 +871,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),0,Object.Behavior::PropertyHaloGrowSpeed())"
+                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),min(Object.Behavior::PropertyThumbHeight()/2,Object.Behavior::PropertyThumbWidth()/2),Object.Behavior::PropertyHaloGrowSpeed())"
                           ],
                           "subInstructions": []
                         }
@@ -1474,11 +1511,58 @@
                       "colorR": 74,
                       "creationTime": 0,
                       "disabled": false,
-                      "folded": true,
+                      "folded": false,
                       "name": "Halo",
                       "source": "",
                       "type": "BuiltinCommonInstructions::Group",
                       "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Prepare halo",
+                          "comment2": ""
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::FillColor"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Object.Behavior::PropertyThumbColor()"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "PrimitiveDrawing::OutlineOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "0"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
                         {
                           "disabled": false,
                           "folded": false,
@@ -1521,18 +1605,6 @@
                                 "Object",
                                 "=",
                                 "Object.Behavior::PropertyHaloOpacityHover()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
                               ],
                               "subInstructions": []
                             },
@@ -1600,18 +1672,6 @@
                             {
                               "type": {
                                 "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
                                 "value": "PrimitiveDrawing::Circle"
                               },
                               "parameters": [
@@ -1634,7 +1694,7 @@
                       "colorR": 74,
                       "creationTime": 0,
                       "disabled": false,
-                      "folded": true,
+                      "folded": false,
                       "name": "Thumb",
                       "source": "",
                       "type": "BuiltinCommonInstructions::Group",

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -1139,18 +1139,6 @@
                         "Object"
                       ],
                       "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DebuggerTools::ConsoleLog"
-                      },
-                      "parameters": [
-                        "\"Redraw\"",
-                        "",
-                        ""
-                      ],
-                      "subInstructions": []
                     }
                   ],
                   "events": [

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -1,17 +1,18 @@
 {
   "author": "Tristan Rhodes (https://victrisgames.itch.io/), D8H",
-  "description": "This extension provides a behavior that draws a slider that can be dragged by the users. The value range and the tick spacing can be defined with properties.\nNote that this behavior can only be attached to a **Shape Painter** object.\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
+  "description": "This extension provides a behavior that draws a horizontal or vertical slider that can be dragged by the users. The value range and the tick spacing can be defined with properties.\n\nNote that this behavior can only be attached to a **Shape Painter** object.\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
   "extensionNamespace": "",
-  "fullName": "Draggable slider",
-  "helpPath": "",
+  "fullName": "Draggable Slider Control",
+  "helpPath": "https://victrisgames.itch.io/draggable-slider-control-extension",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSI3IiByPSIzIi8+DQo8bGluZSBjbGFzcz0ic3QwIiB4MT0iMyIgeTE9IjciIHgyPSIyMCIgeTI9IjciLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjciIHgyPSIyNiIgeTI9IjciLz4NCjxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjEyIiBjeT0iMTYiIHI9IjMiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIzIiB5MT0iMTYiIHgyPSI5IiB5Mj0iMTYiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjE2IiB4Mj0iMTUiIHkyPSIxNiIvPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSIyNSIgcj0iMyIvPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjMiIHkxPSIyNSIgeDI9IjIwIiB5Mj0iMjUiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjI1IiB4Mj0iMjYiIHkyPSIyNSIvPg0KPC9zdmc+DQo=",
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
-  "shortDescription": "A draggable slider that lets users to choose a numerical value.",
-  "version": "0.6.0",
+  "shortDescription": "A horizontal or vertical slider that can be dragged by the users. ",
+  "version": "0.7.0",
   "tags": [
     "draggable",
     "slider",
+    "control",
     "shape painter",
     "ui",
     "widget"
@@ -24,16 +25,1620 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Let users choose a numerical value. ",
-      "fullName": "Draggable slider",
-      "name": "DraggableSliderControl",
+      "description": "Draw a vertical slider that can be dragged by the users. \n\nThe value range and the tick spacing can be defined with properties.",
+      "fullName": "Draggable Slider Control (vertical)",
+      "name": "DraggableSliderControlVertical",
       "objectType": "PrimitiveDrawing::Drawer",
       "eventsFunctions": [
         {
           "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
+          "name": "doStepPreEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Slider logic",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Move slider when being dragged",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOffset"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Y()-MouseY(Object.Layer())"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "End sliding and update variables",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseButtonReleased"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__DraggableSliderBehavior.SlideInProgress",
+                            "False"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Update \"Value\" based on the location of the thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__DraggableSliderBehavior.SlideInProgress",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "LayerVisible"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Object.Layer()"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Visible"
+                      },
+                      "parameters": [
+                        "Object"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Detect mouse clicks near track, start dragging",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisBouton"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.X() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.X() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.Y() - Object.Behavior::PropertyTrackWidth() - Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.Y() + Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__DraggableSliderBehavior.SlideInProgress",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Detect when the mouse is hovering over thumb ",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisX"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            ">=",
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SourisY"
+                          },
+                          "parameters": [
+                            "",
+                            "<=",
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyWasHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Slider drawing",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyNeedRedraw"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                      },
+                      "parameters": [
+                        "Object"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set default ThumbShape",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "\"Rectangle\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "\"Circle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "\"Circle\"",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Use a more opaque halo while being dragged",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyHaloOpacityClick()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "-Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set inactive track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0;0;0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0;0;0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyInactiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyInactiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyInactiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "-Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "180",
+                            "360",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw inactive track",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "-Object.Behavior::PropertyTrackWidth()",
+                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())",
+                            "-Object.Behavior::PropertyThumbOffset()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set active track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0;0;0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0;0;0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyActiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyActiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "0",
+                            "180",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw active track (2 pixels bigger than property) ",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "-1",
+                            "-Object.Behavior::PropertyThumbOffset()",
+                            "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())+1",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Prepare thumb settings",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyThumbOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Circle thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Circle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackHeight() / 2",
+                            "-Object.Behavior::PropertyThumbOffset()",
+                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Rectangle thumb",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Rectangle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "-Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "-Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw hover",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyHaloOpacityHover()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "-Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the slider is being dragged.",
+          "fullName": "Is being dragged",
+          "functionType": "Condition",
+          "name": "IsBeingDragged",
+          "private": false,
+          "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
           "name": "onCreated",
           "private": false,
           "sentence": "",
@@ -69,17 +1674,661 @@
                     "no"
                   ],
                   "subInstructions": []
-                },
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "Object.Behavior::PropertyValueMin()"
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change height of track.",
+          "fullName": "Track height",
+          "functionType": "Action",
+          "name": "SetTrackHeight",
+          "private": false,
+          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Track height",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change height of thumb.",
+          "fullName": "Thumb height",
+          "functionType": "Action",
+          "name": "SetThumbHeight",
+          "private": false,
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb height",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of thumb.",
+          "fullName": "Thumb opacity",
+          "functionType": "Action",
+          "name": "SetThumbOpacity",
+          "private": false,
+          "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of inactive track.",
+          "fullName": "Inactive track opacity",
+          "functionType": "Action",
+          "name": "SetInactiveTrackOpacity",
+          "private": false,
+          "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Inactive track opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of active track.",
+          "fullName": "Active track opacity",
+          "functionType": "Action",
+          "name": "SetActiveTrackOpacity",
+          "private": false,
+          "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Active track opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change width of track.",
+          "fullName": "Track width",
+          "functionType": "Action",
+          "name": "SetTrackWidth",
+          "private": false,
+          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Track width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change width of thumb.",
+          "fullName": "Thumb width",
+          "functionType": "Action",
+          "name": "SetThumbWidth",
+          "private": false,
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
                   ],
                   "subInstructions": []
                 }
@@ -169,17 +2418,1121 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
               "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
             }
           ],
           "objectGroups": []
         },
         {
+          "description": "Change shape of thumb (circle or rectangle).",
+          "fullName": "Thumb shape",
+          "functionType": "Action",
+          "name": "SetThumbShape",
+          "private": false,
+          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"Shape\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "New thumb shape",
+              "longDescription": "",
+              "name": "Shape",
+              "optional": false,
+              "supplementaryInformation": "[\"Circle\",\"Rectangle\"]",
+              "type": "stringWithSelector"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the radius of halo.",
+          "fullName": "Halo Radius",
+          "functionType": "Action",
+          "name": "SetHaloRadius",
+          "private": false,
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo radius",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the color of the track that is LEFT of the thumb.",
+          "fullName": "Active track color ",
+          "functionType": "Action",
+          "name": "SetActiveTrackColor",
+          "private": false,
+          "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Active track color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the color of the track that is RIGHT of the thumb.",
+          "fullName": "Inactive track color",
+          "functionType": "Action",
+          "name": "SetInactiveTrackColor",
+          "private": false,
+          "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Inactive track color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make track use rounded ends.",
+          "fullName": "Rounded track ends",
+          "functionType": "Action",
+          "name": "SetRoundedTrack",
+          "private": false,
+          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "1"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Ronded track",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the thumb color to a specific value.",
+          "fullName": "Thumb color",
+          "functionType": "Action",
+          "name": "SetThumbColor",
+          "private": false,
+          "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the value of a slider to a specific value (this will move the thumb to the correct position).",
+          "fullName": "Slider value",
+          "functionType": "Action",
+          "name": "SetValue",
+          "private": false,
+          "sentence": "Set value of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "round(GetArgumentAsNumber(\"Value\") / Object.Behavior::PropertyTickSpacing()) * Object.Behavior::PropertyTickSpacing()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "Object.Behavior::PropertyValueMax()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyValueMax()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Set the proper offset (this is move the slider)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOffset"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Slider value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "The value of the slider (based on position of the thumb).",
+          "fullName": "Slider value",
+          "functionType": "Expression",
+          "name": "Value",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyValue()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Minimum value",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ValueMin"
+        },
+        {
+          "value": "1",
+          "type": "Number",
+          "label": "Maximum value",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ValueMax"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Tick spacing",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "TickSpacing"
+        },
+        {
+          "value": "circle",
+          "type": "Choice",
+          "label": "Thumb shape",
+          "description": "",
+          "extraInformation": [
+            "Circle",
+            "Rectangle"
+          ],
+          "hidden": false,
+          "name": "ThumbShape"
+        },
+        {
+          "value": "20",
+          "type": "Number",
+          "label": "Thumb width",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ThumbWidth"
+        },
+        {
+          "value": "20",
+          "type": "Number",
+          "label": "Thumb height",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ThumbHeight"
+        },
+        {
+          "value": "24;119;211",
+          "type": "Color",
+          "label": "Thumb Color",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ThumbColor"
+        },
+        {
+          "value": "255",
+          "type": "Number",
+          "label": "Thumb opacity",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ThumbOpacity"
+        },
+        {
+          "value": "200",
+          "type": "Number",
+          "label": "Track width",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "TrackWidth"
+        },
+        {
+          "value": "4",
+          "type": "Number",
+          "label": "Track height",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "TrackHeight"
+        },
+        {
+          "value": "",
+          "type": "Color",
+          "label": "Inactive track color (thumb color by default)",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "InactiveTrackColor"
+        },
+        {
+          "value": "96",
+          "type": "Number",
+          "label": "Inactive track opacity",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "InactiveTrackOpacity"
+        },
+        {
+          "value": " ",
+          "type": "Color",
+          "label": "Active track color (thumb color by default)",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ActiveTrackColor"
+        },
+        {
+          "value": "255",
+          "type": "Number",
+          "label": "Active track opacity",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ActiveTrackOpacity"
+        },
+        {
+          "value": "24",
+          "type": "Number",
+          "label": "Hover halo size",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HaloRadius"
+        },
+        {
+          "value": "32",
+          "type": "Number",
+          "label": "Hover halo opacity",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HaloOpacityHover"
+        },
+        {
+          "value": "64",
+          "type": "Number",
+          "label": "Pressed halo opacity",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HaloOpacityClick"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Rounded track ends",
+          "description": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "RoundedTrack"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Is being dragged",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsBeingDragged"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Value",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Value"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Thumb offset (thumb position on the track)",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ThumbOffset"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Need redraw",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "NeedRedraw"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Is hovered",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsHovered"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Was Hovered",
+          "description": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "WasHovered"
+        }
+      ]
+    },
+    {
+      "description": "Draw a horizontal slider that can be dragged by the users. \n\nThe value range and the tick spacing can be defined with properties.",
+      "fullName": "Draggable Slider Control (horizontal)",
+      "name": "DraggableSliderControl",
+      "objectType": "PrimitiveDrawing::Drawer",
+      "eventsFunctions": [
+        {
           "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "doStepPreEvents",
           "private": false,
           "sentence": "",
@@ -195,41 +3548,6 @@
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseX"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.ToDrawingX(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseY"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.ToDrawingY(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
                 {
                   "disabled": false,
                   "folded": false,
@@ -272,7 +3590,7 @@
                         "Object",
                         "Behavior",
                         "=",
-                        "Object.Behavior::PropertyMouseX()"
+                        "MouseX(Object.Layer())-Object.X()"
                       ],
                       "subInstructions": []
                     },
@@ -338,12 +3656,11 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "ModVarScene"
+                            "value": "SetSceneVariableAsBoolean"
                           },
                           "parameters": [
                             "__DraggableSliderBehavior.SlideInProgress",
-                            "=",
-                            "0"
+                            "False"
                           ],
                           "subInstructions": []
                         }
@@ -423,12 +3740,11 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "VarScene"
+                        "value": "SceneVariableAsBoolean"
                       },
                       "parameters": [
                         "__DraggableSliderBehavior.SlideInProgress",
-                        "=",
-                        "0"
+                        "False"
                       ],
                       "subInstructions": []
                     },
@@ -490,48 +3806,56 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisX"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
+                            "",
                             ">=",
-                            "-Object.Behavior::PropertyThumbWidth() / 2"
+                            "Object.X() - Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisX"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
+                            "",
                             "<=",
-                            "Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2"
+                            "Object.X() + Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyThumbWidth() / 2",
+                            "Object.Layer()",
+                            "0"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisY"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
+                            "",
                             ">=",
-                            "- (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2"
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisY"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
+                            "",
                             "<=",
-                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            "0"
                           ],
                           "subInstructions": []
                         }
@@ -552,12 +3876,11 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "ModVarScene"
+                            "value": "SetSceneVariableAsBoolean"
                           },
                           "parameters": [
                             "__DraggableSliderBehavior.SlideInProgress",
-                            "=",
-                            "1"
+                            "True"
                           ],
                           "subInstructions": []
                         },
@@ -686,48 +4009,56 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisX"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
+                            "",
                             ">=",
-                            "Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisX"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseX()",
+                            "",
                             "<=",
-                            "Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
+                            "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
+                            "Object.Layer()",
+                            ""
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisY"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
+                            "",
                             ">=",
-                            "- (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2"
+                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Egal"
+                            "value": "SourisY"
                           },
                           "parameters": [
-                            "Object.Behavior::PropertyMouseY()",
+                            "",
                             "<=",
-                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
+                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Layer()",
+                            ""
                           ],
                           "subInstructions": []
                         }
@@ -870,7 +4201,6 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "doStepPostEvents",
           "private": false,
           "sentence": "",
@@ -928,6 +4258,70 @@
                     }
                   ],
                   "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set default ThumbShape",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "\"Rectangle\""
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "\"Circle\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetThumbShape"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "\"Circle\"",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
                     {
                       "disabled": false,
                       "folded": false,
@@ -1030,7 +4424,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"\""
+                            "\"0;0;0\""
                           ],
                           "subInstructions": []
                         }
@@ -1064,7 +4458,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"\""
+                            "\"0;0;0\""
                           ],
                           "subInstructions": []
                         }
@@ -1198,7 +4592,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "0",
+                            "Object.Behavior::PropertyThumbOffset()",
                             "0",
                             "Object.Behavior::PropertyTrackWidth()",
                             "min(Object.Behavior::PropertyTrackHeight(),Object.Behavior::PropertyThumbHeight())"
@@ -1237,7 +4631,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"\""
+                            "\"0;0;0\""
                           ],
                           "subInstructions": []
                         }
@@ -1271,7 +4665,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"\""
+                            "\"0;0;0\""
                           ],
                           "subInstructions": []
                         }
@@ -1479,7 +4873,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"circle\""
+                            "\"Circle\""
                           ],
                           "subInstructions": []
                         }
@@ -1530,7 +4924,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "\"rectangle\""
+                            "\"Rectangle\""
                           ],
                           "subInstructions": []
                         }
@@ -1645,7 +5039,6 @@
           "description": "Check if the slider is being dragged.",
           "fullName": "Is being dragged",
           "functionType": "Condition",
-          "group": "",
           "name": "IsBeingDragged",
           "private": false,
           "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
@@ -1707,14 +5100,28 @@
           "objectGroups": []
         },
         {
-          "description": "The value of the slider (based on position of the thumb).",
-          "fullName": "Slider value",
-          "functionType": "Expression",
-          "group": "Slider",
-          "name": "Value",
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onCreated",
           "private": false,
           "sentence": "",
           "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure object doesn't get re-drawn every frame",
+              "comment2": ""
+            },
             {
               "disabled": false,
               "folded": false,
@@ -1724,10 +5131,75 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SetReturnNumber"
+                    "value": "PrimitiveDrawing::ClearBetweenFrames"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyValue()"
+                    "Object",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
                   ],
                   "subInstructions": []
                 }
@@ -1760,13 +5232,1257 @@
           "objectGroups": []
         },
         {
-          "description": "Change the value of a slider (this will move the thumb to the correct position).",
+          "description": "Change height of track.",
+          "fullName": "Track height",
+          "functionType": "Action",
+          "name": "SetTrackHeight",
+          "private": false,
+          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Track height",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change height of thumb.",
+          "fullName": "Thumb height",
+          "functionType": "Action",
+          "name": "SetThumbHeight",
+          "private": false,
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbHeight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb height",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of thumb.",
+          "fullName": "Thumb opacity",
+          "functionType": "Action",
+          "name": "SetThumbOpacity",
+          "private": false,
+          "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of inactive track.",
+          "fullName": "Inactive track opacity",
+          "functionType": "Action",
+          "name": "SetInactiveTrackOpacity",
+          "private": false,
+          "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Inactive track opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change opacity of active track.",
+          "fullName": "Active track opacity",
+          "functionType": "Action",
+          "name": "SetActiveTrackOpacity",
+          "private": false,
+          "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Active track opacity",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change width of track.",
+          "fullName": "Track width",
+          "functionType": "Action",
+          "name": "SetTrackWidth",
+          "private": false,
+          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Track width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change width of thumb.",
+          "fullName": "Thumb width",
+          "functionType": "Action",
+          "name": "SetThumbWidth",
+          "private": false,
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb width",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change shape of thumb (circle or rectangle).",
+          "fullName": "Thumb shape",
+          "functionType": "Action",
+          "name": "SetThumbShape",
+          "private": false,
+          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"Shape\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Rectangle\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyTrackHeight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "New thumb shape",
+              "longDescription": "",
+              "name": "Shape",
+              "optional": false,
+              "supplementaryInformation": "[\"Circle\",\"Rectangle\"]",
+              "type": "stringWithSelector"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the radius of halo.",
+          "fullName": "Halo Radius",
+          "functionType": "Action",
+          "name": "SetHaloRadius",
+          "private": false,
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Halo radius",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the color of the track that is LEFT of the thumb.",
+          "fullName": "Active track color ",
+          "functionType": "Action",
+          "name": "SetActiveTrackColor",
+          "private": false,
+          "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Active track color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the color of the track that is RIGHT of the thumb.",
+          "fullName": "Inactive track color",
+          "functionType": "Action",
+          "name": "SetInactiveTrackColor",
+          "private": false,
+          "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Inactive track color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make track use rounded ends.",
+          "fullName": "Rounded track ends",
+          "functionType": "Action",
+          "name": "SetRoundedTrack",
+          "private": false,
+          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"Value\")",
+                    "=",
+                    "1"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Ronded track",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the thumb color to a specific value.",
+          "fullName": "Thumb color",
+          "functionType": "Action",
+          "name": "SetThumbColor",
+          "private": false,
+          "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "GetArgumentAsString(\"Color\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Thumb color",
+              "longDescription": "",
+              "name": "Color",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the value of a slider to a specific value (this will move the thumb to the correct position).",
           "fullName": "Slider value",
           "functionType": "Action",
-          "group": "Slider",
           "name": "SetValue",
           "private": false,
-          "sentence": "Change the value of _PARAM0_: _PARAM2_",
+          "sentence": "Set value of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1924,7 +6640,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Set the proper offset (it moves the slider)",
+              "comment": "Set the proper offset (this is move the slider)",
               "comment2": ""
             },
             {
@@ -1997,13 +6713,12 @@
           "objectGroups": []
         },
         {
-          "description": "The minimum value of a slider.",
-          "fullName": "Slider minimum value",
+          "description": "The value of the slider (based on position of the thumb).",
+          "fullName": "Slider value",
           "functionType": "Expression",
-          "group": "Slider value configuration",
-          "name": "ValueMin",
+          "name": "Value",
           "private": false,
-          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
+          "sentence": "",
           "events": [
             {
               "disabled": false,
@@ -2017,7 +6732,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyValueMin()"
+                    "Object.Behavior::PropertyValue()"
                   ],
                   "subInstructions": []
                 }
@@ -2045,1620 +6760,6 @@
               "optional": false,
               "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
               "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the maximum value of a slider.",
-          "fullName": "Slider maximum value",
-          "functionType": "Action",
-          "group": "Slider value configuration",
-          "name": "SetValueMin",
-          "private": false,
-          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValueMin"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"ValueMin\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::Value()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Minimum value",
-              "longDescription": "",
-              "name": "ValueMin",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "The maximum value of a slider.",
-          "fullName": "Slider maximum value",
-          "functionType": "Expression",
-          "group": "Slider value configuration",
-          "name": "ValueMax",
-          "private": false,
-          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnNumber"
-                  },
-                  "parameters": [
-                    "Object.Behavior::PropertyValueMax()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the minimum value of a slider.",
-          "fullName": "Slider minimum value",
-          "functionType": "Action",
-          "group": "Slider value configuration",
-          "name": "SetValueMax",
-          "private": false,
-          "sentence": "Change the minimum value of _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValueMax"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"ValueMax\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::Value()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Maximum value",
-              "longDescription": "",
-              "name": "ValueMax",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "The tick spacing of a slider.",
-          "fullName": "Tick spacing",
-          "functionType": "Expression",
-          "group": "Slider value configuration",
-          "name": "TickSpacing",
-          "private": false,
-          "sentence": "Change the tick spacing of _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnNumber"
-                  },
-                  "parameters": [
-                    "Object.Behavior::PropertyTickSpacing()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Tick spacing",
-              "longDescription": "",
-              "name": "TickSpacing",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the tick spacing of a slider.",
-          "fullName": "Tick spacing",
-          "functionType": "Action",
-          "group": "Slider value configuration",
-          "name": "SetTickSpacing",
-          "private": false,
-          "sentence": "Change the tick spacing of _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTickSpacing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"TickSpacing\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::Value()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Tick spacing",
-              "longDescription": "",
-              "name": "TickSpacing",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change height of track.",
-          "fullName": "Track height",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetTrackHeight",
-          "private": false,
-          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackHeight()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Track height",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change height of thumb.",
-          "fullName": "Thumb height",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbHeight",
-          "private": false,
-          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbHeight"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb height",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of thumb.",
-          "fullName": "Thumb opacity",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbOpacity",
-          "private": false,
-          "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of inactive track.",
-          "fullName": "Inactive track opacity",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetInactiveTrackOpacity",
-          "private": false,
-          "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Inactive track opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of active track.",
-          "fullName": "Active track opacity",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetActiveTrackOpacity",
-          "private": false,
-          "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Active track opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change width of track.",
-          "fullName": "Track width",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetTrackWidth",
-          "private": false,
-          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Track width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change width of thumb.",
-          "fullName": "Thumb width",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbWidth",
-          "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackHeight()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change shape of thumb (circle or rectangle).",
-          "fullName": "Thumb shape",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbShape",
-          "private": false,
-          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Shape\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackHeight()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackHeight()",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "New thumb shape",
-              "longDescription": "",
-              "name": "Shape",
-              "optional": false,
-              "supplementaryInformation": "[\"circle\",\"rectangle\"]",
-              "type": "stringWithSelector"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetHaloRadius",
-          "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloRadius"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo radius",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the color of the track that is LEFT of the thumb.",
-          "fullName": "Active track color ",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetActiveTrackColor",
-          "private": false,
-          "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyActiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Active track color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the color of the track that is RIGHT of the thumb.",
-          "fullName": "Inactive track color",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetInactiveTrackColor",
-          "private": false,
-          "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyInactiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Inactive track color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Make track use rounded ends.",
-          "fullName": "Rounded track ends",
-          "functionType": "Action",
-          "group": "Slider track configuration",
-          "name": "SetRoundedTrack",
-          "private": false,
-          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "no"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "1"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyRoundedTrack"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Rounded track",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "yesorno"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the thumb color to a specific value.",
-          "fullName": "Thumb color",
-          "functionType": "Action",
-          "group": "Slider thumb configuration",
-          "name": "SetThumbColor",
-          "private": false,
-          "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
             }
           ],
           "objectGroups": []
@@ -3670,7 +6771,6 @@
           "type": "Number",
           "label": "Minimum value",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "ValueMin"
@@ -3680,7 +6780,6 @@
           "type": "Number",
           "label": "Maximum value",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "ValueMax"
@@ -3690,18 +6789,19 @@
           "type": "Number",
           "label": "Tick spacing",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "TickSpacing"
         },
         {
           "value": "circle",
-          "type": "String",
-          "label": "Thumb shape (\"circle\" or \"rectangle\")",
+          "type": "Choice",
+          "label": "Thumb shape",
           "description": "",
-          "group": "Thumb",
-          "extraInformation": [],
+          "extraInformation": [
+            "Circle",
+            "Rectangle"
+          ],
           "hidden": false,
           "name": "ThumbShape"
         },
@@ -3710,7 +6810,6 @@
           "type": "Number",
           "label": "Thumb width",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbWidth"
@@ -3720,17 +6819,15 @@
           "type": "Number",
           "label": "Thumb height",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbHeight"
         },
         {
-          "value": " 24;119;211",
+          "value": "24;119;211",
           "type": "Color",
           "label": "Thumb Color",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbColor"
@@ -3740,7 +6837,6 @@
           "type": "Number",
           "label": "Thumb opacity",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbOpacity"
@@ -3748,9 +6844,8 @@
         {
           "value": "200",
           "type": "Number",
-          "label": "Track length",
+          "label": "Track width",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "TrackWidth"
@@ -3758,9 +6853,8 @@
         {
           "value": "4",
           "type": "Number",
-          "label": "Track thickness",
+          "label": "Track height",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "TrackHeight"
@@ -3770,7 +6864,6 @@
           "type": "Color",
           "label": "Inactive track color (thumb color by default)",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "InactiveTrackColor"
@@ -3780,7 +6873,6 @@
           "type": "Number",
           "label": "Inactive track opacity",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "InactiveTrackOpacity"
@@ -3790,7 +6882,6 @@
           "type": "Color",
           "label": "Active track color (thumb color by default)",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "ActiveTrackColor"
@@ -3800,7 +6891,6 @@
           "type": "Number",
           "label": "Active track opacity",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "ActiveTrackOpacity"
@@ -3810,7 +6900,6 @@
           "type": "Number",
           "label": "Hover halo size",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloRadius"
@@ -3820,7 +6909,6 @@
           "type": "Number",
           "label": "Hover halo opacity",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloOpacityHover"
@@ -3830,7 +6918,6 @@
           "type": "Number",
           "label": "Pressed halo opacity",
           "description": "",
-          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloOpacityClick"
@@ -3840,7 +6927,6 @@
           "type": "Boolean",
           "label": "Rounded track ends",
           "description": "",
-          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "RoundedTrack"
@@ -3848,9 +6934,8 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "",
+          "label": "Is being dragged",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "IsBeingDragged"
@@ -3858,9 +6943,8 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "",
+          "label": "Value",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Value"
@@ -3868,9 +6952,8 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "",
+          "label": "Thumb offset (thumb position on the track)",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "ThumbOffset"
@@ -3878,9 +6961,8 @@
         {
           "value": "true",
           "type": "Boolean",
-          "label": "",
+          "label": "Need redraw",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "NeedRedraw"
@@ -3888,9 +6970,8 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "",
+          "label": "Is hovered",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "IsHovered"
@@ -3898,32 +6979,11 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "",
+          "label": "Was Hovered",
           "description": "",
-          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "WasHovered"
-        },
-        {
-          "value": "",
-          "type": "Number",
-          "label": "",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "MouseX"
-        },
-        {
-          "value": "",
-          "type": "Number",
-          "label": "",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "MouseY"
         }
       ]
     }

--- a/Extensions/DraggableSliderControl.json
+++ b/Extensions/DraggableSliderControl.json
@@ -1,18 +1,17 @@
 {
   "author": "Tristan Rhodes (https://victrisgames.itch.io/), D8H",
-  "description": "This extension provides a behavior that draws a horizontal or vertical slider that can be dragged by the users. The value range and the tick spacing can be defined with properties.\n\nNote that this behavior can only be attached to a **Shape Painter** object.\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
+  "description": "Draws a draggable slider that users can move to select a numerical value.\nThe value range, tick spacing, and the appearance of the slider can be defined with properties.\n\nHow to use:\n- Add this behavior a **Shape Painter** object\n- Place an instance of that shape painter on the screen where you want the slider to appear\n- Use the \"Value\" expression to find the Value based on the position of the slider\n\nTips:\n- You can disable the slider to prevent a user from interacting with it\n- You can set the Value of the slider and the slider will move to the correct position\n\nFurther details can be found in [this tutorial video](https://youtu.be/iiTUwdAT_hs).\n",
   "extensionNamespace": "",
-  "fullName": "Draggable Slider Control",
-  "helpPath": "https://victrisgames.itch.io/draggable-slider-control-extension",
+  "fullName": "Draggable slider",
+  "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSI3IiByPSIzIi8+DQo8bGluZSBjbGFzcz0ic3QwIiB4MT0iMyIgeTE9IjciIHgyPSIyMCIgeTI9IjciLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjciIHgyPSIyNiIgeTI9IjciLz4NCjxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjEyIiBjeT0iMTYiIHI9IjMiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIzIiB5MT0iMTYiIHgyPSI5IiB5Mj0iMTYiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjE2IiB4Mj0iMTUiIHkyPSIxNiIvPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjMiIGN5PSIyNSIgcj0iMyIvPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjMiIHkxPSIyNSIgeDI9IjIwIiB5Mj0iMjUiLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSIyOSIgeTE9IjI1IiB4Mj0iMjYiIHkyPSIyNSIvPg0KPC9zdmc+DQo=",
   "name": "DraggableSliderControl",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_sliders_options.svg",
-  "shortDescription": "A horizontal or vertical slider that can be dragged by the users. ",
-  "version": "0.7.5",
+  "shortDescription": "A draggable slider that users can move to select a numerical value.",
+  "version": "0.7.0",
   "tags": [
     "draggable",
     "slider",
-    "control",
     "shape painter",
     "ui",
     "widget"
@@ -25,1690 +24,16 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Draw a vertical slider that can be dragged by the users. \n\nThe value range and the tick spacing can be defined with properties.",
-      "fullName": "Draggable Slider Control (vertical)",
-      "name": "DraggableSliderControlVertical",
+      "description": "A draggable slider that users can move to select a numerical value.",
+      "fullName": "Draggable slider",
+      "name": "DraggableSliderControl",
       "objectType": "PrimitiveDrawing::Drawer",
       "eventsFunctions": [
         {
           "description": "",
           "fullName": "",
           "functionType": "Action",
-          "name": "doStepPreEvents",
-          "private": false,
-          "sentence": "",
-          "events": [
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Slider logic",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Move slider when being dragged",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOffset"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.Y()-MouseY(Object.Layer())"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "End sliding and update variables",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseButtonReleased"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsBeingDragged"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__DraggableSliderBehavior.SlideInProgress",
-                            "False"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Update \"Value\" based on the location of the thumb",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetValue"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Detect hover/touch/click (but only if the layer and object is visible, and the object is not already being dragged)",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__DraggableSliderBehavior.SlideInProgress",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "LayerVisible"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Object.Layer()"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Detect mouse clicks near track, start dragging.  A scene variable is used so that only one slider can be dragged at once.",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisBouton"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            ">=",
-                            "Object.X() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            "<=",
-                            "Object.X() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisY"
-                          },
-                          "parameters": [
-                            "",
-                            ">=",
-                            "Object.Y() - Object.Behavior::PropertyTrackLength() - Object.Behavior::PropertyThumbWidth() / 2",
-                            "Object.Layer()",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisY"
-                          },
-                          "parameters": [
-                            "",
-                            "<=",
-                            "Object.Y() + Object.Behavior::PropertyThumbWidth() / 2",
-                            "Object.Layer()",
-                            "0"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsBeingDragged"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__DraggableSliderBehavior.SlideInProgress",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Detect when the mouse is hovering over thumb ",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            ">=",
-                            "Object.X() + Object.Behavior::PropertyTrackThickness() / 2 - max(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisX"
-                          },
-                          "parameters": [
-                            "",
-                            "<=",
-                            "Object.X() + Object.Behavior::PropertyTrackThickness() / 2 + max(Object.Behavior::PropertyThumbWidth(), Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisY"
-                          },
-                          "parameters": [
-                            "",
-                            ">=",
-                            "Object.Y() - Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisY"
-                          },
-                          "parameters": [
-                            "",
-                            "<=",
-                            "Object.Y() - Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "",
-          "fullName": "",
-          "functionType": "Action",
-          "name": "doStepPostEvents",
-          "private": false,
-          "sentence": "",
-          "events": [
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Slider drawing",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyNeedRedraw"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "no"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::Drawer::ClearShapes"
-                      },
-                      "parameters": [
-                        "Object"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Set default ThumbShape",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "!=",
-                            "\"Rectangle\""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "!=",
-                            "\"Circle\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControlVertical::SetThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "\"Circle\"",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Pressed halo",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Use a more opaque halo while being dragged",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityClick()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "-Object.Behavior::PropertyThumbOffset()",
-                                "Object.Behavior::PropertyHaloRadius()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Inactive track",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Set inactive track parameters (by default, use thumb color)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyInactiveTrackColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyInactiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyInactiveTrackOpacity()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw half circle at inactive end (optional)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyRoundedTrack"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Arc"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "-Object.Behavior::PropertyTrackLength()",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "180",
-                                "360",
-                                "",
-                                "yes"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw inactive track",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "0",
-                                "-Object.Behavior::PropertyTrackLength()",
-                                "min(Object.Behavior::PropertyTrackThickness(), Object.Behavior::PropertyThumbHeight())",
-                                "-Object.Behavior::PropertyThumbOffset()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Active track",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Set active track parameters (by default, use thumb color)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyActiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"0;0;0\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyActiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"0;0;0\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyActiveTrackColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyActiveTrackOpacity()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw half circle at active end (optional)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyRoundedTrack"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Arc"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "0",
-                                "1 + Object.Behavior::PropertyTrackThickness() / 2",
-                                "0",
-                                "180",
-                                "",
-                                "yes"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw active track (2 pixels bigger than property) ",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "-1",
-                                "-Object.Behavior::PropertyThumbOffset()",
-                                "min(Object.Behavior::PropertyTrackThickness(), Object.Behavior::PropertyThumbHeight()) + 1",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Hover",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw hover",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsHovered"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityHover()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "-Object.Behavior::PropertyThumbOffset()",
-                                "Object.Behavior::PropertyHaloRadius()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Thumb",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Prepare thumb settings",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyThumbOpacity()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw Circle thumb",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"Circle\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "-Object.Behavior::PropertyThumbOffset()",
-                                "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw Rectangle thumb",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"Rectangle\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
-                                "-Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                                "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
-                                "-Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Check if the slider is being dragged.",
-          "fullName": "Is being dragged",
-          "functionType": "Condition",
-          "name": "IsBeingDragged",
-          "private": false,
-          "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyIsBeingDragged"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "",
-          "fullName": "",
-          "functionType": "Action",
+          "group": "",
           "name": "onCreated",
           "private": false,
           "sentence": "",
@@ -1760,645 +85,25 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
+              "comment": "Use correct min value (instead of always starting at 0)",
               "comment2": ""
             },
             {
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"Rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change thickness of track.",
-          "fullName": "Track thickness",
-          "functionType": "Action",
-          "name": "SetTrackThickness",
-          "private": false,
-          "sentence": "Change track thickness of _PARAM0_ to _PARAM2_ px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyTrackThickness"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track thickness (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"Rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Track height",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change height of thumb.",
-          "fullName": "Thumb height",
-          "functionType": "Action",
-          "name": "SetThumbHeight",
-          "private": false,
-          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_ px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbHeight"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb height",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of thumb.",
-          "fullName": "Thumb opacity",
-          "functionType": "Action",
-          "name": "SetThumbOpacity",
-          "private": false,
-          "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of inactive track.",
-          "fullName": "Inactive track opacity",
-          "functionType": "Action",
-          "name": "SetInactiveTrackOpacity",
-          "private": false,
-          "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyInactiveTrackOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Inactive track opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change opacity of active track.",
-          "fullName": "Active track opacity",
-          "functionType": "Action",
-          "name": "SetActiveTrackOpacity",
-          "private": false,
-          "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyActiveTrackOpacity"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Active track opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change length of track.",
-          "fullName": "Track length",
-          "functionType": "Action",
-          "name": "SetTrackLength",
-          "private": false,
-          "sentence": "Change track length of _PARAM0_ to _PARAM2_ px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyTrackLength"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Track width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change width of thumb.",
-          "fullName": "Thumb width",
-          "functionType": "Action",
-          "name": "SetThumbWidth",
-          "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_ px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
+                    "Object.Behavior::PropertyValueMin()"
                   ],
                   "subInstructions": []
                 }
@@ -2428,7 +133,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
                   },
                   "parameters": [
                     "Object",
@@ -2441,13 +146,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Object.Behavior::PropertyTrackHeight()"
                   ],
                   "subInstructions": []
                 }
@@ -2456,13 +161,13 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Object.Behavior::PropertyTrackHeight()",
+                    ""
                   ],
                   "subInstructions": []
                 }
@@ -2488,1507 +193,17 @@
               "longDescription": "",
               "name": "Behavior",
               "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb width",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change shape of thumb (circle or rectangle).",
-          "fullName": "Thumb shape",
-          "functionType": "Action",
-          "name": "SetThumbShape",
-          "private": false,
-          "sentence": "Change shape of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsString(\"Shape\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbShape"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"Rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackThickness()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "New thumb shape",
-              "longDescription": "",
-              "name": "Shape",
-              "optional": false,
-              "supplementaryInformation": "[\"Circle\",\"Rectangle\"]",
-              "type": "stringWithSelector"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the opacity of halo when pressed.",
-          "fullName": "Halo opacity when pressed",
-          "functionType": "Action",
-          "name": "SetHaloOpacityClick",
-          "private": false,
-          "sentence": "Change halo opacity when pressed of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloOpacityClick"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo opacity when pressed",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the opacity of halo.",
-          "fullName": "Halo opacity",
-          "functionType": "Action",
-          "name": "SetHaloOpacity",
-          "private": false,
-          "sentence": "Change halo opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloOpacityHover"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the radius of halo.",
-          "fullName": "Halo Radius",
-          "functionType": "Action",
-          "name": "SetHaloRadius",
-          "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_ px",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyHaloRadius"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo radius",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the color of the track that is LEFT of the thumb.",
-          "fullName": "Active track color ",
-          "functionType": "Action",
-          "name": "SetActiveTrackColor",
-          "private": false,
-          "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyActiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Active track color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the color of the track that is RIGHT of the thumb.",
-          "fullName": "Inactive track color",
-          "functionType": "Action",
-          "name": "SetInactiveTrackColor",
-          "private": false,
-          "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyInactiveTrackColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Inactive track color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Make track use rounded ends.",
-          "fullName": "Rounded track ends",
-          "functionType": "Action",
-          "name": "SetRoundedTrack",
-          "private": false,
-          "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "no"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"Value\")",
-                    "=",
-                    "1"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Ronded track",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "yesorno"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the thumb color to a specific value.",
-          "fullName": "Thumb color",
-          "functionType": "Action",
-          "name": "SetThumbColor",
-          "private": false,
-          "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbColor"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "GetArgumentAsString(\"Color\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Thumb color",
-              "longDescription": "",
-              "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "color"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the value of a slider to a specific value (this will move the thumb to the correct position).",
-          "fullName": "Slider value",
-          "functionType": "Action",
-          "name": "SetValue",
-          "private": false,
-          "sentence": "Set value of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyTickSpacing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyTickSpacing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "round(GetArgumentAsNumber(\"Value\") / Object.Behavior::PropertyTickSpacing()) * Object.Behavior::PropertyTickSpacing()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyValueMin()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyValueMin()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "Object.Behavior::PropertyValueMax()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyValueMax()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Set the proper offset (this is move the slider)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyThumbOffset"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackLength() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Slider value",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Check if the slider is disabled.",
-          "fullName": "Is disabled",
-          "functionType": "Condition",
-          "name": "IsDisabled",
-          "private": false,
-          "sentence": "_PARAM0_ is disabled",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::PropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "False"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
               "type": "behavior"
             }
           ],
           "objectGroups": []
         },
-        {
-          "description": "Disable (or enable) the slider.  Users cannot interact with disabled sliders.",
-          "fullName": "Disable (or enable) the slider",
-          "functionType": "Action",
-          "name": "SetDisabled",
-          "private": false,
-          "sentence": "Disable _PARAM0_: _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "GetArgumentAsBoolean"
-                  },
-                  "parameters": [
-                    "\"State\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "no"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "GetArgumentAsBoolean"
-                  },
-                  "parameters": [
-                    "\"State\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControlVertical::SetPropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Disabled",
-              "longDescription": "",
-              "name": "State",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "yesorno"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "The value of the slider (based on position of the thumb).",
-          "fullName": "Slider value",
-          "functionType": "Expression",
-          "name": "Value",
-          "private": false,
-          "sentence": "",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnNumber"
-                  },
-                  "parameters": [
-                    "Object.Behavior::PropertyValue()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControlVertical",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        }
-      ],
-      "propertyDescriptors": [
-        {
-          "value": "0",
-          "type": "Number",
-          "label": "Minimum value (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ValueMin"
-        },
-        {
-          "value": "1",
-          "type": "Number",
-          "label": "Maximum value (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ValueMax"
-        },
-        {
-          "value": "0",
-          "type": "Number",
-          "label": "Tick spacing (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "TickSpacing"
-        },
-        {
-          "value": "circle",
-          "type": "Choice",
-          "label": "Thumb shape (property)",
-          "description": "",
-          "extraInformation": [
-            "Circle",
-            "Rectangle"
-          ],
-          "hidden": false,
-          "name": "ThumbShape"
-        },
-        {
-          "value": "20",
-          "type": "Number",
-          "label": "Thumb width (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ThumbWidth"
-        },
-        {
-          "value": "20",
-          "type": "Number",
-          "label": "Thumb height (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ThumbHeight"
-        },
-        {
-          "value": "24;119;211",
-          "type": "Color",
-          "label": "Thumb Color (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ThumbColor"
-        },
-        {
-          "value": "255",
-          "type": "Number",
-          "label": "Thumb opacity (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ThumbOpacity"
-        },
-        {
-          "value": "200",
-          "type": "Number",
-          "label": "Track length (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "TrackLength"
-        },
-        {
-          "value": "4",
-          "type": "Number",
-          "label": "Track thickness (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "TrackThickness"
-        },
-        {
-          "value": "",
-          "type": "Color",
-          "label": "Inactive track color (thumb color by default) (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "InactiveTrackColor"
-        },
-        {
-          "value": "96",
-          "type": "Number",
-          "label": "Inactive track opacity (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "InactiveTrackOpacity"
-        },
-        {
-          "value": " ",
-          "type": "Color",
-          "label": "Active track color (thumb color by default) (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ActiveTrackColor"
-        },
-        {
-          "value": "255",
-          "type": "Number",
-          "label": "Active track opacity (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "ActiveTrackOpacity"
-        },
-        {
-          "value": "24",
-          "type": "Number",
-          "label": "Hover halo size (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "HaloRadius"
-        },
-        {
-          "value": "32",
-          "type": "Number",
-          "label": "Hover halo opacity",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "HaloOpacityHover"
-        },
-        {
-          "value": "64",
-          "type": "Number",
-          "label": "Pressed halo opacity (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "HaloOpacityClick"
-        },
-        {
-          "value": "true",
-          "type": "Boolean",
-          "label": "Rounded track ends (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "RoundedTrack"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Is being dragged (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "IsBeingDragged"
-        },
-        {
-          "value": "0",
-          "type": "Number",
-          "label": "Value (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "Value"
-        },
-        {
-          "value": "0",
-          "type": "Number",
-          "label": "Thumb offset (thumb position on the track) (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "ThumbOffset"
-        },
-        {
-          "value": "true",
-          "type": "Boolean",
-          "label": "Need redraw (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "NeedRedraw"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Is hovered (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "IsHovered"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Was Hovered (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "WasHovered"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Disabled (property)",
-          "description": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "Disabled"
-        }
-      ]
-    },
-    {
-      "description": "Draw a horizontal slider that can be dragged by the users. \n\nThe value range and the tick spacing can be defined with properties.",
-      "fullName": "Draggable Slider Control (horizontal)",
-      "name": "DraggableSliderControl",
-      "objectType": "PrimitiveDrawing::Drawer",
-      "eventsFunctions": [
         {
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPreEvents",
           "private": false,
           "sentence": "",
@@ -4004,6 +219,56 @@
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Track where the mouse is (in relation to object)",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.ToDrawingX(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyMouseY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.ToDrawingY(MouseX(Object.Layer(), 0), MouseY(Object.Layer(), 0))"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
                 {
                   "disabled": false,
                   "folded": false,
@@ -4046,7 +311,7 @@
                         "Object",
                         "Behavior",
                         "=",
-                        "MouseX(Object.Layer())-Object.X()"
+                        "Object.Behavior::PropertyMouseX()"
                       ],
                       "subInstructions": []
                     },
@@ -4112,11 +377,12 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
+                            "value": "ModVarScene"
                           },
                           "parameters": [
                             "__DraggableSliderBehavior.SlideInProgress",
-                            "False"
+                            "=",
+                            "0"
                           ],
                           "subInstructions": []
                         }
@@ -4152,8 +418,45 @@
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackLength()",
+                            "Object.Behavior::PropertyValueMin() + (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin()) * Object.Behavior::PropertyThumbOffset() / Object.Behavior::PropertyTrackWidth()",
                             ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Grow halo even more when pressed",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),1.25 * Object.Behavior::PropertyHaloRadius(),Object.Behavior::PropertyHaloGrowSpeed())"
                           ],
                           "subInstructions": []
                         }
@@ -4196,11 +499,12 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "SceneVariableAsBoolean"
+                        "value": "VarScene"
                       },
                       "parameters": [
                         "__DraggableSliderBehavior.SlideInProgress",
-                        "False"
+                        "=",
+                        "0"
                       ],
                       "subInstructions": []
                     },
@@ -4224,17 +528,6 @@
                         "Object"
                       ],
                       "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ],
-                      "subInstructions": []
                     }
                   ],
                   "actions": [],
@@ -4251,7 +544,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Detect mouse clicks near track, start dragging.  A scene variable is used so that only one slider can be dragged at once.",
+                      "comment": "Detect mouse clicks near track, start dragging",
                       "comment2": ""
                     },
                     {
@@ -4273,56 +566,48 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisX"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseX()",
                             ">=",
-                            "Object.X() - Object.Behavior::PropertyThumbWidth() / 2",
-                            "Object.Layer()",
-                            "0"
+                            "-Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisX"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseX()",
                             "<=",
-                            "Object.X() + Object.Behavior::PropertyTrackLength() + Object.Behavior::PropertyThumbWidth() / 2",
-                            "Object.Layer()",
-                            "0"
+                            "Object.Behavior::PropertyTrackWidth() + Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisY"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseY()",
                             ">=",
-                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            "0"
+                            "-Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisY"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseY()",
                             "<=",
-                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            "0"
+                            "Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         }
@@ -4343,11 +628,12 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
+                            "value": "ModVarScene"
                           },
                           "parameters": [
                             "__DraggableSliderBehavior.SlideInProgress",
-                            "True"
+                            "=",
+                            "1"
                           ],
                           "subInstructions": []
                         },
@@ -4378,74 +664,8 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Detect when the mouse is hovering over thumb ",
+                      "comment": "Reset hover detection ",
                       "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyWasHovered"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
                     },
                     {
                       "disabled": false,
@@ -4471,61 +691,68 @@
                     {
                       "disabled": false,
                       "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Grow halo when hovered",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisX"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseX()",
                             ">=",
-                            "Object.X() + Object.Behavior::PropertyThumbOffset() - max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
+                            "Object.Behavior::PropertyThumbOffset() - Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisX"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseX()",
                             "<=",
-                            "Object.X() + Object.Behavior::PropertyThumbOffset() + max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2",
-                            "Object.Layer()",
-                            ""
+                            "Object.Behavior::PropertyThumbOffset() + Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisY"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseY()",
                             ">=",
-                            "Object.Y() - (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            ""
+                            "- Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         },
                         {
                           "type": {
                             "inverted": false,
-                            "value": "SourisY"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "",
+                            "Object.Behavior::PropertyMouseY()",
                             "<=",
-                            "Object.Y() + (Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2",
-                            "Object.Layer()",
-                            ""
+                            "Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         }
@@ -4542,9 +769,98 @@
                             "yes"
                           ],
                           "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),Object.Behavior::PropertyHaloRadius(),0.2)"
+                          ],
+                          "subInstructions": []
                         }
                       ],
                       "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Shrink halo to zero when not hovered",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyIsHovered"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyCurrentHaloRadius"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Behavior::PropertyCurrentHaloRadius(),0,Object.Behavior::PropertyHaloGrowSpeed())"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Redraw slider only when halo is not at final size",
+                      "comment2": ""
                     },
                     {
                       "disabled": false,
@@ -4564,12 +880,13 @@
                         },
                         {
                           "type": {
-                            "inverted": true,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyWasHovered"
+                            "inverted": false,
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "Object",
-                            "Behavior"
+                            "Object.Behavior::PropertyCurrentHaloRadius()",
+                            "!=",
+                            "Object.Behavior::PropertyHaloRadius()"
                           ],
                           "subInstructions": []
                         }
@@ -4609,11 +926,12 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyWasHovered"
+                            "value": "Egal"
                           },
                           "parameters": [
-                            "Object",
-                            "Behavior"
+                            "Object.Behavior::PropertyCurrentHaloRadius()",
+                            "!=",
+                            "0"
                           ],
                           "subInstructions": []
                         }
@@ -4668,6 +986,7 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPostEvents",
           "private": false,
           "sentence": "",
@@ -4737,7 +1056,738 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Set default ThumbShape",
+                      "comment": "Draw halo (it will grow or shrink as needed)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyHaloOpacityHover()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyCurrentHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Use a more opaque halo while being dragged (it will grow or shrink as needed)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyHaloOpacityClick()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyCurrentHaloRadius()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set inactive track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControlTRR::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControlTRR::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyInactiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyInactiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyInactiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw inactive track",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "0",
+                            "Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyTrackHeight()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTrackWidth()",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "270",
+                            "90",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Set active track parameters (by default, use thumb color)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"0\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyActiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyActiveTrackColor()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyActiveTrackOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw active track (2 pixels bigger than property) ",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "-1",
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight() + 1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw half circle at end (optional)",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Arc"
+                          },
+                          "parameters": [
+                            "Object",
+                            "0",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "Object.Behavior::PropertyTrackHeight()/2",
+                            "90",
+                            "270",
+                            "",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Prepare thumb settings",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbColor()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "Object.Behavior::PropertyThumbOpacity()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Circle thumb",
                       "comment2": ""
                     },
                     {
@@ -4753,21 +1803,8 @@
                           "parameters": [
                             "Object",
                             "Behavior",
-                            "!=",
-                            "\"Rectangle\""
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "!=",
-                            "\"Circle\""
+                            "=",
+                            "\"circle\""
                           ],
                           "subInstructions": []
                         }
@@ -4776,13 +1813,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "DraggableSliderControl::DraggableSliderControl::SetThumbShape"
+                            "value": "PrimitiveDrawing::Circle"
                           },
                           "parameters": [
                             "Object",
-                            "Behavior",
-                            "\"Circle\"",
-                            ""
+                            "Object.Behavior::PropertyThumbOffset()",
+                            "Object.Behavior::PropertyTrackHeight() / 2",
+                            "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
                           ],
                           "subInstructions": []
                         }
@@ -4790,780 +1827,56 @@
                       "events": []
                     },
                     {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
                       "disabled": false,
                       "folded": false,
-                      "name": "Pressed halo",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Use a more opaque halo while being dragged",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsBeingDragged"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityClick()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "Object.Behavior::PropertyTrackThickness()/2",
-                                "Object.Behavior::PropertyHaloRadius()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Rectangle thumb",
+                      "comment2": ""
                     },
                     {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
                       "disabled": false,
                       "folded": false,
-                      "name": "Inactive track",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
                         {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
+                          "type": {
+                            "inverted": false,
+                            "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
                           },
-                          "comment": "Set inactive track parameters (by default, use thumb color)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyInactiveTrackColor()"
-                              ],
-                              "subInstructions": []
-                            }
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"rectangle\""
                           ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyInactiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyInactiveTrackOpacity()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw half circle at inactive end (optional)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Arc"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyTrackLength()",
-                                "Object.Behavior::PropertyTrackThickness()/2",
-                                "Object.Behavior::PropertyTrackThickness()/2",
-                                "270",
-                                "90",
-                                "",
-                                "yes"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw inactive track",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "0",
-                                "Object.Behavior::PropertyTrackLength()",
-                                "min(Object.Behavior::PropertyTrackThickness(),Object.Behavior::PropertyThumbHeight())"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
+                          "subInstructions": []
                         }
                       ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Active track",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
+                      "actions": [
                         {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
                           },
-                          "comment": "Set active track parameters (by default, use thumb color)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"0;0;0\""
-                              ],
-                              "subInstructions": []
-                            }
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
+                            "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackHeight()) / 2",
+                            "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
+                            "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackHeight()) / 2"
                           ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyActiveTrackColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"0;0;0\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyActiveTrackColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyActiveTrackOpacity()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw half circle at active end (optional)",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyRoundedTrack"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Arc"
-                              },
-                              "parameters": [
-                                "Object",
-                                "0",
-                                "Object.Behavior::PropertyTrackThickness()/2",
-                                "1 + Object.Behavior::PropertyTrackThickness()/2",
-                                "90",
-                                "270",
-                                "",
-                                "yes"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw active track (2 pixels bigger than property) ",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "0",
-                                "-1",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "min(Object.Behavior::PropertyTrackThickness(),Object.Behavior::PropertyThumbHeight()) + 1"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
+                          "subInstructions": []
                         }
                       ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Halo",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw halo",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyIsHovered"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyHaloOpacityHover()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::OutlineOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "0"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "Object.Behavior::PropertyTrackThickness()/2",
-                                "Object.Behavior::PropertyHaloRadius()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "disabled": false,
-                      "folded": false,
-                      "name": "Thumb",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Prepare thumb settings",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "Object",
-                                "=",
-                                "Object.Behavior::PropertyThumbOpacity()"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::FillColor"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbColor()"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw Circle thumb",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"Circle\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Circle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset()",
-                                "Object.Behavior::PropertyTrackThickness() / 2",
-                                "max(Object.Behavior::PropertyThumbWidth(),Object.Behavior::PropertyThumbHeight()) / 2"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Draw Rectangle thumb",
-                          "comment2": ""
-                        },
-                        {
-                          "disabled": false,
-                          "folded": false,
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "=",
-                                "\"Rectangle\""
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "PrimitiveDrawing::Rectangle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Object.Behavior::PropertyThumbOffset() - (Object.Behavior::PropertyThumbWidth() / 2)",
-                                "-1 * (Object.Behavior::PropertyThumbHeight() - Object.Behavior::PropertyTrackThickness()) / 2",
-                                "Object.Behavior::PropertyThumbOffset() + (Object.Behavior::PropertyThumbWidth() / 2)",
-                                "(Object.Behavior::PropertyThumbHeight() + Object.Behavior::PropertyTrackThickness()) / 2"
-                              ],
-                              "subInstructions": []
-                            }
-                          ],
-                          "events": []
-                        }
-                      ],
-                      "parameters": []
+                      "events": []
                     }
                   ]
                 }
@@ -5599,6 +1912,7 @@
           "description": "Check if the slider is being dragged.",
           "fullName": "Is being dragged",
           "functionType": "Condition",
+          "group": "",
           "name": "IsBeingDragged",
           "private": false,
           "sentence": "Slider _PARAM0_ is being dragged using the _PARAM1_ behavior",
@@ -5660,42 +1974,39 @@
           "objectGroups": []
         },
         {
-          "description": "",
-          "fullName": "",
-          "functionType": "Action",
-          "name": "onCreated",
+          "description": "Check if the slider is disabled.",
+          "fullName": "Is disabled",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsDisabled",
           "private": false,
-          "sentence": "",
+          "sentence": "_PARAM0_ is disabled",
           "events": [
             {
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure object doesn't get re-drawn every frame",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
               "actions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "PrimitiveDrawing::ClearBetweenFrames"
+                    "value": "SetReturnBoolean"
                   },
                   "parameters": [
-                    "Object",
-                    "no"
+                    "True"
                   ],
                   "subInstructions": []
                 }
@@ -5705,46 +2016,16 @@
             {
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbShape"
+                    "inverted": true,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
                   },
                   "parameters": [
                     "Object",
-                    "Behavior",
-                    "=",
-                    "\"Rectangle\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyThumbWidth"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Behavior"
                   ],
                   "subInstructions": []
                 }
@@ -5753,13 +2034,10 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetThumbWidth"
+                    "value": "SetReturnBoolean"
                   },
                   "parameters": [
-                    "Object",
-                    "Behavior",
-                    "Object.Behavior::PropertyTrackThickness()",
-                    ""
+                    "False"
                   ],
                   "subInstructions": []
                 }
@@ -5792,12 +2070,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change thickness of track.",
-          "fullName": "Track thickness",
-          "functionType": "Action",
-          "name": "SetTrackThickness",
+          "description": "The value of the slider (based on position of the thumb).",
+          "fullName": "Slider value",
+          "functionType": "Expression",
+          "group": "Slider",
+          "name": "Value",
           "private": false,
-          "sentence": "Change track thickness of _PARAM0_ to _PARAM2_ px",
+          "sentence": "",
           "events": [
             {
               "disabled": false,
@@ -5808,7 +2087,703 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackThickness"
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyValue()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the value of a slider (this will move the thumb to the correct position).",
+          "fullName": "Slider value",
+          "functionType": "Action",
+          "group": "Slider",
+          "name": "SetValue",
+          "private": false,
+          "sentence": "Change the value of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "round(GetArgumentAsNumber(\"Value\") / Object.Behavior::PropertyTickSpacing()) * Object.Behavior::PropertyTickSpacing()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "Object.Behavior::PropertyValueMax()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyValueMax()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Set the proper offset (it moves the slider)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyTrackWidth() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Slider value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "The minimum value of a slider.",
+          "fullName": "Slider minimum value",
+          "functionType": "Expression",
+          "group": "Slider value configuration",
+          "name": "ValueMin",
+          "private": false,
+          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyValueMin()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the maximum value of a slider.",
+          "fullName": "Slider maximum value",
+          "functionType": "Action",
+          "group": "Slider value configuration",
+          "name": "SetValueMin",
+          "private": false,
+          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValueMin"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"ValueMin\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::Value()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Minimum value",
+              "longDescription": "",
+              "name": "ValueMin",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "The maximum value of a slider.",
+          "fullName": "Slider maximum value",
+          "functionType": "Expression",
+          "group": "Slider value configuration",
+          "name": "ValueMax",
+          "private": false,
+          "sentence": "Change the maximum value of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyValueMax()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the minimum value of a slider.",
+          "fullName": "Slider minimum value",
+          "functionType": "Action",
+          "group": "Slider value configuration",
+          "name": "SetValueMax",
+          "private": false,
+          "sentence": "Change the minimum value of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValueMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"ValueMax\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::Value()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Maximum value",
+              "longDescription": "",
+              "name": "ValueMax",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "The tick spacing of a slider.",
+          "fullName": "Tick spacing",
+          "functionType": "Expression",
+          "group": "Slider value configuration",
+          "name": "TickSpacing",
+          "private": false,
+          "sentence": "Change the tick spacing of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyTickSpacing()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Tick spacing",
+              "longDescription": "",
+              "name": "TickSpacing",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the tick spacing of a slider.",
+          "fullName": "Tick spacing",
+          "functionType": "Action",
+          "group": "Slider value configuration",
+          "name": "SetTickSpacing",
+          "private": false,
+          "sentence": "Change the tick spacing of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTickSpacing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"TickSpacing\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::Value()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Tick spacing",
+              "longDescription": "",
+              "name": "TickSpacing",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change height of track.",
+          "fullName": "Track height",
+          "functionType": "Action",
+          "group": "Slider track configuration",
+          "name": "SetTrackHeight",
+          "private": false,
+          "sentence": "Change track height of _PARAM0_ to _PARAM2_px",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackHeight"
                   },
                   "parameters": [
                     "Object",
@@ -5845,7 +2820,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure thumb width is not smaller than track thickness (to prevent track ends from showing)",
+              "comment": "Make sure thumb width is not smaller than track height (to prevent track ends from showing)",
               "comment2": ""
             },
             {
@@ -5862,7 +2837,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "\"Rectangle\""
+                    "\"rectangle\""
                   ],
                   "subInstructions": []
                 },
@@ -5875,7 +2850,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Object.Behavior::PropertyTrackHeight()"
                   ],
                   "subInstructions": []
                 }
@@ -5889,7 +2864,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackThickness()",
+                    "Object.Behavior::PropertyTrackHeight()",
                     ""
                   ],
                   "subInstructions": []
@@ -5922,7 +2897,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Track thickness",
+              "description": "Track height",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -5936,9 +2911,10 @@
           "description": "Change height of thumb.",
           "fullName": "Thumb height",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetThumbHeight",
           "private": false,
-          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_ px",
+          "sentence": "Change thumb height of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -6013,6 +2989,7 @@
           "description": "Change opacity of thumb.",
           "fullName": "Thumb opacity",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetThumbOpacity",
           "private": false,
           "sentence": "Change thumb opacity of _PARAM0_ to _PARAM2_",
@@ -6090,6 +3067,7 @@
           "description": "Change opacity of inactive track.",
           "fullName": "Inactive track opacity",
           "functionType": "Action",
+          "group": "Slider track configuration",
           "name": "SetInactiveTrackOpacity",
           "private": false,
           "sentence": "Change inactive track opacity of _PARAM0_ to _PARAM2_",
@@ -6167,6 +3145,7 @@
           "description": "Change opacity of active track.",
           "fullName": "Active track opacity",
           "functionType": "Action",
+          "group": "Slider track configuration",
           "name": "SetActiveTrackOpacity",
           "private": false,
           "sentence": "Change active track opacity of _PARAM0_ to _PARAM2_",
@@ -6241,12 +3220,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change length of track.",
-          "fullName": "Track length",
+          "description": "Change width of track.",
+          "fullName": "Track width",
           "functionType": "Action",
-          "name": "SetTrackLength",
+          "group": "Slider track configuration",
+          "name": "SetTrackWidth",
           "private": false,
-          "sentence": "Change track length of _PARAM0_ to _PARAM2_ px",
+          "sentence": "Change track width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -6257,7 +3237,7 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackLength"
+                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyTrackWidth"
                   },
                   "parameters": [
                     "Object",
@@ -6307,7 +3287,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Track length",
+              "description": "Track width",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -6321,9 +3301,10 @@
           "description": "Change width of thumb.",
           "fullName": "Thumb width",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetThumbWidth",
           "private": false,
-          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_ px",
+          "sentence": "Change thumb width of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -6401,7 +3382,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Object.Behavior::PropertyTrackHeight()"
                   ],
                   "subInstructions": []
                 }
@@ -6415,7 +3396,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackThickness()",
+                    "Object.Behavior::PropertyTrackHeight()",
                     ""
                   ],
                   "subInstructions": []
@@ -6462,6 +3443,7 @@
           "description": "Change shape of thumb (circle or rectangle).",
           "fullName": "Thumb shape",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetThumbShape",
           "private": false,
           "sentence": "Change shape of _PARAM0_ to _PARAM2_",
@@ -6529,7 +3511,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "\"Rectangle\""
+                    "\"rectangle\""
                   ],
                   "subInstructions": []
                 },
@@ -6542,7 +3524,7 @@
                     "Object",
                     "Behavior",
                     "<",
-                    "Object.Behavior::PropertyTrackThickness()"
+                    "Object.Behavior::PropertyTrackHeight()"
                   ],
                   "subInstructions": []
                 }
@@ -6556,7 +3538,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "Object.Behavior::PropertyTrackThickness()",
+                    "Object.Behavior::PropertyTrackHeight()",
                     ""
                   ],
                   "subInstructions": []
@@ -6593,173 +3575,20 @@
               "longDescription": "",
               "name": "Shape",
               "optional": false,
-              "supplementaryInformation": "[\"Circle\",\"Rectangle\"]",
+              "supplementaryInformation": "[\"circle\",\"rectangle\"]",
               "type": "stringWithSelector"
             }
           ],
           "objectGroups": []
         },
         {
-          "description": "Change the opacity of halo when pressed.",
-          "fullName": "Halo opacity when pressed",
-          "functionType": "Action",
-          "name": "SetHaloOpacityClick",
-          "private": false,
-          "sentence": "Change halo opacity when pressed of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloOpacityClick"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo opacity when pressed",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Change the opacity of halo.",
-          "fullName": "Halo opacity",
-          "functionType": "Action",
-          "name": "SetHaloOpacity",
-          "private": false,
-          "sentence": "Change halo opacity of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyHaloOpacityHover"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Halo opacity",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
           "description": "Change the radius of halo.",
-          "fullName": "Halo radius",
+          "fullName": "Halo Radius",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetHaloRadius",
           "private": false,
-          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_ px",
+          "sentence": "Change halo radius of _PARAM0_ to _PARAM2_px",
           "events": [
             {
               "disabled": false,
@@ -6834,6 +3663,7 @@
           "description": "Change the color of the track that is LEFT of the thumb.",
           "fullName": "Active track color ",
           "functionType": "Action",
+          "group": "Slider track configuration",
           "name": "SetActiveTrackColor",
           "private": false,
           "sentence": "Change active track color of _PARAM0_ to _PARAM2_",
@@ -6852,6 +3682,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
+                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -6910,6 +3741,7 @@
           "description": "Change the color of the track that is RIGHT of the thumb.",
           "fullName": "Inactive track color",
           "functionType": "Action",
+          "group": "Slider track configuration",
           "name": "SetInactiveTrackColor",
           "private": false,
           "sentence": "Change inactive track color of _PARAM0_ to _PARAM2_",
@@ -6928,6 +3760,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
+                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -6986,6 +3819,7 @@
           "description": "Make track use rounded ends.",
           "fullName": "Rounded track ends",
           "functionType": "Action",
+          "group": "Slider track configuration",
           "name": "SetRoundedTrack",
           "private": false,
           "sentence": "Draw _PARAM0_ with a rounded track: _PARAM2_",
@@ -7104,7 +3938,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Ronded track",
+              "description": "Rounded track",
               "longDescription": "",
               "name": "Value",
               "optional": false,
@@ -7118,6 +3952,7 @@
           "description": "Change the thumb color to a specific value.",
           "fullName": "Thumb color",
           "functionType": "Action",
+          "group": "Slider thumb configuration",
           "name": "SetThumbColor",
           "private": false,
           "sentence": "Change thumb color of _PARAM0_ to _PARAM2_",
@@ -7136,6 +3971,7 @@
                   "parameters": [
                     "Object",
                     "Behavior",
+                    "=",
                     "GetArgumentAsString(\"Color\")"
                   ],
                   "subInstructions": []
@@ -7191,340 +4027,10 @@
           "objectGroups": []
         },
         {
-          "description": "Change the value of a slider to a specific value (this will move the thumb to the correct position).",
-          "fullName": "Slider value",
-          "functionType": "Action",
-          "name": "SetValue",
-          "private": false,
-          "sentence": "Set value of _PARAM0_ to _PARAM2_",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyTickSpacing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "round(GetArgumentAsNumber(\"Value\") / Object.Behavior::PropertyTickSpacing()) * Object.Behavior::PropertyTickSpacing()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "<",
-                    "Object.Behavior::PropertyValueMin()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyValueMin()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "Object.Behavior::PropertyValueMax()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyValue"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyValueMax()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Set the proper offset (this is move the slider)",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyThumbOffset"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Behavior::PropertyTrackLength() * (Object.Behavior::PropertyValue() - Object.Behavior::PropertyValueMin()) / (Object.Behavior::PropertyValueMax() - Object.Behavior::PropertyValueMin())"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::SetPropertyNeedRedraw"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Slider value",
-              "longDescription": "",
-              "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
-              "type": "expression"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Check if the slider is disabled.",
-          "fullName": "Is disabled",
-          "functionType": "Condition",
-          "name": "IsDisabled",
-          "private": false,
-          "sentence": "_PARAM0_ is disabled",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "DraggableSliderControl::DraggableSliderControl::PropertyDisabled"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "False"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "description": "Disable (or enable) the slider. Users cannot interact with disabled sliders.",
+          "description": "Disable (or enable) the slider. Users cannot interact while it is disabled.",
           "fullName": "Disable (or enable) the slider",
           "functionType": "Action",
+          "group": "",
           "name": "SetDisabled",
           "private": false,
           "sentence": "Disable _PARAM0_: _PARAM2_",
@@ -7648,58 +4154,6 @@
             }
           ],
           "objectGroups": []
-        },
-        {
-          "description": "The value of the slider (based on position of the thumb).",
-          "fullName": "Slider value",
-          "functionType": "Expression",
-          "name": "Value",
-          "private": false,
-          "sentence": "",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetReturnNumber"
-                  },
-                  "parameters": [
-                    "Object.Behavior::PropertyValue()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": [
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Object",
-              "longDescription": "",
-              "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "codeOnly": false,
-              "defaultValue": "",
-              "description": "Behavior",
-              "longDescription": "",
-              "name": "Behavior",
-              "optional": false,
-              "supplementaryInformation": "DraggableSliderControl::DraggableSliderControl",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -7708,6 +4162,7 @@
           "type": "Number",
           "label": "Minimum value",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "ValueMin"
@@ -7717,6 +4172,7 @@
           "type": "Number",
           "label": "Maximum value",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "ValueMax"
@@ -7726,6 +4182,7 @@
           "type": "Number",
           "label": "Tick spacing",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "TickSpacing"
@@ -7733,11 +4190,12 @@
         {
           "value": "circle",
           "type": "Choice",
-          "label": "Thumb shape",
+          "label": "Thumb shape (\"circle\" or \"rectangle\")",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [
-            "Circle",
-            "Rectangle"
+            "circle",
+            "thumb"
           ],
           "hidden": false,
           "name": "ThumbShape"
@@ -7747,6 +4205,7 @@
           "type": "Number",
           "label": "Thumb width",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbWidth"
@@ -7756,15 +4215,17 @@
           "type": "Number",
           "label": "Thumb height",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbHeight"
         },
         {
-          "value": "24;119;211",
+          "value": " 24;119;211",
           "type": "Color",
           "label": "Thumb Color",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbColor"
@@ -7774,6 +4235,7 @@
           "type": "Number",
           "label": "Thumb opacity",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "ThumbOpacity"
@@ -7781,26 +4243,29 @@
         {
           "value": "200",
           "type": "Number",
-          "label": "Track width",
+          "label": "Track length",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackLength"
+          "name": "TrackWidth"
         },
         {
           "value": "4",
           "type": "Number",
-          "label": "Track height",
+          "label": "Track thickness",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
-          "name": "TrackThickness"
+          "name": "TrackHeight"
         },
         {
           "value": "",
           "type": "Color",
           "label": "Inactive track color (thumb color by default)",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "InactiveTrackColor"
@@ -7810,6 +4275,7 @@
           "type": "Number",
           "label": "Inactive track opacity",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "InactiveTrackOpacity"
@@ -7819,6 +4285,7 @@
           "type": "Color",
           "label": "Active track color (thumb color by default)",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "ActiveTrackColor"
@@ -7828,6 +4295,7 @@
           "type": "Number",
           "label": "Active track opacity",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "ActiveTrackOpacity"
@@ -7835,8 +4303,9 @@
         {
           "value": "24",
           "type": "Number",
-          "label": "Hover halo size",
+          "label": "Halo size (hover)",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloRadius"
@@ -7844,8 +4313,9 @@
         {
           "value": "32",
           "type": "Number",
-          "label": "Hover halo opacity",
+          "label": "Halo opacity (hover)",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloOpacityHover"
@@ -7853,8 +4323,9 @@
         {
           "value": "64",
           "type": "Number",
-          "label": "Pressed halo opacity",
+          "label": "Halo opacity (pressed)",
           "description": "",
+          "group": "Thumb",
           "extraInformation": [],
           "hidden": false,
           "name": "HaloOpacityClick"
@@ -7864,6 +4335,7 @@
           "type": "Boolean",
           "label": "Rounded track ends",
           "description": "",
+          "group": "Track",
           "extraInformation": [],
           "hidden": false,
           "name": "RoundedTrack"
@@ -7871,8 +4343,9 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "Is being dragged",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "IsBeingDragged"
@@ -7880,8 +4353,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Value",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Value"
@@ -7889,8 +4363,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Thumb offset (thumb position on the track)",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "ThumbOffset"
@@ -7898,8 +4373,9 @@
         {
           "value": "true",
           "type": "Boolean",
-          "label": "Need redraw",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "NeedRedraw"
@@ -7907,29 +4383,62 @@
         {
           "value": "",
           "type": "Boolean",
-          "label": "Is hovered",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "IsHovered"
         },
         {
           "value": "",
-          "type": "Boolean",
-          "label": "Was Hovered",
+          "type": "Number",
+          "label": "",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "WasHovered"
+          "name": "MouseX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "MouseY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "Current halo radius (used to animate halo)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CurrentHaloRadius"
         },
         {
           "value": "",
           "type": "Boolean",
-          "label": "Disabled",
+          "label": "Disabled (users cannot interact while disabled)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "Disabled"
+        },
+        {
+          "value": "0.2",
+          "type": "Number",
+          "label": "Halo grow (and shrink) speed (used for animation) Range: 0 to 1",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "HaloGrowSpeed"
         }
       ]
     }


### PR DESCRIPTION
## Changes

- Added new vertical slider behavior
- Updated horizontal slider to use color picker
- Updated horizontal slider to use a list of strings (Rectangle/Circle)
- Added link to test extension:
https://victrisgames.itch.io/draggable-slider-control-extension

## To Do:
- Fix logic on setting Inactive Track color
- Decide if the horizontal version should be renamed with the word "Horizontal"

## Video 

https://user-images.githubusercontent.com/8879811/146629931-5a50f539-8f8f-401a-bcf9-34f7e03d9fa0.mp4


