### PR TITLE
Add the SmoothCamera extension to follow an object.

### DIFF
--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -5924,7 +5924,7 @@
       ]
     },
     {
-      "description": "Smoothly scroll to follow a character and stabilize the camera when jumping",
+      "description": "Smoothly scroll to follow a character and stabilize the camera when jumping.",
       "fullName": "Smooth platformer camera",
       "name": "SmoothPlatformerCamera",
       "objectType": "",

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -731,7 +731,7 @@
           "objectGroups": []
         },
         {
-          "description": "Delay the camera and catch up the delay at a given speed. This action must be used when the object doesn't move yet.",
+          "description": "Delay the camera according to a maximum speed and catch up the delay.",
           "fullName": "Wait and catch up",
           "functionType": "Action",
           "group": "",

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -6219,7 +6219,7 @@
           "name": "FloorFollowFreeAreaBottom"
         },
         {
-          "value": "0,95",
+          "value": "0.95",
           "type": "Number",
           "label": "Upward speed in the air (in ratio persecond)",
           "description": "",
@@ -6229,7 +6229,7 @@
           "name": "AirUpwardSpeed"
         },
         {
-          "value": "0,95",
+          "value": "0.95",
           "type": "Number",
           "label": "Downward speed in the air (in ratio persecond)",
           "description": "",
@@ -6239,7 +6239,7 @@
           "name": "AirDownwardSpeed"
         },
         {
-          "value": "0,9",
+          "value": "0.9",
           "type": "Number",
           "label": "Upward speed on the floor (in ratio persecond)",
           "description": "",
@@ -6249,7 +6249,7 @@
           "name": "FloorUpwardSpeed"
         },
         {
-          "value": "0,9",
+          "value": "0.9",
           "type": "Number",
           "label": "Downward speed on the floor (in ratio persecond)",
           "description": "",

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -503,7 +503,7 @@
                           "parameters": [
                             "",
                             "=",
-                            "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
+                            "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
                           ],

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -1,0 +1,4823 @@
+{
+  "author": "",
+  "category": "",
+  "description": "The camera follows an object according to:\n- a frame rate independent speed to make the scrolling from smooth to strong\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- position forecasting and delay to simulate a cameraman response time\n- an extra delay and catch-up speed to give an impression of speed (like a spin dash)\n- a platformer dedicated behavior to stabilize the camera for jumps",
+  "extensionNamespace": "",
+  "fullName": "Smooth Camera",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQoJLnN0MXtmaWxsOm5vbmU7c3Ryb2tlOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjI7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30NCjwvc3R5bGU+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjQsMTNoLTZjLTEuMSwwLTItMC45LTItMlY1YzAtMS4xLDAuOS0yLDItMmg2YzEuMSwwLDIsMC45LDIsMnY2QzI2LDEyLjEsMjUuMSwxMywyNCwxM3oiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yNiw4djEwYzAsMS4xLTAuOSwyLTIsMkg4Yy0xLjEsMC0yLTAuOS0yLTJWOGMwLTEuMSwwLjktMiwyLTJoOCIvPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjEiIGN5PSI4IiByPSIyIi8+DQo8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxMSIgY3k9IjE2IiByPSIxIi8+DQo8cmVjdCB4PSI5IiB5PSI5IiBjbGFzcz0ic3QwIiB3aWR0aD0iNCIgaGVpZ2h0PSIzIi8+DQo8cG9seWxpbmUgY2xhc3M9InN0MCIgcG9pbnRzPSIyMSwyOSAyMSwyOSAxMSwyOSAxMSwyOSAiLz4NCjxwb2x5bGluZSBjbGFzcz0ic3QwIiBwb2ludHM9IjE4LDIwIDE4LDI5IDE0LDI5IDE0LDIwICIvPg0KPHJlY3QgeD0iNyIgeT0iMyIgY2xhc3M9InN0MCIgd2lkdGg9IjQiIGhlaWdodD0iMyIvPg0KPC9zdmc+DQo=",
+  "name": "SmoothCamera",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_camcoder_gopro_go_pro_camera.svg",
+  "shortDescription": "Smoothly scroll to follow an object.",
+  "version": "0.1.0",
+  "tags": [
+    "camera",
+    "scrolling",
+    "follow",
+    "smooth"
+  ],
+  "authorIds": [
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [],
+  "eventsBasedBehaviors": [
+    {
+      "description": "Smoothly scroll to follow an object.",
+      "fullName": "Smooth Camera",
+      "name": "SmoothCamera",
+      "objectType": "",
+      "eventsFunctions": [
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "onCreated",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Update private properties through setters.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyLeftwardSpeed()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetRightwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyRightwardSpeed()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyUpwardSpeed()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyDownwardSpeed()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyCameraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "<",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariableClearChildren"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectPositions"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPreEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Delaying and forecasting can be used at the same time.\nForecasting only use the positions that are older than the one used for delaying.\nThe behavior uses a position history that is split in 2 arrays:\n- one for delaying the position (from TimeFromStart to TimeFromStart - CamearDelay)\n- one for forecasting the position (from TimeFromStart - CamearDelay to TimeFromStart - CamearDelay - ForecastHistoryDuration",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::UpdateDelayedPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::UpdateForecastedPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "pow is probably more efficient than precalculated log if the speed is changed continuously but this might be rare enough.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyFollowOnX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraX"
+                      },
+                      "parameters": [
+                        "",
+                        ">",
+                        "Object.Behavior::FreeAreaRight()",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Object.Behavior::FreeAreaRight()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "<",
+                        "Object.Behavior::FreeAreaLeft()",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Object.Behavior::FreeAreaLeft()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyFollowOnY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraY"
+                      },
+                      "parameters": [
+                        "",
+                        ">",
+                        "Object.Behavior::FreeAreaBottom()",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Object.Behavior::FreeAreaBottom()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "<",
+                        "Object.Behavior::FreeAreaTop()",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Object.Behavior::FreeAreaTop()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
+                        "Object.Behavior::PropertyLayerName()",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyCameraExtraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, Object.Behavior::PropertyCameraExtraDelay() -Object.Behavior::PropertyCameraDelayCatchUpSpeed() * TimeDelta())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Delay the camera and catch up the delay at a given speed. This action must be used when the object doesn't move yet.",
+          "fullName": "Wait and catch up",
+          "functionType": "Action",
+          "group": "",
+          "name": "WaitAndCatchUp",
+          "private": false,
+          "sentence": "Delay the camera of _PARAM0_ from _PARAM2_ seconds and catch up in _PARAM3_ seconds",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"CameraDelay\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"CameraDelay\") / GetArgumentAsNumber(\"CatchUpDuration\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DebuggerTools::ConsoleLog"
+                  },
+                  "parameters": [
+                    "\"Wait and catch up\"",
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Camera delay (in seconds)",
+              "longDescription": "",
+              "name": "CameraDelay",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Catch up duration (in seconds)",
+              "longDescription": "",
+              "name": "CatchUpDuration",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Draw the targeted and actual camera position.",
+          "fullName": "Draw debug",
+          "functionType": "Action",
+          "group": "",
+          "name": "DrawDebug",
+          "private": false,
+          "sentence": "Draw targeted and actual camera position for _PARAM0_ on _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "PrimitiveDrawing::FillOpacity"
+                  },
+                  "parameters": [
+                    "ShapePainter",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Path used by the forecasting",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                        ">",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::OutlineColor"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "\"245;166;35\""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::BeginFillPath"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                        "Object.Variable(__SmoothCamera_ForecastHistoryY[0])"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Repeat",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::PathLineTo"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::EndFillPath"
+                          },
+                          "parameters": [
+                            "ShapePainter"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Follow-free area.",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaLeft"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaRight"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaTop"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaBottom"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::OutlineColor"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "\"126;211;33\""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::Rectangle"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "Object.Behavior::FreeAreaLeft()",
+                        "Object.Behavior::FreeAreaTop()",
+                        "Object.Behavior::FreeAreaRight()",
+                        "Object.Behavior::FreeAreaBottom()"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Linear regression vector used by the forcasting.",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": true,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::OutlineColor"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "\"0;0;0\""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::LineV2"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "0",
+                        "Object.Behavior::PropertyForecastHistoryLinearB()",
+                        "1600",
+                        "Object.Behavior::PropertyForecastHistoryLinearB() + 1600 * Object.Behavior::PropertyForecastHistoryLinearA()",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::LineV2"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "Object.Behavior::PropertyForecastHistoryLinearB()",
+                        "0",
+                        "Object.Behavior::PropertyForecastHistoryLinearB() + 1600 * Object.Behavior::PropertyForecastHistoryLinearA()",
+                        "1600",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::OutlineColor"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "\"208;2;27\""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::LineV2"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "Object.Behavior::PropertyProjectedOldestX()",
+                        "Object.Behavior::PropertyProjectedOldestY()",
+                        "Object.Behavior::PropertyProjectedNewestX()",
+                        "Object.Behavior::PropertyProjectedNewestY()",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Targeted and actual camera position",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::Circle"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "Object.Behavior::PropertyForecastedX()",
+                        "Object.Behavior::PropertyForecastedY()",
+                        "3"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::LineV2"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "CameraX(Object.Behavior::PropertyLayerName(), 0)",
+                        "CameraY(Object.Behavior::PropertyLayerName(), 0) - 4",
+                        "CameraX(Object.Behavior::PropertyLayerName(), 0)",
+                        "CameraY(Object.Behavior::PropertyLayerName(), 0) + 4",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PrimitiveDrawing::LineV2"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "CameraX(Object.Behavior::PropertyLayerName(), 0) - 4",
+                        "CameraY(Object.Behavior::PropertyLayerName(), 0)",
+                        "CameraX(Object.Behavior::PropertyLayerName(), 0) + 4",
+                        "CameraY(Object.Behavior::PropertyLayerName(), 0)",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Shape painter",
+              "longDescription": "",
+              "name": "ShapePainter",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "objectList"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Enable or disable the following on X axis.",
+          "fullName": "Follow on X",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowOnX",
+          "private": false,
+          "sentence": "The camera follows _PARAM0_ on X axis: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"FollowOnY\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow on Y axis",
+              "longDescription": "",
+              "name": "FollowOnY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Enable or disable the following on Y axis.",
+          "fullName": "Follow on Y",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowOnY",
+          "private": false,
+          "sentence": "The camera follows _PARAM0_ on Y axis: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"FollowOnY\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow on Y axis",
+              "longDescription": "",
+              "name": "FollowOnY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera leftward catch-up speed (in ratio per second).",
+          "fullName": "Leftward speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetLeftwardSpeed",
+          "private": false,
+          "sentence": "Change the camera leftward speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "clamp(0, 1, GetArgumentAsNumber(\"LeftwardSpeed\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLogLeftwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "log(1 - Object.Behavior::PropertyLeftwardSpeed())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Leftward speed",
+              "longDescription": "",
+              "name": "LeftwardSpeed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera rightward catch-up speed (in ratio per second).",
+          "fullName": "Rightward speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetRightwardSpeed",
+          "private": false,
+          "sentence": "Change the camera rightward speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyRightwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "clamp(0, 1, GetArgumentAsNumber(\"RightwardSpeed\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLogRightwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "log(1 - Object.Behavior::PropertyRightwardSpeed())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Rightward speed",
+              "longDescription": "",
+              "name": "RightwardSpeed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera downward catch-up speed (in ratio per second).",
+          "fullName": "Downward speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetDownwardSpeed",
+          "private": false,
+          "sentence": "Change the camera downward speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "clamp(0, 1, GetArgumentAsNumber(\"DownwardSpeed\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLogDownwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "log(1 - Object.Behavior::PropertyDownwardSpeed())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Downward speed",
+              "longDescription": "",
+              "name": "DownwardSpeed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera upward catch-up speed (in ratio per second).",
+          "fullName": "Upward speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetUpwardSpeed",
+          "private": false,
+          "sentence": "Change the camera upward speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "clamp(0, 1, GetArgumentAsNumber(\"UpwardSpeed\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLogUpwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "log(1 - Object.Behavior::PropertyUpwardSpeed())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Upward speed",
+              "longDescription": "",
+              "name": "UpwardSpeed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera offset on X axis of an object.",
+          "fullName": "Camera Offset X",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetOffsetX",
+          "private": false,
+          "sentence": "Change the camera offset on X axis of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"CameraOffsetX\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Camera offset X",
+              "longDescription": "",
+              "name": "CameraOffsetX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera offset on Y axis of an object.",
+          "fullName": "Camera Offset Y",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetOffsetY",
+          "private": false,
+          "sentence": "Change the camera offset on Y axis of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"CameraOffsetY\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Camera offset X",
+              "longDescription": "",
+              "name": "CameraOffsetX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera forecast time (in seconds).",
+          "fullName": "Forecast time",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetForecastTime",
+          "private": false,
+          "sentence": "Change the camera forecast time of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastTime"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "min(0, GetArgumentAsNumber(\"ForecastTime\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Forecast time",
+              "longDescription": "",
+              "name": "ForecastTime",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera delay (in seconds).",
+          "fullName": "Camera delay",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetCameraDelay",
+          "private": false,
+          "sentence": "Change the camera delay of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "min(0, GetArgumentAsNumber(\"CameraDelay\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Camera delay",
+              "longDescription": "",
+              "name": "CameraDelay",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return follow free area left border X.",
+          "fullName": "Free area left",
+          "functionType": "Expression",
+          "group": "Private",
+          "name": "FreeAreaLeft",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() - Object.Behavior::PropertyFollowFreeAreaLeft()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return follow free area right border X.",
+          "fullName": "Free area right",
+          "functionType": "Expression",
+          "group": "Private",
+          "name": "FreeAreaRight",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() + Object.Behavior::PropertyFollowFreeAreaRight()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return follow free area bottom border Y.",
+          "fullName": "Free area bottom",
+          "functionType": "Expression",
+          "group": "Private",
+          "name": "FreeAreaBottom",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() + Object.Behavior::PropertyFollowFreeAreaBottom()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return follow free area top border Y.",
+          "fullName": "Free area top",
+          "functionType": "Expression",
+          "group": "Private",
+          "name": "FreeAreaTop",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() - Object.Behavior::PropertyFollowFreeAreaTop()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Update delayed position and delayed history. This is called in doStepPreEvents.",
+          "fullName": "Update delayed position",
+          "functionType": "Action",
+          "group": "Private",
+          "name": "UpdateDelayedPosition",
+          "private": true,
+          "sentence": "Update delayed position and delayed history of _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Use the object center when no delay is asked.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.CenterX()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.CenterY()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "TimeFromStart()",
+                    "Object.CenterX()",
+                    "Object.CenterY()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectTime",
+                    "TimeFromStart()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectX",
+                    "Object.CenterX()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectY",
+                    "Object.CenterY()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Remove history entries that are too old to be useful for delaying and pass it to the history for forecasting.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "infiniteLoopWarning": true,
+                  "type": "BuiltinCommonInstructions::While",
+                  "whileConditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                        ">=",
+                        "2"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime[1]",
+                        "<",
+                        "TimeFromStart() - Object.Behavior::CurrentDelay()"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Variable(__SmoothCamera_ObjectTime[0])",
+                        "Object.Variable(__SmoothCamera_ObjectX[0])",
+                        "Object.Variable(__SmoothCamera_ObjectY[0])",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectX",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectY",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Don't move the camera if there is not enough history.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Variable(__SmoothCamera_ObjectX[0])"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Variable(__SmoothCamera_ObjectY[0])"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                        ">=",
+                        "2"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime[0]",
+                        "<",
+                        "TimeFromStart() - Object.Behavior::CurrentDelay()"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "The time with delay is now between the first 2 indexes",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Variable(__SmoothCamera_ObjectX[1]), Object.Variable(__SmoothCamera_ObjectX[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(Object.Variable(__SmoothCamera_ObjectY[1]), Object.Variable(__SmoothCamera_ObjectY[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return the current camera delay.",
+          "fullName": "Camera is delayed",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsDelayed",
+          "private": true,
+          "sentence": "The camera of _PARAM0_ is delayed",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "Object.Behavior::CurrentDelay()",
+                    ">",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return the current camera delay.",
+          "fullName": "Current delay",
+          "functionType": "Expression",
+          "group": "",
+          "name": "CurrentDelay",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyCameraDelay() + Object.Behavior::PropertyCameraExtraDelay()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Add a position to the history for forecasting. This is called 2 times in UpadteDelayedPosition.",
+          "fullName": "Add forecast history position",
+          "functionType": "Action",
+          "group": "Private",
+          "name": "AddForecastHistoryPosition",
+          "private": true,
+          "sentence": "Add the time:_PARAM2_ and position: _PARAM3_; _PARAM4_ to the forecast history of _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ForecastHistoryTime",
+                    "GetArgumentAsNumber(\"Time\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ForecastHistoryX",
+                    "GetArgumentAsNumber(\"ObjectX\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ForecastHistoryY",
+                    "GetArgumentAsNumber(\"ObjectY\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Remove history entries that are too old to be useful.\nKeep at least 2 positions because no forecast can be done with less positions.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "infiniteLoopWarning": true,
+                  "type": "BuiltinCommonInstructions::While",
+                  "whileConditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                        ">=",
+                        "3"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryTime[0]",
+                        "<",
+                        "TimeFromStart() - Object.Behavior::PropertyCameraDelay() - Object.Behavior::PropertyCameraExtraDelay() - Object.Behavior::PropertyForecastHistoryDuration()"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryTime",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryX",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ObjectVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryY",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Time",
+              "longDescription": "",
+              "name": "Time",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object X",
+              "longDescription": "",
+              "name": "ObjectX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object Y",
+              "longDescription": "",
+              "name": "ObjectY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Update forecasted position. This is called in doStepPreEvents.",
+          "fullName": "Update forecasted position",
+          "functionType": "Action",
+          "group": "Private",
+          "name": "UpdateForecastedPosition",
+          "private": true,
+          "sentence": "Update forecasted position of _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyDelayedCenterX()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyDelayedCenterY()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Simple linear regression\ny = A * x + B\n\nA = Covariance / VarianceX\nB = MeanY - A * MeanX\n\nNote than we could use only one position every N positions to reduce the process time,\nbut if we really need efficient process JavaScript and circular queues are a must.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                    ">=",
+                    "2"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Mean X",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Repeat",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "/",
+                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Mean Y",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Repeat",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "/",
+                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DebuggerTools::ConsoleLog"
+                          },
+                          "parameters": [
+                            "\"Mean: \" + ToString(Object.Behavior::PropertyForecastHistoryMeanX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryMeanY())",
+                            "",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Variance and Covariance",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "VarianceX = sum((X[i] - MeanX)²)\nVarianceY = sum((Y[i] - MeanY)²)\nCovariance = sum((X[i] - MeanX) * (Y[i] - MeanY))",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Repeat",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "pow(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX(), 2)"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "pow(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY(), 2)"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX())\n*\n(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY())"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": true,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "DebuggerTools::ConsoleLog"
+                          },
+                          "parameters": [
+                            "\"Variances: \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceY()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryCovariance())",
+                            "\"info\"",
+                            "\"SmoothCamera\""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                            "<",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
+                            "<",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Behavior::PropertyDelayedCenterX()"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Behavior::PropertyDelayedCenterY()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                ">=",
+                                "1"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
+                                ">=",
+                                "1"
+                              ],
+                              "subInstructions": []
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "disabled": false,
+                          "folded": false,
+                          "name": "Linear function parameters",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "y = A * x + B\n\nA = Covariance / VarianceX\nB = MeanY - A * MeanX",
+                              "comment2": ""
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                    ">=",
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "=",
+                                    "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceX()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "=",
+                                    "Object.Behavior::PropertyForecastHistoryMeanY() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanX()"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": [
+                                {
+                                  "disabled": true,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "DebuggerTools::ConsoleLog"
+                                      },
+                                      "parameters": [
+                                        "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
+                                        "\"info\"",
+                                        "\"SmoothCamera\""
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "disabled": false,
+                                  "folded": false,
+                                  "name": "Projection",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "disabled": false,
+                                      "folded": false,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
+                                            ""
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    }
+                                  ],
+                                  "parameters": []
+                                }
+                              ]
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Axis permutation to avoid a ratio between 2 numbers near 0.",
+                              "comment2": ""
+                            },
+                            {
+                              "disabled": false,
+                              "folded": false,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                    "<",
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "=",
+                                    "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceY()"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "=",
+                                    "Object.Behavior::PropertyForecastHistoryMeanX() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanY()"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": [
+                                {
+                                  "disabled": true,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "DebuggerTools::ConsoleLog"
+                                      },
+                                      "parameters": [
+                                        "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
+                                        "\"info\"",
+                                        "\"SmoothCamera\""
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "disabled": false,
+                                  "folded": false,
+                                  "name": "Projection",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "disabled": false,
+                                      "folded": false,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
+                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
+                                            ""
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
+                                    {
+                                      "disabled": false,
+                                      "folded": false,
+                                      "type": "BuiltinCommonInstructions::Comment",
+                                      "color": {
+                                        "b": 109,
+                                        "g": 230,
+                                        "r": 255,
+                                        "textB": 0,
+                                        "textG": 0,
+                                        "textR": 0
+                                      },
+                                      "comment": "Permute back axis",
+                                      "comment2": ""
+                                    },
+                                    {
+                                      "disabled": false,
+                                      "folded": false,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedOldestX()"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedOldestY()"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyIndex()"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
+                                    {
+                                      "disabled": false,
+                                      "folded": false,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedNewestX()"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedNewestY()"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyIndex()"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    }
+                                  ],
+                                  "parameters": []
+                                },
+                                {
+                                  "disabled": true,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "DebuggerTools::ConsoleLog"
+                                      },
+                                      "parameters": [
+                                        "\"Oldest: \" + ToString(Object.Behavior::PropertyProjectedOldestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedOldestY())",
+                                        "\"info\"",
+                                        "\"SmoothCamera\""
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "disabled": true,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "DebuggerTools::ConsoleLog"
+                                      },
+                                      "parameters": [
+                                        "\"Newest: \" + ToString(Object.Behavior::PropertyProjectedNewestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedNewestY())",
+                                        "\"info\"",
+                                        "\"SmoothCamera\""
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            },
+                            {
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "disabled": false,
+                              "folded": false,
+                              "name": "Forcasted position",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
+                              "events": [
+                                {
+                                  "disabled": false,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyProjectedNewestX() + ( Object.Behavior::PropertyProjectedNewestX() - Object.Behavior::PropertyProjectedOldestX()) * Object.Behavior::ForecastTimeRatio()"
+                                      ],
+                                      "subInstructions": []
+                                    },
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyProjectedNewestY() + ( Object.Behavior::PropertyProjectedNewestY() - Object.Behavior::PropertyProjectedOldestY()) * Object.Behavior::ForecastTimeRatio()"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "disabled": true,
+                                  "folded": false,
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "DebuggerTools::ConsoleLog"
+                                      },
+                                      "parameters": [
+                                        "\"Forecasted: \" + ToString(Object.Behavior::PropertyForecastedX()) + \" \" + ToString(Object.Behavior::PropertyForecastedY())",
+                                        "\"info\"",
+                                        "\"SmoothCamera\""
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ],
+                              "parameters": []
+                            }
+                          ],
+                          "parameters": []
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Project history ends position to have the vector on the line from linear regression. This function is only called by UpdateForecastedPosition.",
+          "fullName": "Project history ends",
+          "functionType": "Action",
+          "group": "Private",
+          "name": "ProjectHistoryEnds",
+          "private": true,
+          "sentence": "Project history oldest: _PARAM2_;_PARAM3_ and newest position: _PARAM4_;_PARAM5_ of _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Perpendicular line:\npA = -1/a; \npB = -pA * x + y\n\nIntersection:\n/ ProjectedY = a * ProjectedX + b\n\\ ProjectedY = pA * ProjectedX + b\n\nSolution that is cleaned out from indeterminism (like 0 / 0 or infinity / infinity):\nProjectedX= (x + (y - b) * a) / (a² + 1)\nProjectedY = y + (x * a - y + b) / (a² + 1)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "(GetArgumentAsNumber(\"NewestX\") + (GetArgumentAsNumber(\"NewestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"NewestY\") + (GetArgumentAsNumber(\"NewestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"NewestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "(GetArgumentAsNumber(\"OldestX\") + (GetArgumentAsNumber(\"OldestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"OldestY\") + (GetArgumentAsNumber(\"OldestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"OldestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "OldestX",
+              "longDescription": "",
+              "name": "OldestX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "OldestY",
+              "longDescription": "",
+              "name": "OldestY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Newest X",
+              "longDescription": "",
+              "name": "NewestX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Newest Y",
+              "longDescription": "",
+              "name": "NewestY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return the ratio between forecast time and the duration of the history. This function is only called by UpdateForecastedPosition.",
+          "fullName": "Forecast time ratio",
+          "functionType": "Expression",
+          "group": "Private",
+          "name": "ForecastTimeRatio",
+          "private": true,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "- Object.Behavior::PropertyForecastTime() / (Object.Variable(__SmoothCamera_ForecastHistoryTime[0]) - Object.Variable(__SmoothCamera_ForecastHistoryTime[Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime) - 1]))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "0.9",
+          "type": "Number",
+          "label": "Leftward speed (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "LeftwardSpeed"
+        },
+        {
+          "value": "0.9",
+          "type": "Number",
+          "label": "Rightward speed (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "RightwardSpeed"
+        },
+        {
+          "value": "0.9",
+          "type": "Number",
+          "label": "Upward speed (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "UpwardSpeed"
+        },
+        {
+          "value": "0.9",
+          "type": "Number",
+          "label": "Downward speed (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "DownwardSpeed"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Follow on X axis",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowOnX"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Follow on Y axis",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowOnY"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Layer name",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "LayerName"
+        },
+        {
+          "value": "32",
+          "type": "Number",
+          "label": "Follow free area left border",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowFreeAreaLeft"
+        },
+        {
+          "value": "32",
+          "type": "Number",
+          "label": "Follow free area right border",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowFreeAreaRight"
+        },
+        {
+          "value": "32",
+          "type": "Number",
+          "label": "Follow free area top border",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowFreeAreaTop"
+        },
+        {
+          "value": "32",
+          "type": "Number",
+          "label": "Follow free area bottom border",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowFreeAreaBottom"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Camera offset X",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "CameraOffsetX"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Camera offset Y",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "CameraOffsetY"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Camera delay (in seconds)",
+          "description": "",
+          "group": "Timing",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "CameraDelay"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Forcast time (in seconds)",
+          "description": "",
+          "group": "Timing",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ForecastTime"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Forecast history duration (in second)",
+          "description": "",
+          "group": "Timing",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ForecastHistoryDuration"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "LogLeftwardSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "LogRightwardSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "LogDownwardSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "LogUpwardSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "DelayedCenterX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "DelayedCenterY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryMeanX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryMeanY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryVarianceX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryCovariance"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryLinearA"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryLinearB"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastedX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastedY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ProjectedNewestX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ProjectedNewestY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ProjectedOldestX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ProjectedOldestY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ForecastHistoryVarianceY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Index"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CameraDelayCatchUpSpeed"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CameraExtraDelay"
+        }
+      ]
+    },
+    {
+      "description": "Smoothly scroll to follow a character and disable vertical following when it jumps.",
+      "fullName": "Smooth platformer camera",
+      "name": "SmoothPlatformerCamera",
+      "objectType": "",
+      "eventsFunctions": [
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPreEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothPlatformerCamera::PropertyFollowWhenJumping"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "PlatformBehavior::IsJumping"
+                      },
+                      "parameters": [
+                        "Object",
+                        "PlatformerCharacter"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": [],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothPlatformerCamera::SetPropertyJumpOriginY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.CenterY()"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::SetFollowOnY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "no",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "BuiltinCommonInstructions::And"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "PlatformBehavior::IsJumping"
+                              },
+                              "parameters": [
+                                "Object",
+                                "PlatformerCharacter"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "PlatformBehavior::IsFalling"
+                              },
+                              "parameters": [
+                                "Object",
+                                "PlatformerCharacter"
+                              ],
+                              "subInstructions": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothPlatformerCamera::PropertyJumpOriginY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "<",
+                            "Object.CenterY()"
+                          ],
+                          "subInstructions": []
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::SetFollowOnY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "yes",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothPlatformerCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "Platformer character behavior",
+          "description": "",
+          "group": "",
+          "extraInformation": [
+            "PlatformBehavior::PlatformerObjectBehavior"
+          ],
+          "hidden": false,
+          "name": "PlatformerCharacter"
+        },
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "Smooth camera behavior",
+          "description": "",
+          "group": "",
+          "extraInformation": [
+            "SmoothCamera::SmoothCamera"
+          ],
+          "hidden": false,
+          "name": "SmoothCamera"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "JumpOriginY"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Follow when jumping",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FollowWhenJumping"
+        }
+      ]
+    }
+  ]
+}

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "",
-  "description": "The camera follows an object according to:\n- a frame rate independent speed to make the scrolling from smooth to strong\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- position forecasting and delay to simulate a cameraman response time\n- an extra delay and catch-up speed to give an impression of speed (like a spin dash)\n- a platformer dedicated behavior to stabilize the camera for jumps",
+  "description": "The camera follows an object according to:\n- a frame rate independent catch-up speed to make the scrolling from smooth to strong\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- a maximum speed to do linear following or slow down the camera when teleporting the object\n- position forecasting and delay to simulate a cameraman response time\n- an extra delay and catch-up speed to give an impression of speed (useful for dash)\n- a platformer dedicated behavior to stabilize the camera for jumps",
   "extensionNamespace": "",
   "fullName": "Smooth Camera",
   "helpPath": "",
@@ -49,7 +49,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Update private properties through setters.",
+              "comment": "Update private properties through setters to check their values and initialize state.",
               "comment2": ""
             },
             {
@@ -109,30 +109,111 @@
                     "log(1 - )"
                   ],
                   "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
+                },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::PropertyCameraDelay"
+                    "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeedMax"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "<",
-                    "0"
+                    "Object.Behavior::PropertyLeftwardSpeedMax()",
+                    "log(1 - )"
                   ],
                   "subInstructions": []
-                }
-              ],
-              "actions": [
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetRightwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyRightwardSpeedMax()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyUpwardSpeedMax()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyDownwardSpeedMax()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyFollowFreeAreaLeft()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyFollowFreeAreaRight()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyFollowFreeAreaTop()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Object.Behavior::PropertyFollowFreeAreaBottom()",
+                    "log(1 - )"
+                  ],
+                  "subInstructions": []
+                },
                 {
                   "type": {
                     "inverted": false,
@@ -142,18 +223,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ObjectVariableClearChildren"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__SmoothCamera_ObjectPositions"
+                    "Object.Behavior::PropertyCameraDelay()"
                   ],
                   "subInstructions": []
                 }
@@ -254,7 +324,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "pow is probably more efficient than precalculated log if the speed is changed continuously but this might be rare enough.",
+              "comment": "At each frame, the camera must catchup the target by a given ratio (speed)\ncameraX(t) - targetX = (cameraX(t - 1) - targetX) * speed\n\nThe frame rate must not impact on the catch-up speed, we don't want a speed in ratio per frame but a speed ratio per second, like this:\ncameraX(t) - targetX = (cameraX(t - 1s) - targetX) * speed\n\nOk, but we still need to process each frame, we can use a exponent for this:\ncameraX(t) - targetX = (cameraX(t - timeDelta) - targetX) * speed^timeDelta\ncameraX(t) = targetX + (cameraX(t - timeDelta) - targetX) * exp(timeDelta * ln(speed))\n\npow is probably more efficient than precalculated log if the speed is changed continuously but this might be rare enough.",
               "comment2": ""
             },
             {
@@ -274,7 +344,21 @@
                   "subInstructions": []
                 }
               ],
