### PR TITLE
Updated Gamepad parameters to use a list of strings

### DIFF
--- a/Extensions/Gamepads.json
+++ b/Extensions/Gamepads.json
@@ -1,6 +1,6 @@
 {
   "author": "Bouh",
-  "description": "Add support for gamepads (or other controllers) to your game, giving access to information such as button presses, axis positions, axis force, trigger pressure, deadzone for each gamepad, etc...\n\nUp to 4 gamepads can be connected: for each condition or expression, you'll have to enter the index of the gamepad to read. This is 1, 2,3 or 4.",
+  "description": "Add support for gamepads (or other controllers) to your game, giving access to information such as button presses, axis positions, axis force, trigger pressure, deadzone for each gamepad, etc...\n\nUp to 4 gamepads can be connected. For each condition or expression, you'll have to enter the index of the gamepad to read. This is 1, 2, 3 or 4.",
   "extensionNamespace": "",
   "fullName": "Gamepads (controllers)",
   "helpPath": "/all-features/gamepad",
@@ -8,7 +8,7 @@
   "name": "Gamepads",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/gamepad-variant-outline.svg",
   "shortDescription": "Add support for gamepads (or other controllers) to your game, giving access to information such as button presses, axis positions, trigger pressure, etc...",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "tags": [
     "controllers",
     "gamepads",
@@ -54,12 +54,12 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Trigger: \"LT\", \"RT\", \"L2\", \"R2\"",
+          "description": "Trigger button",
           "longDescription": "",
           "name": "trigger",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"LT\",\"RT\",\"L2\",\"R2\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -100,8 +100,8 @@
           "longDescription": "",
           "name": "stick",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"LEFT\",\"RIGHT\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -142,8 +142,8 @@
           "longDescription": "",
           "name": "stick",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"LEFT\",\"RIGHT\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -184,18 +184,18 @@
           "longDescription": "",
           "name": "stick",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"LEFT\",\"RIGHT\"]",
+          "type": "stringWithSelector"
         },
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Direction: \"UP\", \"DOWN\", \"LEFT\", \"RIGHT\", \"HORIZONTAL\" or \"VERTICAL\"",
+          "description": "Direction",
           "longDescription": "",
           "name": "direction",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\",\"HORIZONTAL\",\"VERTICAL\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -232,12 +232,12 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "The name of the button",
+          "description": "Name of the button",
           "longDescription": "",
           "name": "button",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"A\",\"CROSS\",\"B\",\"CIRCLE\",\"X\",\"SQUARE\",\"Y\",\"TRIANGLE\",\"LB\",\"L1\",\"RB\",\"R1\",\"LT\",\"L2\",\"RT\",\"R2\",\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\",\"BACK\",\"SHARE\",\"START\",\"OPTIONS\",\"CLICK_STICK_LEFT\",\"CLICK_STICK_RIGHT\",\"PS_BUTTON\",\"CLICK_TOUCHPAD\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -338,12 +338,12 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Controller type \"XBOX\" or \"PS4\". This defines the type of button names to return as a string. \"Mapping not exist\" is returned if invalid type is used",
+          "description": "Controller type",
           "longDescription": "",
           "name": "controller_type",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"XBOX\",\"PS4\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -380,12 +380,12 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "The name of the button",
+          "description": "Name of the button",
           "longDescription": "",
           "name": "button",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"A\",\"CROSS\",\"B\",\"CIRCLE\",\"X\",\"SQUARE\",\"Y\",\"TRIANGLE\",\"LB\",\"L1\",\"RB\",\"R1\",\"LT\",\"L2\",\"RT\",\"R2\",\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\",\"BACK\",\"SHARE\",\"START\",\"OPTIONS\",\"CLICK_STICK_LEFT\",\"CLICK_STICK_RIGHT\",\"PS_BUTTON\",\"CLICK_TOUCHPAD\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -508,18 +508,18 @@
           "longDescription": "",
           "name": "stick",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"LEFT\",\"RIGHT\"]",
+          "type": "stringWithSelector"
         },
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Direction: \"UP\", \"DOWN\", \"LEFT\" or \"RIGHT\"",
+          "description": "Direction",
           "longDescription": "",
           "name": "direction",
           "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "supplementaryInformation": "[\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []


### PR DESCRIPTION
I predict that the gamepad extension is going to be one of the most used (and it will eventually be included by default), so I thought I would give it some love.

To do this, I changed almost all string parameters to use a list. 

The one exception was "C_Controller_type".

I think this function compares the given string parameter "controllerType" with the "gamepad.id" string provided by the gamepad device.  However, I don't understand how this is done using this line:

```
eventsFunctionContext.returnValue = gamepad ? gamepad.id.toUpperCase().indexOf(controllerType) !== -1 : false;
```

Can someone confirm that this function should not use a list of strings?