-              "actions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyOldX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "CameraX(Object.Layer(), 0)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
               "events": [
                 {
                   "disabled": false,
@@ -305,14 +389,53 @@
                       "parameters": [
                         "",
                         "=",
-                        "Object.Behavior::FreeAreaRight()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
+                        "Object.Behavior::FreeAreaRight()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
                         "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetCameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
                 },
                 {
                   "disabled": false,
@@ -343,14 +466,53 @@
                       "parameters": [
                         "",
                         "=",
-                        "Object.Behavior::FreeAreaLeft()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
+                        "Object.Behavior::FreeAreaLeft()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
                         "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraX"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetCameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
                 }
               ]
             },
@@ -371,7 +533,21 @@
                   "subInstructions": []
                 }
               ],
-              "actions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyOldY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "CameraY(Object.Layer(), 0)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
               "events": [
                 {
                   "disabled": false,
@@ -402,14 +578,53 @@
                       "parameters": [
                         "",
                         "=",
-                        "Object.Behavior::FreeAreaBottom()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
+                        "Object.Behavior::FreeAreaBottom()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
                         "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetCameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
                 },
                 {
                   "disabled": false,
@@ -440,14 +655,53 @@
                       "parameters": [
                         "",
                         "=",
-                        "Object.Behavior::FreeAreaTop()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
+                        "Object.Behavior::FreeAreaTop()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
                         "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "events": []
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraY"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetCameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
+                            "Object.Layer()",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
                 }
               ]
             }
@@ -1573,13 +1827,277 @@
           "objectGroups": []
         },
         {
+          "description": "Change the camera leftward maximum speed (in pixels per second).",
+          "fullName": "Leftward maximum speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetLeftwardSpeedMax",
+          "private": false,
+          "sentence": "Change the camera leftward maximum speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"Speed\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Leftward maximum speed (in ratio per second)",
+              "longDescription": "",
+              "name": "Speed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera rightward maximum speed (in pixels per second).",
+          "fullName": "Rightward maximum speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetRightwardSpeedMax",
+          "private": false,
+          "sentence": "Change the camera rightward maximum speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"Speed\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Rightward maximum speed (in pixels per second)",
+              "longDescription": "",
+              "name": "Speed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera upward maximum speed (in pixels per second).",
+          "fullName": "Upward maximum speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetUpwardSpeedMax",
+          "private": false,
+          "sentence": "Change the camera upward maximum speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"Speed\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Upward maximum speed (in pixels per second)",
+              "longDescription": "",
+              "name": "Speed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera downward maximum speed (in pixels per second).",
+          "fullName": "Downward maximum speed",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetDownwardSpeedMax",
+          "private": false,
+          "sentence": "Change the camera downward maximum speed of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"Speed\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Downward maximum speed (in pixels per second)",
+              "longDescription": "",
+              "name": "Speed",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change the camera leftward catch-up speed (in ratio per second).",
-          "fullName": "Leftward speed",
+          "fullName": "Leftward catch-up speed",
           "functionType": "Action",
           "group": "Camera configuration",
           "name": "SetLeftwardSpeed",
           "private": false,
-          "sentence": "Change the camera leftward speed of _PARAM0_: _PARAM2_",
+          "sentence": "Change the camera leftward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1641,7 +2159,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Leftward speed",
+              "description": "Leftward catch-up speed (in ratio per second)",
               "longDescription": "",
               "name": "LeftwardSpeed",
               "optional": false,
@@ -1653,12 +2171,12 @@
         },
         {
           "description": "Change the camera rightward catch-up speed (in ratio per second).",
-          "fullName": "Rightward speed",
+          "fullName": "Rightward catch-up speed",
           "functionType": "Action",
           "group": "Camera configuration",
           "name": "SetRightwardSpeed",
           "private": false,
-          "sentence": "Change the camera rightward speed of _PARAM0_: _PARAM2_",
+          "sentence": "Change the camera rightward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1720,7 +2238,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Rightward speed",
+              "description": "Rightward catch-up speed (in ratio per second)",
               "longDescription": "",
               "name": "RightwardSpeed",
               "optional": false,
@@ -1732,12 +2250,12 @@
         },
         {
           "description": "Change the camera downward catch-up speed (in ratio per second).",
-          "fullName": "Downward speed",
+          "fullName": "Downward catch-up speed",
           "functionType": "Action",
           "group": "Camera configuration",
           "name": "SetDownwardSpeed",
           "private": false,
-          "sentence": "Change the camera downward speed of _PARAM0_: _PARAM2_",
+          "sentence": "Change the camera downward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1799,7 +2317,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Downward speed",
+              "description": "Downward catch-up speed (in ratio per second)",
               "longDescription": "",
               "name": "DownwardSpeed",
               "optional": false,
@@ -1811,12 +2329,12 @@
         },
         {
           "description": "Change the camera upward catch-up speed (in ratio per second).",
-          "fullName": "Upward speed",
+          "fullName": "Upward catch-up speed",
           "functionType": "Action",
           "group": "Camera configuration",
           "name": "SetUpwardSpeed",
           "private": false,
-          "sentence": "Change the camera upward speed of _PARAM0_: _PARAM2_",
+          "sentence": "Change the camera upward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1878,7 +2396,7 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Upward speed",
+              "description": "Upward catch-up speed (in ratio per second)",
               "longDescription": "",
               "name": "UpwardSpeed",
               "optional": false,
@@ -4936,9 +5454,9 @@
         {
           "value": "0.9",
           "type": "Number",
-          "label": "Leftward speed (in ratio persecond)",
+          "label": "Leftward catch-up speed (in ratio per second)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "LeftwardSpeed"
@@ -4946,9 +5464,9 @@
         {
           "value": "0.9",
           "type": "Number",
-          "label": "Rightward speed (in ratio persecond)",
+          "label": "Rightward catch-up speed (in ratio per second)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "RightwardSpeed"
@@ -4956,9 +5474,9 @@
         {
           "value": "0.9",
           "type": "Number",
-          "label": "Upward speed (in ratio persecond)",
+          "label": "Upward catch-up speed (in ratio per second)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "UpwardSpeed"
@@ -4966,9 +5484,9 @@
         {
           "value": "0.9",
           "type": "Number",
-          "label": "Downward speed (in ratio persecond)",
+          "label": "Downward catch-up speed (in ratio per second)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "DownwardSpeed"
@@ -4994,7 +5512,7 @@
           "name": "FollowOnY"
         },
         {
-          "value": "32",
+          "value": "0",
           "type": "Number",
           "label": "Follow free area left border",
           "description": "",
@@ -5004,7 +5522,7 @@
           "name": "FollowFreeAreaLeft"
         },
         {
-          "value": "32",
+          "value": "0",
           "type": "Number",
           "label": "Follow free area right border",
           "description": "",
@@ -5014,7 +5532,7 @@
           "name": "FollowFreeAreaRight"
         },
         {
-          "value": "32",
+          "value": "0",
           "type": "Number",
           "label": "Follow free area top border",
           "description": "",
@@ -5024,7 +5542,7 @@
           "name": "FollowFreeAreaTop"
         },
         {
-          "value": "32",
+          "value": "0",
           "type": "Number",
           "label": "Follow free area bottom border",
           "description": "",
@@ -5342,11 +5860,71 @@
           "extraInformation": [],
           "hidden": true,
           "name": "CameraDelayCatchUpDuration"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Leftward maximum speed (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "LeftwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Rightward maximum speed (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "RightwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Upward maximum speed (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "UpwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Downward maximum speed (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "DownwardSpeedMax"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "OldX (local variable)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "OldX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "OldY (local variable)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "OldY"
         }
       ]
     },
     {
-      "description": "Smoothly scroll to follow a character and disable vertical following when it jumps.",
+      "description": "Smoothly scroll to follow a character and stabilize the camera when jumping",
       "fullName": "Smooth platformer camera",
       "name": "SmoothPlatformerCamera",
       "objectType": "",
@@ -5440,6 +6018,32 @@
                     ""
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorUpwardSpeedMax()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorDownwardSpeedMax()",
+                    ""
+                  ],
+                  "subInstructions": []
                 }
               ],
               "events": []
@@ -5530,6 +6134,32 @@
                     "Object",
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirDownwardSpeed()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirUpwardSpeedMax()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirDownwardSpeedMax()",
                     ""
                   ],
                   "subInstructions": []
@@ -5643,7 +6273,7 @@
           "type": "Number",
           "label": "Upward speed in the air (in ratio persecond)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "AirUpwardSpeed"
@@ -5653,7 +6283,7 @@
           "type": "Number",
           "label": "Downward speed in the air (in ratio persecond)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "AirDownwardSpeed"
@@ -5663,7 +6293,7 @@
           "type": "Number",
           "label": "Upward speed on the floor (in ratio persecond)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "FloorUpwardSpeed"
@@ -5673,10 +6303,50 @@
           "type": "Number",
           "label": "Downward speed on the floor (in ratio persecond)",
           "description": "",
-          "group": "Speed",
+          "group": "Catch-up speed",
           "extraInformation": [],
           "hidden": false,
           "name": "FloorDownwardSpeed"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Upward maximum speed in the air (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "AirUpwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Downward maximum speed in the air (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "AirDownwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Upward maximum speed on the floor (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorUpwardSpeedMax"
+        },
+        {
+          "value": "9000",
+          "type": "Number",
+          "label": "Downward maximum speed on the floor (in pixels per second)",
+          "description": "",
+          "group": "Maximum speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorDownwardSpeedMax"
         }
       ]
     }

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -290,7 +290,7 @@
                         "",
                         ">",
                         "Object.Behavior::FreeAreaRight()",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -306,7 +306,7 @@
                         "",
                         "=",
                         "Object.Behavior::FreeAreaRight()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -328,7 +328,7 @@
                         "",
                         "<",
                         "Object.Behavior::FreeAreaLeft()",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -344,7 +344,7 @@
                         "",
                         "=",
                         "Object.Behavior::FreeAreaLeft()\n+ (CameraX(\"\", 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -387,7 +387,7 @@
                         "",
                         ">",
                         "Object.Behavior::FreeAreaBottom()",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -403,7 +403,7 @@
                         "",
                         "=",
                         "Object.Behavior::FreeAreaBottom()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -425,7 +425,7 @@
                         "",
                         "<",
                         "Object.Behavior::FreeAreaTop()",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -441,7 +441,7 @@
                         "",
                         "=",
                         "Object.Behavior::FreeAreaTop()\n+ (CameraY(\"\", 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
-                        "Object.Behavior::PropertyLayerName()",
+                        "Object.Layer()",
                         "0"
                       ],
                       "subInstructions": []
@@ -450,42 +450,6 @@
                   "events": []
                 }
               ]
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::PropertyCameraExtraDelay"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "max(0, Object.Behavior::PropertyCameraExtraDelay() -Object.Behavior::PropertyCameraDelayCatchUpSpeed() * TimeDelta())"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
             }
           ],
           "parameters": [
@@ -519,8 +483,23 @@
           "group": "",
           "name": "WaitAndCatchUp",
           "private": false,
-          "sentence": "Delay the camera of _PARAM0_ from _PARAM2_ seconds and catch up in _PARAM3_ seconds",
+          "sentence": "Delay the camera of _PARAM0_ during: _PARAM2_ seconds according to the maximum speed _PARAM3_;_PARAM4_ seconds and catch up in _PARAM5_ seconds",
           "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Maybe the catch-up show be done in constant pixel speed instead of constant time speed.",
+              "comment2": ""
+            },
             {
               "disabled": false,
               "folded": false,
@@ -530,26 +509,52 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingEnd"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"CameraDelay\")"
+                    "TimeFromStart() + GetArgumentAsNumber(\"WaitingDuration\")"
                   ],
                   "subInstructions": []
                 },
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpSpeed"
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedXMax"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"CameraDelay\") / GetArgumentAsNumber(\"CatchUpDuration\")"
+                    "GetArgumentAsNumber(\"WaitingSpeedXMax\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedYMax"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"WaitingSpeedYMax\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"CatchUpDuration\")"
                   ],
                   "subInstructions": []
                 }
@@ -557,7 +562,7 @@
               "events": []
             },
             {
-              "disabled": false,
+              "disabled": true,
               "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
@@ -569,8 +574,8 @@
                   },
                   "parameters": [
                     "\"Wait and catch up\"",
-                    "",
-                    ""
+                    "\"info\"",
+                    "\"SmoothCamera\""
                   ],
                   "subInstructions": []
                 }
@@ -602,9 +607,29 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Camera delay (in seconds)",
+              "description": "Waiting duration (in seconds)",
               "longDescription": "",
-              "name": "CameraDelay",
+              "name": "WaitingDuration",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Waiting maximum camera target speed X",
+              "longDescription": "",
+              "name": "WaitingSpeedXMax",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Waiting maximum camera target speed Y",
+              "longDescription": "",
+              "name": "WaitingSpeedYMax",
               "optional": false,
               "supplementaryInformation": "",
               "type": "expression"
@@ -876,10 +901,10 @@
                       },
                       "parameters": [
                         "ShapePainter",
-                        "Object.Behavior::FreeAreaLeft()",
-                        "Object.Behavior::FreeAreaTop()",
-                        "Object.Behavior::FreeAreaRight()",
-                        "Object.Behavior::FreeAreaBottom()"
+                        "Object.Behavior::FreeAreaLeft() - 1",
+                        "Object.Behavior::FreeAreaTop() - 1",
+                        "Object.Behavior::FreeAreaRight() + 1",
+                        "Object.Behavior::FreeAreaBottom() + 1"
                       ],
                       "subInstructions": []
                     }
@@ -1025,10 +1050,10 @@
                       },
                       "parameters": [
                         "ShapePainter",
-                        "CameraX(Object.Behavior::PropertyLayerName(), 0)",
-                        "CameraY(Object.Behavior::PropertyLayerName(), 0) - 4",
-                        "CameraX(Object.Behavior::PropertyLayerName(), 0)",
-                        "CameraY(Object.Behavior::PropertyLayerName(), 0) + 4",
+                        "CameraX(Object.Layer(), 0)",
+                        "CameraY(Object.Layer(), 0) - 4",
+                        "CameraX(Object.Layer(), 0)",
+                        "CameraY(Object.Layer(), 0) + 4",
                         "1"
                       ],
                       "subInstructions": []
@@ -1040,10 +1065,10 @@
                       },
                       "parameters": [
                         "ShapePainter",
-                        "CameraX(Object.Behavior::PropertyLayerName(), 0) - 4",
-                        "CameraY(Object.Behavior::PropertyLayerName(), 0)",
-                        "CameraX(Object.Behavior::PropertyLayerName(), 0) + 4",
-                        "CameraY(Object.Behavior::PropertyLayerName(), 0)",
+                        "CameraX(Object.Layer(), 0) - 4",
+                        "CameraY(Object.Layer(), 0)",
+                        "CameraX(Object.Layer(), 0) + 4",
+                        "CameraY(Object.Layer(), 0)",
                         "1"
                       ],
                       "subInstructions": []
@@ -1279,6 +1304,270 @@
               "optional": false,
               "supplementaryInformation": "",
               "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera follow free area right border.",
+          "fullName": "Follow free area right border",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowFreeAreaRight",
+          "private": false,
+          "sentence": "Change the camera follow free area right border of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaRight\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow free area right border",
+              "longDescription": "",
+              "name": "SetFollowFreeAreaRight",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera follow free area left border.",
+          "fullName": "Follow free area left border",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowFreeAreaLeft",
+          "private": false,
+          "sentence": "Change the camera follow free area left border of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaLeft\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow free area left border",
+              "longDescription": "",
+              "name": "SetFollowFreeAreaLeft",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera follow free area top border.",
+          "fullName": "Follow free area top border",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowFreeAreaTop",
+          "private": false,
+          "sentence": "Change the camera follow free area top border of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"FollowFreeAreaTop\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow free area top border",
+              "longDescription": "",
+              "name": "FollowFreeAreaTop",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change the camera follow free area bottom border.",
+          "fullName": "Follow free area bottom border",
+          "functionType": "Action",
+          "group": "Camera configuration",
+          "name": "SetFollowFreeAreaBottom",
+          "private": false,
+          "sentence": "Change the camera follow free area bottom border of _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaBottom"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaBottom\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Follow free area bottom border",
+              "longDescription": "",
+              "name": "SetFollowFreeAreaBottom",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
             }
           ],
           "objectGroups": []
@@ -2096,6 +2385,91 @@
                 "textG": 0,
                 "textR": 0
               },
+              "comment": "Add the previous position to have enough (2) positions to evaluate the extra delay for waiting mode.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Egal"
+                  },
+                  "parameters": [
+                    "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                    "=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectTime",
+                    "TimeFromStart()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectX",
+                    "Object.Behavior::PropertyDelayedCenterX()"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariablePushNumber"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectY",
+                    "Object.Behavior::PropertyDelayedCenterY()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
               "comment": "Use the object center when no delay is asked.",
               "comment2": ""
             },
@@ -2179,14 +2553,35 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                    "value": "BuiltinCommonInstructions::Or"
                   },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ""
-                  ],
-                  "subInstructions": []
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ]
                 }
               ],
               "actions": [
@@ -2426,6 +2821,78 @@
                         "textG": 0,
                         "textR": 0
                       },
+                      "comment": "Add the extra delay that could be needed to respect the speed limit in waiting mode.\n\nspeedRatio = min(speedMaxX / historySpeedX, speedMaxY / historySpeedY)\ndelay += min(0, timeDelta * (1 - speedRatio))",
+                      "comment2": ""
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "+",
+                            "max(0, TimeDelta() * (1 - min(Object.Behavior::PropertyWaitingSpeedXMax() * abs(Object.Variable(__SmoothCamera_ObjectX[1]) - Object.Variable(__SmoothCamera_ObjectX[0])), Object.Behavior::PropertyWaitingSpeedYMax() * abs(Object.Variable(__SmoothCamera_ObjectY[1]) - Object.Variable(__SmoothCamera_ObjectY[0]))) / (Object.Variable(__SmoothCamera_ObjectTime[1]) - Object.Variable(__SmoothCamera_ObjectTime[0]))))"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": [
+                        {
+                          "disabled": true,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "DebuggerTools::ConsoleLog"
+                              },
+                              "parameters": [
+                                "\"Extra delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
+                                "\"info\"",
+                                "\"SmoothCamera\""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ]
+                    },
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
                       "comment": "The time with delay is now between the first 2 indexes",
                       "comment2": ""
                     },
@@ -2467,6 +2934,208 @@
                   ]
                 }
               ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariableClearChildren"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectTime"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariableClearChildren"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectX"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ObjectVariableClearChildren"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__SmoothCamera_ObjectY"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyCameraExtraDelay() / Object.Behavior::PropertyCameraDelayCatchUpDuration()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": true,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DebuggerTools::ConsoleLog"
+                      },
+                      "parameters": [
+                        "\"Start to catch up\"",
+                        "\"info\"",
+                        "\"SmoothCamera\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyCameraExtraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "max(0, Object.Behavior::PropertyCameraExtraDelay() -Object.Behavior::PropertyCameraDelayCatchUpSpeed() * TimeDelta())"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": true,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DebuggerTools::ConsoleLog"
+                      },
+                      "parameters": [
+                        "\"Catching up delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
+                        "\"info\"",
+                        "\"SmoothCamera\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
             }
           ],
           "parameters": [
@@ -2494,7 +3163,7 @@
           "objectGroups": []
         },
         {
-          "description": "Return the current camera delay.",
+          "description": "Check if the camera following target is delayed from the object.",
           "fullName": "Camera is delayed",
           "functionType": "Condition",
           "group": "",
@@ -2581,6 +3250,73 @@
                   },
                   "parameters": [
                     "Object.Behavior::PropertyCameraDelay() + Object.Behavior::PropertyCameraExtraDelay()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the camera following is waiting at a reduced speed.",
+          "fullName": "Camera is waiting",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsWaiting",
+          "private": true,
+          "sentence": "The camera of _PARAM0_ is waiting",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::PropertyWaitingEnd"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "TimeFromStart()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
                   ],
                   "subInstructions": []
                 }
@@ -4258,16 +4994,6 @@
           "name": "FollowOnY"
         },
         {
-          "value": "",
-          "type": "String",
-          "label": "Layer name",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "LayerName"
-        },
-        {
           "value": "32",
           "type": "Number",
           "label": "Follow free area left border",
@@ -4550,7 +5276,7 @@
         {
           "value": "",
           "type": "Number",
-          "label": "",
+          "label": "Index (local variable)",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -4576,6 +5302,46 @@
           "extraInformation": [],
           "hidden": true,
           "name": "CameraExtraDelay"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "WaitingSpeedXMax"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "WaitingSpeedYMax"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "WaitingEnd"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CameraDelayCatchUpDuration"
         }
       ]
     },
@@ -4602,22 +5368,94 @@
                 {
                   "type": {
                     "inverted": true,
-                    "value": "SmoothCamera::SmoothPlatformerCamera::PropertyFollowWhenJumping"
+                    "value": "PlatformBehavior::IsJumping"
                   },
                   "parameters": [
                     "Object",
-                    "Behavior"
+                    "PlatformerCharacter"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "PlatformBehavior::IsFalling"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PlatformerCharacter"
                   ],
                   "subInstructions": []
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorFollowFreeAreaTop()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorFollowFreeAreaBottom()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorUpwardSpeed()",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyFloorDownwardSpeed()",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
                     {
                       "type": {
                         "inverted": false,
@@ -4632,119 +5470,72 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SmoothCamera::SmoothPlatformerCamera::SetPropertyJumpOriginY"
+                        "value": "PlatformBehavior::IsFalling"
                       },
                       "parameters": [
                         "Object",
-                        "Behavior",
-                        "=",
-                        "Object.CenterY()"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SmoothCamera::SmoothCamera::SetFollowOnY"
-                      },
-                      "parameters": [
-                        "Object",
-                        "SmoothCamera",
-                        "no",
-                        ""
+                        "PlatformerCharacter"
                       ],
                       "subInstructions": []
                     }
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirFollowFreeAreaTop()",
+                    ""
                   ],
-                  "events": []
+                  "subInstructions": []
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Or"
-                      },
-                      "parameters": [],
-                      "subInstructions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "BuiltinCommonInstructions::And"
-                          },
-                          "parameters": [],
-                          "subInstructions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "PlatformBehavior::IsJumping"
-                              },
-                              "parameters": [
-                                "Object",
-                                "PlatformerCharacter"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "PlatformBehavior::IsFalling"
-                              },
-                              "parameters": [
-                                "Object",
-                                "PlatformerCharacter"
-                              ],
-                              "subInstructions": []
-                            }
-                          ]
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SmoothCamera::SmoothPlatformerCamera::PropertyJumpOriginY"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "<",
-                            "Object.CenterY()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ]
-                    }
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirFollowFreeAreaBottom()",
+                    ""
                   ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SmoothCamera::SmoothCamera::SetFollowOnY"
-                      },
-                      "parameters": [
-                        "Object",
-                        "SmoothCamera",
-                        "yes",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirUpwardSpeed()",
+                    ""
                   ],
-                  "events": []
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "SmoothCamera",
+                    "Object.Behavior::PropertyAirDownwardSpeed()",
+                    ""
+                  ],
+                  "subInstructions": []
                 }
-              ]
+              ],
+              "events": []
             }
           ],
           "parameters": [
@@ -4808,14 +5599,84 @@
           "name": "JumpOriginY"
         },
         {
-          "value": "",
-          "type": "Boolean",
-          "label": "Follow when jumping",
+          "value": "0",
+          "type": "Number",
+          "label": "Follow free area top in the air",
           "description": "",
-          "group": "",
+          "group": "Position",
           "extraInformation": [],
           "hidden": false,
-          "name": "FollowWhenJumping"
+          "name": "AirFollowFreeAreaTop"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Follow free area bottom in the air",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "AirFollowFreeAreaBottom"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Follow free area top on the floor",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorFollowFreeAreaTop"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Follow free area bottom on the floor",
+          "description": "",
+          "group": "Position",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorFollowFreeAreaBottom"
+        },
+        {
+          "value": "0,95",
+          "type": "Number",
+          "label": "Upward speed in the air (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "AirUpwardSpeed"
+        },
+        {
+          "value": "0,95",
+          "type": "Number",
+          "label": "Downward speed in the air (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "AirDownwardSpeed"
+        },
+        {
+          "value": "0,9",
+          "type": "Number",
+          "label": "Upward speed on the floor (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorUpwardSpeed"
+        },
+        {
+          "value": "0,9",
+          "type": "Number",
+          "label": "Downward speed on the floor (in ratio persecond)",
+          "description": "",
+          "group": "Speed",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloorDownwardSpeed"
         }
       ]
     }

--- a/Extensions/SmoothCamera.json
+++ b/Extensions/SmoothCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "",
-  "description": "The camera follows an object according to:\n- a frame rate independent catch-up speed to make the scrolling from smooth to strong\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- a maximum speed to do linear following or slow down the camera when teleporting the object\n- position forecasting and delay to simulate a cameraman response time\n- an extra delay and catch-up speed to give an impression of speed (useful for dash)\n- a platformer dedicated behavior to stabilize the camera for jumps",
+  "description": "The camera follows an object according to:\n- a frame rate independent catch-up speed to make the scrolling from smooth to strong\n- a maximum speed to do linear following or slow down the camera when teleporting the object\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- an extra delay and catch-up speed to give an impression of speed (useful for dash)\n- position forecasting and delay to simulate a cameraman response time\n\nA platformer dedicated behavior allows to switch of settings when the character is in air or on the floor. This can be used to stabilize the camera when jumping.",
   "extensionNamespace": "",
   "fullName": "Smooth Camera",
   "helpPath": "",
@@ -1179,56 +1179,6 @@
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
-                {
-                  "disabled": true,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::OutlineColor"
-                      },
-                      "parameters": [
-                        "ShapePainter",
-                        "\"0;0;0\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::LineV2"
-                      },
-                      "parameters": [
-                        "ShapePainter",
-                        "0",
-                        "Object.Behavior::PropertyForecastHistoryLinearB()",
-                        "1600",
-                        "Object.Behavior::PropertyForecastHistoryLinearB() + 1600 * Object.Behavior::PropertyForecastHistoryLinearA()",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PrimitiveDrawing::LineV2"
-                      },
-                      "parameters": [
-                        "ShapePainter",
-                        "Object.Behavior::PropertyForecastHistoryLinearB()",
-                        "0",
-                        "Object.Behavior::PropertyForecastHistoryLinearB() + 1600 * Object.Behavior::PropertyForecastHistoryLinearA()",
-                        "1600",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
                 {
                   "disabled": false,
                   "folded": false,


### PR DESCRIPTION
The camera follows an object according to:
- a frame rate independent speed to make the scrolling from smooth to strong
- a follow-free zone to avoid scrolling on small movements
- an offset to see further in one direction
- position forecasting and delay to simulate a cameraman response time
- an extra delay and catch-up speed to give an impression of speed (like a spin dash)
- a platformer dedicated behavior to stabilize the camera for jumps

## Demo
4 camera settings (press Return) and a catch up like the spin dash (the object need to be fixed before the dash)
- Stabilized jump exponential following
- Exponential following
- Linear following (Sonic like)
- Shoulder camera (not a great idea for platformers)

* Project: https://www.dropbox.com/s/08d29yjf5kf3817/AdvancedJumpAirAndWallJumpExample_D8H-1.zip?dl=1
* Build: https://liluo.io/instant-builds/6430a99f-51b0-4b0e-a77b-d2ea76ee02de

Low resolution examples:
* Exponential following: https://liluo.io/games/0a969e3e-21be-4c38-99d5-0c5a0f2ec5ad
* Linear following: https://liluo.io/games/22587fe8-6afd-4f0a-8140-969f480a3677