### PR TITLE
New extension: EdgeScrollCamera

### DIFF
--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -8,7 +8,7 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNhbWVyYS1tZXRlcmluZy1tYXRyaXgiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCw0SDIwQTIsMiAwIDAsMSAyMiw2VjE4QTIsMiAwIDAsMSAyMCwyMEg0QTIsMiAwIDAsMSAyLDE4VjZBMiwyIDAgMCwxIDQsNE00LDZWMThIMjBWNkg0TTUuNSw3LjVIMTFWOS4xN0MxMC4xNSw5LjQ3IDkuNDcsMTAuMTUgOS4xNywxMUg1LjVWNy41TTE4LjUsNy41VjExSDE0LjgzQzE0LjUzLDEwLjE1IDEzLjg1LDkuNDcgMTMsOS4xN1Y3LjVIMTguNU0xOC41LDE2LjVIMTNWMTQuODNDMTMuODUsMTQuNTMgMTQuNTMsMTMuODUgMTQuODMsMTNIMTguNVYxNi41TTUuNSwxNi41VjEzSDkuMTdDOS40NywxMy44NSAxMC4xNSwxNC41MyAxMSwxNC44M1YxNi41SDUuNU0xMiwxMC41QTEuNSwxLjUgMCAwLDEgMTMuNSwxMkExLjUsMS41IDAgMCwxIDEyLDEzLjVBMS41LDEuNSAwIDAsMSAxMC41LDEyQTEuNSwxLjUgMCAwLDEgMTIsMTAuNVoiIC8+PC9zdmc+",
   "name": "EdgeScrollCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-metering-matrix.svg",
-  "shortDescription": "Scroll camera when mouse is near edge of screen",
+  "shortDescription": "Scroll camera when mouse is near edge of screen.",
   "version": "0.1.0",
   "tags": [
     "camera",
@@ -22,7 +22,7 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Scroll camera when mouse is near edge of screen",
+      "description": "Scroll camera when mouse is near edge of screen.",
       "fullName": "Scroll camera when mouse is near edge of screen",
       "functionType": "Action",
       "group": "",
@@ -47,6 +47,17 @@
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "False"
+                  ],
+                  "subInstructions": []
+                },
                 {
                   "type": {
                     "inverted": false,
@@ -87,17 +98,6 @@
                   },
                   "parameters": [
                     "__EdgeScrollCamera.MovingRight",
-                    "False"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
                     "False"
                   ],
                   "subInstructions": []

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
+  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) camera edge scrolling\" at the beginning of scene\n- Run the action \"Configure camera edge scrolling\" at the beginning of scene\n\nTips:\n- Progressive speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -106,7 +106,7 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "name": "Prevent camera movement until cursor has move away from starting position",
+                  "name": "Prevent camera movement until cursor has moved (cursor starts at 0,0 which triggers scrolling)",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
@@ -669,7 +669,7 @@
                                             "value": "SceneVariableAsBoolean"
                                           },
                                           "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "__EdgeScrollCamera.ProgressiveSpeedEnabled",
                                             "False"
                                           ]
                                         }
@@ -772,7 +772,7 @@
                                             "value": "SceneVariableAsBoolean"
                                           },
                                           "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "__EdgeScrollCamera.ProgressiveSpeedEnabled",
                                             "True"
                                           ]
                                         }
@@ -1082,13 +1082,13 @@
       "objectGroups": []
     },
     {
-      "description": "Enable (or disable) edge scrolling camera.  Use \"Configure edge scrolling camera\" to adjust settings.",
-      "fullName": "Enable (or disable) edge scrolling camera",
+      "description": "Enable (or disable) camera edge scrolling .  Use \"Configure camera edge scrolling\" to adjust settings.",
+      "fullName": "Enable (or disable) camera edge scrolling",
       "functionType": "Action",
       "group": "",
       "name": "EnableEdgeScrollCamera",
       "private": false,
-      "sentence": "Enable edge scrolling camera? _PARAM1_",
+      "sentence": "Enable camera edge scrolling: _PARAM1_",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Comment",
@@ -1160,7 +1160,7 @@
         {
           "codeOnly": false,
           "defaultValue": "yes",
-          "description": "Enable edge scrolling camera?",
+          "description": "Enable camera edge scrolling",
           "longDescription": "",
           "name": "EnableEdgeScrolling",
           "optional": true,
@@ -1171,13 +1171,13 @@
       "objectGroups": []
     },
     {
-      "description": "Configure edge scrolling camera that moves when mouse is near an edge of the screen.",
-      "fullName": "Configure edge scrolling camera",
+      "description": "Configure camera edge scrolling that moves when mouse is near an edge of the screen.",
+      "fullName": "Configure camera edge scrolling",
       "functionType": "Action",
       "group": "",
       "name": "ConfigureEdgeScrollCamera",
       "private": false,
-      "sentence": "Configure edge scrolling camera on layer _PARAM3_, screen margin _PARAM1_, scroll speed _PARAM2_, use variable speed? _PARAM5_ ",
+      "sentence": "Configure camera edge scrolling (layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, progressive: _PARAM5_)",
       "events": [
         {
           "colorB": 228,
@@ -1197,7 +1197,7 @@
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
-                    "\"VariableSpeed\""
+                    "\"ProgressiveSpeed\""
                   ]
                 }
               ],
@@ -1207,7 +1207,7 @@
                     "value": "SetSceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.VariableSpeedEnabled",
+                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
                     "False"
                   ]
                 }
@@ -1221,7 +1221,7 @@
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
-                    "\"VariableSpeed\""
+                    "\"ProgressiveSpeed\""
                   ]
                 }
               ],
@@ -1231,7 +1231,7 @@
                     "value": "SetSceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.VariableSpeedEnabled",
+                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
                     "True"
                   ]
                 }
@@ -1331,9 +1331,9 @@
         {
           "codeOnly": false,
           "defaultValue": "yes",
-          "description": "Use variable speed (based on cursor distance from screen edge)",
+          "description": "Use progressive speed (based on cursor distance from screen edge)",
           "longDescription": "",
-          "name": "VariableSpeed",
+          "name": "ProgressiveSpeed",
           "optional": true,
           "supplementaryInformation": "",
           "type": "yesorno"
@@ -1847,11 +1847,11 @@
       "objectGroups": []
     },
     {
-      "description": "Speed the camera is currently scrolling in horizontal direction (in pixels per second).",
-      "fullName": "Current edge scroll speed (horizontal)",
+      "description": "Return the speed the camera is currently scrolling in horizontal direction (in pixels per second).",
+      "fullName": "Horizontal edge scroll speed",
       "functionType": "Expression",
       "group": "",
-      "name": "EdgeScrollSpeedX",
+      "name": "SpeedX",
       "private": false,
       "sentence": "",
       "events": [
@@ -1874,11 +1874,11 @@
       "objectGroups": []
     },
     {
-      "description": "Speed the camera is currently scrolling in vertical direction (in pixels per second).",
-      "fullName": "Current edge scroll speed (vertical)",
+      "description": "Return the speed the camera is currently scrolling in vertical direction (in pixels per second).",
+      "fullName": "Vertical edge scroll speed",
       "functionType": "Expression",
       "group": "",
-      "name": "EdgeScrollSpeedY",
+      "name": "SpeedY",
       "private": false,
       "sentence": "",
       "events": [

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1847,7 +1847,7 @@
       "objectGroups": []
     },
     {
-      "description": "Speed the camera is currently scrolling in horizontal direction (in pixels per second)",
+      "description": "Speed the camera is currently scrolling in horizontal direction (in pixels per second).",
       "fullName": "Current edge scroll speed (horizontal)",
       "functionType": "Expression",
       "group": "",
@@ -1874,7 +1874,7 @@
       "objectGroups": []
     },
     {
-      "description": "Speed the camera is currently scrolling in vertical direction (in pixels per second)",
+      "description": "Speed the camera is currently scrolling in vertical direction (in pixels per second).",
       "fullName": "Current edge scroll speed (vertical)",
       "functionType": "Expression",
       "group": "",

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
+  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- \"Progressive speed\" makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -59,7 +59,7 @@
                 "300",
                 "\"\"",
                 "0",
-                "yes",
+                "\"Progressive speed\"",
                 ""
               ]
             }
@@ -591,7 +591,7 @@
       "group": "",
       "name": "ConfigureEdgeScrollCamera",
       "private": false,
-      "sentence": "Configure camera edge scrolling (layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, progressive: _PARAM5_)",
+      "sentence": "Configure camera edge scrolling (layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, style: _PARAM5_)",
       "events": [
         {
           "colorB": 228,
@@ -607,22 +607,24 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": true,
-                    "value": "GetArgumentAsBoolean"
+                    "value": "BuiltinCommonInstructions::CompareStrings"
                   },
                   "parameters": [
-                    "\"ProgressiveSpeed\""
+                    "GetArgumentAsString(\"ScrollStyle\")",
+                    "=",
+                    "\"Constant speed\""
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "SetSceneVariableAsBoolean"
+                    "value": "ModVarSceneTxt"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                    "False"
+                    "__EdgeScrollCamera.Style",
+                    "=",
+                    "\"Constant speed\""
                   ]
                 }
               ]
@@ -632,21 +634,24 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "GetArgumentAsBoolean"
+                    "value": "BuiltinCommonInstructions::CompareStrings"
                   },
                   "parameters": [
-                    "\"ProgressiveSpeed\""
+                    "GetArgumentAsString(\"ScrollStyle\")",
+                    "=",
+                    "\"Progressive speed\""
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "SetSceneVariableAsBoolean"
+                    "value": "ModVarSceneTxt"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                    "True"
+                    "__EdgeScrollCamera.Style",
+                    "=",
+                    "\"Progressive speed\""
                   ]
                 }
               ]
@@ -744,13 +749,13 @@
         },
         {
           "codeOnly": false,
-          "defaultValue": "yes",
-          "description": "Use progressive speed (based on cursor distance from screen edge)",
+          "defaultValue": "",
+          "description": "Scroll style",
           "longDescription": "",
-          "name": "ProgressiveSpeed",
-          "optional": true,
-          "supplementaryInformation": "",
-          "type": "yesorno"
+          "name": "ScrollStyle",
+          "optional": false,
+          "supplementaryInformation": "[\"Progressive speed\",\"Constant speed\"]",
+          "type": "stringWithSelector"
         }
       ],
       "objectGroups": []
@@ -1258,15 +1263,29 @@
       "sentence": "",
       "events": [
         {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Progressive style increases speed the closer the cursor is to the edge of screen",
+          "comment2": ""
+        },
+        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarSceneTxt"
               },
               "parameters": [
-                "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                "True"
+                "__EdgeScrollCamera.Style",
+                "=",
+                "\"Progressive speed\""
               ]
             }
           ],
@@ -1305,11 +1324,12 @@
               "subInstructions": [
                 {
                   "type": {
-                    "value": "SceneVariableAsBoolean"
+                    "value": "VarSceneTxt"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                    "False"
+                    "__EdgeScrollCamera.Style",
+                    "=",
+                    "\"Constant speed\""
                   ]
                 },
                 {

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,0 +1,1473 @@
+{
+  "author": "",
+  "category": "General",
+  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Camera movement speed is constant, even when travelling in diagonal directions",
+  "extensionNamespace": "",
+  "fullName": "Edge scroll camera",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNhbWVyYS1tZXRlcmluZy1tYXRyaXgiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCw0SDIwQTIsMiAwIDAsMSAyMiw2VjE4QTIsMiAwIDAsMSAyMCwyMEg0QTIsMiAwIDAsMSAyLDE4VjZBMiwyIDAgMCwxIDQsNE00LDZWMThIMjBWNkg0TTUuNSw3LjVIMTFWOS4xN0MxMC4xNSw5LjQ3IDkuNDcsMTAuMTUgOS4xNywxMUg1LjVWNy41TTE4LjUsNy41VjExSDE0LjgzQzE0LjUzLDEwLjE1IDEzLjg1LDkuNDcgMTMsOS4xN1Y3LjVIMTguNU0xOC41LDE2LjVIMTNWMTQuODNDMTMuODUsMTQuNTMgMTQuNTMsMTMuODUgMTQuODMsMTNIMTguNVYxNi41TTUuNSwxNi41VjEzSDkuMTdDOS40NywxMy44NSAxMC4xNSwxNC41MyAxMSwxNC44M1YxNi41SDUuNU0xMiwxMC41QTEuNSwxLjUgMCAwLDEgMTMuNSwxMkExLjUsMS41IDAgMCwxIDEyLDEzLjVBMS41LDEuNSAwIDAsMSAxMC41LDEyQTEuNSwxLjUgMCAwLDEgMTIsMTAuNVoiIC8+PC9zdmc+",
+  "name": "EdgeScrollCamera",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-metering-matrix.svg",
+  "shortDescription": "Scroll camera when mouse is near edge of screen",
+  "version": "0.1.0",
+  "tags": [
+    "camera",
+    "scroll",
+    "edge",
+    "screen"
+  ],
+  "authorIds": [
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Scroll camera when mouse is near edge of screen",
+      "fullName": "Scroll camera when mouse is near edge of screen",
+      "functionType": "Action",
+      "group": "",
+      "name": "EdgeScrollCamera",
+      "private": false,
+      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM9_, Trigger width: Top _PARAM1_ px, Bottom _PARAM2_ px, Left _PARAM3_ px, Right _PARAM4_ px, Move speed: Up _PARAM5_ px/second, Down _PARAM6_ px/second, Left _PARAM7_ px/second, Right _PARAM8_ px/second)",
+      "events": [
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Reset detections",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingUp",
+                    "False"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingDown",
+                    "False"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingLeft",
+                    "False"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingRight",
+                    "False"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "False"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Detect Edge Scrolling",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Up",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "MouseY"
+                  },
+                  "parameters": [
+                    "",
+                    "<",
+                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidthTop\")",
+                    "\"\"",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingUp",
+                    "True"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Down",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "MouseY"
+                  },
+                  "parameters": [
+                    "",
+                    ">",
+                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidthBottom\")",
+                    "\"\"",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingDown",
+                    "True"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Left",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "MouseX"
+                  },
+                  "parameters": [
+                    "",
+                    "<",
+                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidthLeft\")",
+                    "\"\"",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingLeft",
+                    "True"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Right",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "MouseX"
+                  },
+                  "parameters": [
+                    "",
+                    ">",
+                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidthRight\")",
+                    "\"\"",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.MovingRight",
+                    "True"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Moving",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Move camera",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Non-diagonals",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Up",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Down",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "GetArgumentAsNumber(\"ScrollSpeedDown\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Left",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Right",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "GetArgumentAsNumber(\"ScrollSpeedRight\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "disabled": false,
+              "folded": false,
+              "name": "Diagonals",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "NOTE: Speeds are multiplied by \"0.7071\" to keep the linear speed constant",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Up+Left",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Up+Right",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "GetArgumentAsNumber(\"ScrollSpeedDown\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "0.7071 * GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Down+Left",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Down+Right",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "True"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedRight\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsString(\"Layer\")",
+                        "0.7071 * GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Trigger width (TOP edge)",
+          "longDescription": "",
+          "name": "TriggerWidthTop",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Trigger width (BOTTOM edge)",
+          "longDescription": "",
+          "name": "TriggerWidthBottom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Trigger width (LEFT edge)",
+          "longDescription": "",
+          "name": "TriggerWidthLeft",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Trigger width (RIGHT edge)",
+          "longDescription": "",
+          "name": "TriggerWidthRight",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Scroll speed (UP)",
+          "longDescription": "",
+          "name": "ScrollSpeedUp",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Scroll speed (DOWN)",
+          "longDescription": "",
+          "name": "ScrollSpeedDown",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Scroll speed (LEFT)",
+          "longDescription": "",
+          "name": "ScrollSpeedLeft",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Scroll speed (RIGHT)",
+          "longDescription": "",
+          "name": "ScrollSpeedRight",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Camera",
+          "longDescription": "",
+          "name": "Camera",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is scrolling.",
+      "fullName": "Is camera scrolling?",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsCameraScrolling",
+      "private": false,
+      "sentence": "Camera is scrolling",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.Moving",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is scrolling up.",
+      "fullName": "Is camera scrolling up?",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsCameraScrollingUp",
+      "private": false,
+      "sentence": "Camera is scrolling up",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.MovingUp",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is scrolling down.",
+      "fullName": "Is camera scrolling down?",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsCameraScrollingDown",
+      "private": false,
+      "sentence": "Camera is scrolling down",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.MovingDown",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is scrolling left.",
+      "fullName": "Is camera scrolling left?",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsCameraScrollingLeft",
+      "private": false,
+      "sentence": "Camera is scrolling left",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.MovingLeft",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is scrolling right.",
+      "fullName": "Is camera scrolling right?",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsCameraScrollingRight",
+      "private": false,
+      "sentence": "Camera is scrolling right",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.MovingRight",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Camera movement speed is constant, even when travelling in diagonal directions",
+  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Camera movement speed is constant, even when traveling in diagonal directions",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use extension \"Copy camera settings\" if you want multiple layers to move",
+  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -137,7 +137,7 @@
       "group": "",
       "name": "ConfigureEdgeScrollCamera",
       "private": false,
-      "sentence": "Configure edge scrolling camera. Layer: _PARAM3_, Screen margin: _PARAM1_, Scroll speed: _PARAM2_, Use Variable speed? _PARAM5_ ",
+      "sentence": "Configure edge scrolling camera on layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, use variable speed? _PARAM5_ ",
       "events": [
         {
           "colorB": 228,
@@ -648,13 +648,13 @@
       "objectGroups": []
     },
     {
-      "description": "Draw a rectangle that shows where edge scrolling will be triggered",
-      "fullName": "Draw edge scrolling border",
+      "description": "Draw a rectangle that shows where edge scrolling will be triggered.",
+      "fullName": "Draw edge scrolling screen margin",
       "functionType": "Action",
       "group": "",
       "name": "DrawEdgeScrollingBorder",
       "private": false,
-      "sentence": "Draw edge scrolling camera trigger line using _PARAM1_ on layer: _PARAM2_",
+      "sentence": "Draw edge scrolling screen margin with _PARAM1_ on layer: _PARAM2_",
       "events": [
         {
           "colorB": 228,
@@ -839,18 +839,6 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "PrimitiveDrawing::OutlineSize"
-                          },
-                          "parameters": [
-                            "ShapePainter",
-                            "=",
-                            "4"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::UseRelativeCoordinates"
                           },
                           "parameters": [
@@ -875,16 +863,7 @@
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "BuiltinCommonInstructions::Once"
-                          },
-                          "parameters": [],
-                          "subInstructions": []
-                        }
-                      ],
+                      "conditions": [],
                       "actions": [
                         {
                           "type": {
@@ -893,10 +872,10 @@
                           },
                           "parameters": [
                             "ShapePainter",
-                            "",
-                            "Variable(__EdgeScrollCamera.CameraTop)",
-                            "",
-                            ""
+                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)"
                           ],
                           "subInstructions": []
                         }
@@ -1263,236 +1242,232 @@
                               "actions": [],
                               "events": [
                                 {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Up",
-                                  "comment2": ""
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Up",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "MouseY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "<",
+                                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingUp",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdge",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    }
+                                  ],
+                                  "parameters": []
                                 },
                                 {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Down",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "MouseY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "<",
-                                        "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "MouseY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            ">",
+                                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingDown",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdge",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
                                     }
                                   ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetSceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingUp",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    },
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "ModVarScene"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.DistanceFromEdge",
-                                        "=",
-                                        "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
+                                  "parameters": []
                                 },
                                 {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Down",
-                                  "comment2": ""
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Left",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "MouseX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "<",
+                                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingLeft",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdge",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    }
+                                  ],
+                                  "parameters": []
                                 },
                                 {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Right",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "MouseY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        ">",
-                                        "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "MouseX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            ">",
+                                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingRight",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        },
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdge",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
                                     }
                                   ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetSceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingDown",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    },
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "ModVarScene"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.DistanceFromEdge",
-                                        "=",
-                                        "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Left",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "MouseX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "<",
-                                        "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetSceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingLeft",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    },
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "ModVarScene"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.DistanceFromEdge",
-                                        "=",
-                                        "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Right",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "MouseX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        ">",
-                                        "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetSceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingRight",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    },
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "ModVarScene"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.DistanceFromEdge",
-                                        "=",
-                                        "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
+                                  "parameters": []
                                 }
                               ]
                             }
@@ -1552,396 +1527,392 @@
                           "type": "BuiltinCommonInstructions::Group",
                           "events": [
                             {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Up",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingUp",
-                                    "True"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "actions": [],
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "name": "Up",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
                               "events": [
                                 {
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
                                       "type": {
-                                        "inverted": true,
+                                        "inverted": false,
                                         "value": "SceneVariableAsBoolean"
                                       },
                                       "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "__EdgeScrollCamera.MovingUp",
                                         "True"
                                       ],
                                       "subInstructions": []
                                     }
                                   ],
-                                  "actions": [
+                                  "actions": [],
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "-",
-                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": true,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "-",
+                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
-                                        "True"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "-",
-                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "-",
+                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "events": []
                                     }
-                                  ],
-                                  "events": []
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Down",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingDown",
-                                    "True"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
-                              "actions": [],
+                              "parameters": []
+                            },
+                            {
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "name": "Down",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
                               "events": [
                                 {
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
                                       "type": {
-                                        "inverted": true,
+                                        "inverted": false,
                                         "value": "SceneVariableAsBoolean"
                                       },
                                       "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "__EdgeScrollCamera.MovingDown",
                                         "True"
                                       ],
                                       "subInstructions": []
                                     }
                                   ],
-                                  "actions": [
+                                  "actions": [],
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "+",
-                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": true,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "+",
+                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
-                                        "True"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraY"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "+",
-                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "+",
+                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "events": []
                                     }
-                                  ],
-                                  "events": []
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Left",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingLeft",
-                                    "True"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
-                              "actions": [],
+                              "parameters": []
+                            },
+                            {
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "name": "Left",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
                               "events": [
                                 {
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
                                       "type": {
-                                        "inverted": true,
+                                        "inverted": false,
                                         "value": "SceneVariableAsBoolean"
                                       },
                                       "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "__EdgeScrollCamera.MovingLeft",
                                         "True"
                                       ],
                                       "subInstructions": []
                                     }
                                   ],
-                                  "actions": [
+                                  "actions": [],
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "-",
-                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": true,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "-",
+                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
-                                        "True"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "-",
-                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "-",
+                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "events": []
                                     }
-                                  ],
-                                  "events": []
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Right",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingRight",
-                                    "True"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
-                              "actions": [],
+                              "parameters": []
+                            },
+                            {
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "name": "Right",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
                               "events": [
                                 {
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [
                                     {
                                       "type": {
-                                        "inverted": true,
+                                        "inverted": false,
                                         "value": "SceneVariableAsBoolean"
                                       },
                                       "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "__EdgeScrollCamera.MovingRight",
                                         "True"
                                       ],
                                       "subInstructions": []
                                     }
                                   ],
-                                  "actions": [
+                                  "actions": [],
+                                  "events": [
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "+",
-                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": true,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "events": []
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "+",
+                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
+                                      ],
+                                      "events": []
+                                    },
                                     {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.VariableSpeedEnabled",
-                                        "True"
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SetCameraX"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "+",
-                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                        "VariableString(__EdgeScrollCamera.Layer)",
-                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "inverted": false,
+                                            "value": "SetCameraX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "+",
+                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ],
+                                          "subInstructions": []
+                                        }
                                       ],
-                                      "subInstructions": []
+                                      "events": []
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 }
-                              ]
+                              ],
+                              "parameters": []
                             }
                           ],
                           "parameters": []

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -9,7 +9,7 @@
   "name": "EdgeScrollCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-metering-matrix.svg",
   "shortDescription": "Scroll camera when mouse is near edge of screen.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "tags": [
     "camera",
     "scroll",
@@ -28,7 +28,7 @@
       "group": "",
       "name": "EdgeScrollCamera",
       "private": false,
-      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM9_, Trigger width: Top _PARAM1_ px, Bottom _PARAM2_ px, Left _PARAM3_ px, Right _PARAM4_ px, Move speed: Up _PARAM5_ px/second, Down _PARAM6_ px/second, Left _PARAM7_ px/second, Right _PARAM8_ px/second)",
+      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM3_, Trigger width: _PARAM1_ Move speed: _PARAM2_ px/second)",
       "events": [
         {
           "colorB": 228,
@@ -147,7 +147,7 @@
                   "parameters": [
                     "",
                     "<",
-                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidthTop\")",
+                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
                     "\"\"",
                     "GetArgumentAsNumber(\"Camera\")"
                   ],
@@ -208,7 +208,7 @@
                   "parameters": [
                     "",
                     ">",
-                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidthBottom\")",
+                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
                     "\"\"",
                     "GetArgumentAsNumber(\"Camera\")"
                   ],
@@ -269,7 +269,7 @@
                   "parameters": [
                     "",
                     "<",
-                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidthLeft\")",
+                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
                     "\"\"",
                     "GetArgumentAsNumber(\"Camera\")"
                   ],
@@ -330,7 +330,7 @@
                   "parameters": [
                     "",
                     ">",
-                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidthRight\")",
+                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
                     "\"\"",
                     "GetArgumentAsNumber(\"Camera\")"
                   ],
@@ -462,7 +462,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -545,7 +545,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "GetArgumentAsNumber(\"ScrollSpeedDown\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -628,7 +628,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -711,7 +711,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "GetArgumentAsNumber(\"ScrollSpeedRight\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -746,7 +746,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "NOTE: Speeds are multiplied by \"0.7071\" to keep the linear speed constant",
+                  "comment": "NOTE: Speeds are multiplied by \"0.7071\" (cos 45 degrees) to keep the linear speed constant",
                   "comment2": ""
                 },
                 {
@@ -823,7 +823,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -837,7 +837,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -920,7 +920,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -934,7 +934,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "GetArgumentAsNumber(\"ScrollSpeedDown\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "0.7071 * GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -1017,7 +1017,7 @@
                       "parameters": [
                         "",
                         "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedLeft\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -1031,7 +1031,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -1114,7 +1114,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeedRight\")*TimeDelta()",
+                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -1128,7 +1128,7 @@
                       "parameters": [
                         "",
                         "+",
-                        "GetArgumentAsNumber(\"ScrollSpeedUp\")*TimeDelta()",
+                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "0.7071 * GetArgumentAsNumber(\"Camera\")"
                       ],
@@ -1148,9 +1148,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Trigger width (TOP edge)",
+          "description": "Trigger width (pixels)",
           "longDescription": "",
-          "name": "TriggerWidthTop",
+          "name": "TriggerWidth",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -1158,69 +1158,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Trigger width (BOTTOM edge)",
+          "description": "Scroll speed (pixels/second)",
           "longDescription": "",
-          "name": "TriggerWidthBottom",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Trigger width (LEFT edge)",
-          "longDescription": "",
-          "name": "TriggerWidthLeft",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Trigger width (RIGHT edge)",
-          "longDescription": "",
-          "name": "TriggerWidthRight",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Scroll speed (UP)",
-          "longDescription": "",
-          "name": "ScrollSpeedUp",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Scroll speed (DOWN)",
-          "longDescription": "",
-          "name": "ScrollSpeedDown",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Scroll speed (LEFT)",
-          "longDescription": "",
-          "name": "ScrollSpeedLeft",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Scroll speed (RIGHT)",
-          "longDescription": "",
-          "name": "ScrollSpeedRight",
+          "name": "ScrollSpeed",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -22,135 +22,69 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Scroll camera when mouse is near edge of screen.",
+      "description": "Scroll camera when mouse is near an edge of the screen.",
       "fullName": "Scroll camera when mouse is near edge of screen",
       "functionType": "Action",
       "group": "",
       "name": "EdgeScrollCamera",
       "private": false,
-      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM3_, Trigger width: _PARAM1_ Move speed: _PARAM2_ px/second)",
+      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM3_, Trigger width: _PARAM1_px, Move speed: _PARAM2_ px/second)",
       "events": [
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
-          "name": "Reset detections",
+          "name": "Prevent camera movement until cursor has move away from starting position",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
-                    "False"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingUp",
-                    "False"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingDown",
-                    "False"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingLeft",
-                    "False"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingRight",
-                    "False"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": []
-        },
-        {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "disabled": false,
-          "folded": false,
-          "name": "Detect Edge Scrolling",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Up",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "MouseY"
+                    "value": "BuiltinCommonInstructions::Or"
                   },
-                  "parameters": [
-                    "",
-                    "<",
-                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
-                    "\"\"",
-                    "GetArgumentAsNumber(\"Camera\")"
-                  ],
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "MouseX"
+                      },
+                      "parameters": [
+                        "",
+                        "!=",
+                        "0",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "MouseY"
+                      },
+                      "parameters": [
+                        "",
+                        "!=",
+                        "0",
+                        "GetArgumentAsString(\"Layer\")",
+                        "GetArgumentAsNumber(\"Camera\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ]
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
                   "subInstructions": []
                 }
               ],
@@ -161,201 +95,7 @@
                     "value": "SetSceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.MovingUp",
-                    "True"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Down",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseY"
-                  },
-                  "parameters": [
-                    "",
-                    ">",
-                    "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
-                    "\"\"",
-                    "GetArgumentAsNumber(\"Camera\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingDown",
-                    "True"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Left",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseX"
-                  },
-                  "parameters": [
-                    "",
-                    "<",
-                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
-                    "\"\"",
-                    "GetArgumentAsNumber(\"Camera\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingLeft",
-                    "True"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Right",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseX"
-                  },
-                  "parameters": [
-                    "",
-                    ">",
-                    "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
-                    "\"\"",
-                    "GetArgumentAsNumber(\"Camera\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.MovingRight",
-                    "True"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Moving",
+                    "__EdgeScrollCamera.CursorMoved",
                     "True"
                   ],
                   "subInstructions": []
@@ -367,30 +107,335 @@
           "parameters": []
         },
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "disabled": false,
-          "folded": false,
-          "name": "Move camera",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Mouse has moved from starting position",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.CursorMoved",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
           "events": [
             {
               "colorB": 228,
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Non-diagonals",
+              "name": "Reset detections",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingUp",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingDown",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingLeft",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.MovingRight",
+                        "False"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Detect Edge Scrolling",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Only move camera while mouse is inside game window",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "IsMouseInsideCanvas"
+                      },
+                      "parameters": [
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Up",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseY"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
+                            "\"\"",
+                            "GetArgumentAsNumber(\"Camera\")"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.MovingUp",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Down",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseY"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
+                            "\"\"",
+                            "GetArgumentAsNumber(\"Camera\")"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.MovingDown",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Left",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseX"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
+                            "\"\"",
+                            "GetArgumentAsNumber(\"Camera\")"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.MovingLeft",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Right",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "MouseX"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
+                            "\"\"",
+                            "GetArgumentAsNumber(\"Camera\")"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.MovingRight",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Move camera",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -404,8 +449,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -416,39 +459,6 @@
                       "parameters": [
                         "__EdgeScrollCamera.MovingUp",
                         "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
                       ],
                       "subInstructions": []
                     }
@@ -472,8 +482,6 @@
                   "events": []
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -487,8 +495,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -497,41 +503,8 @@
                         "value": "SceneVariableAsBoolean"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
                         "__EdgeScrollCamera.MovingDown",
                         "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
                       ],
                       "subInstructions": []
                     }
@@ -555,8 +528,6 @@
                   "events": []
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -570,8 +541,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -580,41 +549,8 @@
                         "value": "SceneVariableAsBoolean"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
                         "__EdgeScrollCamera.MovingLeft",
                         "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
                       ],
                       "subInstructions": []
                     }
@@ -638,8 +574,6 @@
                   "events": []
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -653,43 +587,8 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
                     {
                       "type": {
                         "inverted": false,
@@ -714,423 +613,6 @@
                         "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
                         "GetArgumentAsString(\"Layer\")",
                         "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Diagonals",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "NOTE: Speeds are multiplied by \"0.7071\" (cos 45 degrees) to keep the linear speed constant",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Up+Left",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Up+Right",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "0.7071 * GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Down+Left",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Down+Right",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "0.7071 * GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "0.7071 * GetArgumentAsNumber(\"Camera\")"
                       ],
                       "subInstructions": []
                     }
@@ -1140,8 +622,7 @@
               ],
               "parameters": []
             }
-          ],
-          "parameters": []
+          ]
         }
       ],
       "parameters": [
@@ -1198,20 +679,60 @@
       "sentence": "Camera is scrolling",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
                 "inverted": false,
-                "value": "SceneVariableAsBoolean"
+                "value": "BuiltinCommonInstructions::Or"
               },
-              "parameters": [
-                "__EdgeScrollCamera.Moving",
-                "True"
-              ],
-              "subInstructions": []
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
+                  },
+                  "parameters": [
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
+                  },
+                  "parameters": [
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
+                  },
+                  "parameters": [
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
+                  },
+                  "parameters": [
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ]
             }
           ],
           "actions": [
@@ -1242,8 +763,6 @@
       "sentence": "Camera is scrolling up",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -1286,8 +805,6 @@
       "sentence": "Camera is scrolling down",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -1330,8 +847,6 @@
       "sentence": "Camera is scrolling left",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -1374,8 +889,6 @@
       "sentence": "Camera is scrolling right",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,20 +1,21 @@
 {
   "author": "",
   "category": "General",
-  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Camera movement speed is constant, even when traveling in diagonal directions",
+  "description": "How to use:\n- Run extension every frame you want the camera to move\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use extension \"Copy camera settings\" if you want multiple layers to move",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNhbWVyYS1tZXRlcmluZy1tYXRyaXgiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCw0SDIwQTIsMiAwIDAsMSAyMiw2VjE4QTIsMiAwIDAsMSAyMCwyMEg0QTIsMiAwIDAsMSAyLDE4VjZBMiwyIDAgMCwxIDQsNE00LDZWMThIMjBWNkg0TTUuNSw3LjVIMTFWOS4xN0MxMC4xNSw5LjQ3IDkuNDcsMTAuMTUgOS4xNywxMUg1LjVWNy41TTE4LjUsNy41VjExSDE0LjgzQzE0LjUzLDEwLjE1IDEzLjg1LDkuNDcgMTMsOS4xN1Y3LjVIMTguNU0xOC41LDE2LjVIMTNWMTQuODNDMTMuODUsMTQuNTMgMTQuNTMsMTMuODUgMTQuODMsMTNIMTguNVYxNi41TTUuNSwxNi41VjEzSDkuMTdDOS40NywxMy44NSAxMC4xNSwxNC41MyAxMSwxNC44M1YxNi41SDUuNU0xMiwxMC41QTEuNSwxLjUgMCAwLDEgMTMuNSwxMkExLjUsMS41IDAgMCwxIDEyLDEzLjVBMS41LDEuNSAwIDAsMSAxMC41LDEyQTEuNSwxLjUgMCAwLDEgMTIsMTAuNVoiIC8+PC9zdmc+",
   "name": "EdgeScrollCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-metering-matrix.svg",
-  "shortDescription": "Scroll camera when mouse is near edge of screen.",
+  "shortDescription": "Scroll camera when cursor is near edge of screen.",
   "version": "1.0.0",
   "tags": [
     "camera",
     "scroll",
     "edge",
-    "screen"
+    "screen",
+    "pan"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
@@ -22,89 +23,55 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Scroll camera when mouse is near an edge of the screen.",
-      "fullName": "Scroll camera when mouse is near edge of screen",
+      "description": "Enable (or disable) edge scrolling camera.  Use \"Configure edge scrolling camera\" to adjust settings.",
+      "fullName": "Enable (or disable) edge scrolling camera",
       "functionType": "Action",
       "group": "",
-      "name": "EdgeScrollCamera",
+      "name": "EnableEdgeScrollCamera",
       "private": false,
-      "sentence": "Scroll camera when mouse is near edge of screen (Layer: _PARAM3_, Trigger width: _PARAM1_px, Move speed: _PARAM2_ px/second)",
+      "sentence": "Enable edge scrolling camera? _PARAM1_",
       "events": [
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "name": "Prevent camera movement until cursor has move away from starting position",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Disable",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Or"
-                  },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "MouseX"
-                      },
-                      "parameters": [
-                        "",
-                        "!=",
-                        "0",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "MouseY"
-                      },
-                      "parameters": [
-                        "",
-                        "!=",
-                        "0",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ]
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
+              "type": {
+                "inverted": true,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"EnableEdgeScrolling\""
               ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SetSceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.CursorMoved",
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+              "subInstructions": []
             }
           ],
-          "parameters": []
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "False"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
         },
         {
           "type": "BuiltinCommonInstructions::Comment",
@@ -116,7 +83,7 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Mouse has moved from starting position",
+          "comment": "Enable",
           "comment2": ""
         },
         {
@@ -125,513 +92,207 @@
             {
               "type": {
                 "inverted": false,
-                "value": "SceneVariableAsBoolean"
+                "value": "GetArgumentAsBoolean"
               },
               "parameters": [
-                "__EdgeScrollCamera.CursorMoved",
+                "\"EnableEdgeScrolling\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.Enabled",
                 "True"
               ],
               "subInstructions": []
             }
           ],
-          "actions": [],
-          "events": [
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "name": "Reset detections",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "False"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "name": "Detect Edge Scrolling",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Only move camera while mouse is inside game window",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "IsMouseInsideCanvas"
-                      },
-                      "parameters": [
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Up",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseY"
-                          },
-                          "parameters": [
-                            "",
-                            "<",
-                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
-                            "\"\"",
-                            "GetArgumentAsNumber(\"Camera\")"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.MovingUp",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Down",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseY"
-                          },
-                          "parameters": [
-                            "",
-                            ">",
-                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
-                            "\"\"",
-                            "GetArgumentAsNumber(\"Camera\")"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.MovingDown",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Left",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseX"
-                          },
-                          "parameters": [
-                            "",
-                            "<",
-                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 + GetArgumentAsNumber(\"TriggerWidth\")",
-                            "\"\"",
-                            "GetArgumentAsNumber(\"Camera\")"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.MovingLeft",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Right",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "MouseX"
-                          },
-                          "parameters": [
-                            "",
-                            ">",
-                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2 - GetArgumentAsNumber(\"TriggerWidth\")",
-                            "\"\"",
-                            "GetArgumentAsNumber(\"Camera\")"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.MovingRight",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "name": "Move camera",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Up",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingUp",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Down",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingDown",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Left",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingLeft",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Right",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__EdgeScrollCamera.MovingRight",
-                        "True"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "+",
-                        "GetArgumentAsNumber(\"ScrollSpeed\")*TimeDelta()",
-                        "GetArgumentAsString(\"Layer\")",
-                        "GetArgumentAsNumber(\"Camera\")"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "parameters": []
-            }
-          ]
+          "events": []
         }
       ],
       "parameters": [
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Trigger width (pixels)",
+          "description": "Enable edge scrolling camera?",
           "longDescription": "",
-          "name": "TriggerWidth",
+          "name": "EnableEdgeScrolling",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Configure edge scrolling camera that moves when mouse is near an edge of the screen.",
+      "fullName": "Configure edge scrolling camera",
+      "functionType": "Action",
+      "group": "",
+      "name": "ConfigureEdgeScrollCamera",
+      "private": false,
+      "sentence": "Configure edge scrolling camera. Layer: _PARAM3_, Screen margin: _PARAM1_, Scroll speed: _PARAM2_, Use Variable speed? _PARAM5_ ",
+      "events": [
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Save values to use in pre-events lifecycle function",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"VariableSpeed\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.VariableSpeedEnabled",
+                    "False"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"VariableSpeed\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.VariableSpeedEnabled",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarSceneTxt"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Layer",
+                    "=",
+                    "GetArgumentAsString(\"Layer\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Camera",
+                    "=",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.ScrollSpeed",
+                    "=",
+                    "GetArgumentAsNumber(\"ScrollSpeed\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.ScreenMargin",
+                    "=",
+                    "GetArgumentAsNumber(\"ScreenMargin\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Screen margin (pixels)",
+          "longDescription": "",
+          "name": "ScreenMargin",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -639,7 +300,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Scroll speed (pixels/second)",
+          "description": "Scroll speed (in pixels per second)",
           "longDescription": "",
           "name": "ScrollSpeed",
           "optional": false,
@@ -665,6 +326,16 @@
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Use variable speed (based on cursor distance from screen edge)",
+          "longDescription": "",
+          "name": "VariableSpeed",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
         }
       ],
       "objectGroups": []
@@ -681,6 +352,17 @@
         {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "True"
+              ],
+              "subInstructions": []
+            },
             {
               "type": {
                 "inverted": false,
@@ -771,6 +453,17 @@
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "True"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
                 "__EdgeScrollCamera.MovingUp",
                 "True"
               ],
@@ -807,6 +500,17 @@
         {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "True"
+              ],
+              "subInstructions": []
+            },
             {
               "type": {
                 "inverted": false,
@@ -855,6 +559,17 @@
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "True"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
                 "__EdgeScrollCamera.MovingLeft",
                 "True"
               ],
@@ -897,6 +612,17 @@
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
+                "__EdgeScrollCamera.Enabled",
+                "True"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
                 "__EdgeScrollCamera.MovingRight",
                 "True"
               ],
@@ -916,6 +642,1319 @@
             }
           ],
           "events": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Draw a rectangle that shows where edge scrolling will be triggered",
+      "fullName": "Draw edge scrolling border",
+      "functionType": "Action",
+      "group": "",
+      "name": "DrawEdgeScrollingBorder",
+      "private": false,
+      "sentence": "Draw edge scrolling camera trigger line using _PARAM1_ on layer: _PARAM2_",
+      "events": [
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Draw Edge Scrolling",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Enabled",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Save camera borders as variables",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CameraTop",
+                            "=",
+                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CameraBottom",
+                            "=",
+                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CameraLeft",
+                            "=",
+                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CameraRight",
+                            "=",
+                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Draw border",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Create an initialize shape painter",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SceneInstancesCount"
+                          },
+                          "parameters": [
+                            "",
+                            "ShapePainter",
+                            "<",
+                            "1"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "Create"
+                          },
+                          "parameters": [
+                            "",
+                            "ShapePainter",
+                            "0",
+                            "0",
+                            "GetArgumentAsString(\"Layer\")"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "=",
+                            "0"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::OutlineSize"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "=",
+                            "4"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::UseRelativeCoordinates"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "no"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::ClearBetweenFrames"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "yes"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": [],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "",
+                            "Variable(__EdgeScrollCamera.CameraTop)",
+                            "",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Shape painter",
+          "longDescription": "",
+          "name": "ShapePainter",
+          "optional": false,
+          "supplementaryInformation": "PrimitiveDrawing::Drawer",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePreEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "colorB": 224,
+          "colorG": 16,
+          "colorR": 189,
+          "creationTime": 0,
+          "name": "Edge Scroll Camera",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Enabled",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Prevent camera movement until cursor has move away from starting position",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "MouseX"
+                              },
+                              "parameters": [
+                                "",
+                                "!=",
+                                "0",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ],
+                              "subInstructions": []
+                            },
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "MouseY"
+                              },
+                              "parameters": [
+                                "",
+                                "!=",
+                                "0",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ],
+                              "subInstructions": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": [],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CursorMoved",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Cursor has moved  from starting position",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CursorMoved",
+                            "True"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Reset detections",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingUp",
+                                    "False"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingDown",
+                                    "False"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingLeft",
+                                    "False"
+                                  ],
+                                  "subInstructions": []
+                                },
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingRight",
+                                    "False"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Save camera borders as variables",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraTop",
+                                    "=",
+                                    "CameraY(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) - CameraHeight(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraBottom",
+                                    "=",
+                                    "CameraY(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) + CameraHeight(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraLeft",
+                                    "=",
+                                    "CameraX(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) - CameraWidth(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraRight",
+                                    "=",
+                                    "CameraX(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) + CameraWidth(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Detect Edge Scrolling",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Only move camera while mouse is inside game window",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "IsMouseInsideCanvas"
+                                  },
+                                  "parameters": [
+                                    ""
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "Up",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "MouseY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "<",
+                                        "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetSceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.MovingUp",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    },
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "ModVarScene"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.DistanceFromEdge",
+                                        "=",
+                                        "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "Down",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "MouseY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        ">",
+                                        "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetSceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.MovingDown",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    },
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "ModVarScene"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.DistanceFromEdge",
+                                        "=",
+                                        "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "Left",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "MouseX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "<",
+                                        "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetSceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.MovingLeft",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    },
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "ModVarScene"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.DistanceFromEdge",
+                                        "=",
+                                        "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "Right",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "MouseX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        ">",
+                                        "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetSceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.MovingRight",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    },
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "ModVarScene"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.DistanceFromEdge",
+                                        "=",
+                                        "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Calculate variable speed percentage",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.VariableSpeedEnabled",
+                                    "True"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.SpeedPercentage",
+                                    "=",
+                                    "1 - (Variable(__EdgeScrollCamera.DistanceFromEdge) / Variable(__EdgeScrollCamera.ScreenMargin))"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "events": []
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Move camera",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Up",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingUp",
+                                    "True"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": true,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "-",
+                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "-",
+                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Down",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingDown",
+                                    "True"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": true,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "+",
+                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraY"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "+",
+                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Left",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingLeft",
+                                    "True"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": true,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "-",
+                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "-",
+                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Right",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": false,
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingRight",
+                                    "True"
+                                  ],
+                                  "subInstructions": []
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": true,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "+",
+                                        "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SceneVariableAsBoolean"
+                                      },
+                                      "parameters": [
+                                        "__EdgeScrollCamera.VariableSpeedEnabled",
+                                        "True"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "inverted": false,
+                                        "value": "SetCameraX"
+                                      },
+                                      "parameters": [
+                                        "",
+                                        "+",
+                                        "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
+                                        "VariableString(__EdgeScrollCamera.Layer)",
+                                        "Variable(__EdgeScrollCamera.Camera)"
+                                      ],
+                                      "subInstructions": []
+                                    }
+                                  ],
+                                  "events": []
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": []
         }
       ],
       "parameters": [],

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) camera edge scrolling\" at the beginning of scene\n- Run the action \"Configure camera edge scrolling\" at the beginning of scene\n\nTips:\n- Progressive speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
+  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -18,7 +18,8 @@
     "pan"
   ],
   "authorIds": [
-    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -102,299 +103,143 @@
               "actions": [],
               "events": [
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Prevent camera movement until cursor has moved (cursor starts at 0,0 which triggers scrolling)",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Prevent camera movement until cursor has moved (cursor starts at 0,0 which triggers scrolling)",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
                         {
                           "type": {
-                            "value": "BuiltinCommonInstructions::Or"
+                            "value": "MouseX"
                           },
-                          "parameters": [],
-                          "subInstructions": [
-                            {
-                              "type": {
-                                "value": "MouseX"
-                              },
-                              "parameters": [
-                                "",
-                                "!=",
-                                "0",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MouseY"
-                              },
-                              "parameters": [
-                                "",
-                                "!=",
-                                "0",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
-                              ]
-                            }
+                          "parameters": [
+                            "",
+                            "!=",
+                            "0",
+                            "VariableString(__EdgeScrollCamera.Layer)",
+                            "Variable(__EdgeScrollCamera.Camera)"
                           ]
                         },
                         {
                           "type": {
-                            "value": "BuiltinCommonInstructions::Once"
-                          },
-                          "parameters": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SetSceneVariableAsBoolean"
+                            "value": "MouseY"
                           },
                           "parameters": [
-                            "__EdgeScrollCamera.CursorMoved",
-                            "True"
+                            "",
+                            "!=",
+                            "0",
+                            "VariableString(__EdgeScrollCamera.Layer)",
+                            "Variable(__EdgeScrollCamera.Camera)"
                           ]
                         }
                       ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": []
                     }
                   ],
-                  "parameters": []
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.CursorMoved",
+                        "True"
+                      ]
+                    }
+                  ]
                 },
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Cursor has moved  from starting position",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.CursorMoved",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.CurrentScrollSpeedX",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__EdgeScrollCamera.CurrentScrollSpeedY",
+                        "=",
+                        "0"
+                      ]
+                    }
+                  ],
                   "events": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "SceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CursorMoved",
-                            "True"
-                          ]
-                        }
-                      ],
-                      "actions": [],
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Detect edge scrolling",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Reset variables",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Only move camera while mouse is inside game window",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
                             {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingUp",
-                                    "False"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingDown",
-                                    "False"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingLeft",
-                                    "False"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingRight",
-                                    "False"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
-                                    "=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
-                                    "=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.DistanceFromEdgeX",
-                                    "=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.DistanceFromEdgeY",
-                                    "=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.SpeedPercentageX",
-                                    "=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.SpeedPercentageY",
-                                    "=",
-                                    "0"
-                                  ]
-                                }
+                              "type": {
+                                "value": "IsMouseInsideCanvas"
+                              },
+                              "parameters": [
+                                ""
                               ]
                             }
                           ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Save camera borders as variables",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraTop",
-                                    "=",
-                                    "CameraY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - CameraHeight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraBottom",
-                                    "=",
-                                    "CameraY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + CameraHeight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraLeft",
-                                    "=",
-                                    "CameraX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - CameraWidth(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraRight",
-                                    "=",
-                                    "CameraX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + CameraWidth(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
-                                  ]
-                                }
-                              ]
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Detect edge scrolling",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
+                          "actions": [],
                           "events": [
                             {
                               "type": "BuiltinCommonInstructions::Comment",
@@ -406,7 +251,7 @@
                                 "textG": 0,
                                 "textR": 0
                               },
-                              "comment": "Only move camera while mouse is inside game window",
+                              "comment": "Up",
                               "comment2": ""
                             },
                             {
@@ -414,663 +259,232 @@
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "IsMouseInsideCanvas"
+                                    "value": "MouseY"
                                   },
                                   "parameters": [
-                                    ""
+                                    "",
+                                    "<=",
+                                    "CameraBorderTop(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                    "VariableString(__EdgeScrollCamera.Layer)",
+                                    "Variable(__EdgeScrollCamera.Camera)"
                                   ]
                                 }
                               ],
-                              "actions": [],
-                              "events": [
+                              "actions": [
                                 {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Up",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "MouseY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "<",
-                                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingUp",
-                                            "True"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdgeY",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Down",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "MouseY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            ">",
-                                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingDown",
-                                            "True"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdgeY",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Left",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "MouseX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "<",
-                                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingLeft",
-                                            "True"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdgeX",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Right",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "MouseX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            ">",
-                                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingRight",
-                                            "True"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdgeX",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "parameters": []
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                    "=",
+                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderTop(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                  ]
                                 }
                               ]
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Perform edge scrolling",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Down",
+                              "comment2": ""
+                            },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "EdgeScrollCamera::IsCameraScrolling"
+                                    "value": "MouseY"
                                   },
                                   "parameters": [
                                     "",
-                                    ""
+                                    ">=",
+                                    "CameraBorderBottom(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                    "VariableString(__EdgeScrollCamera.Layer)",
+                                    "Variable(__EdgeScrollCamera.Camera)"
                                   ]
                                 }
                               ],
-                              "actions": [],
-                              "events": [
+                              "actions": [
                                 {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Calculate current scroll speed",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                                            "False"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [],
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "BuiltinCommonInstructions::Or"
-                                              },
-                                              "parameters": [],
-                                              "subInstructions": [
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                },
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.CurrentScrollSpeedX",
-                                                "=",
-                                                "Variable(__EdgeScrollCamera.ScrollSpeed)"
-                                              ]
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "BuiltinCommonInstructions::Or"
-                                              },
-                                              "parameters": [],
-                                              "subInstructions": [
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                },
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.CurrentScrollSpeedY",
-                                                "=",
-                                                "Variable(__EdgeScrollCamera.ScrollSpeed)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.ProgressiveSpeedEnabled",
-                                            "True"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [],
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "BuiltinCommonInstructions::Or"
-                                              },
-                                              "parameters": [],
-                                              "subInstructions": [
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                },
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.SpeedPercentageX",
-                                                "=",
-                                                "1 - (Variable(__EdgeScrollCamera.DistanceFromEdgeX) / Variable(__EdgeScrollCamera.ScreenMargin))"
-                                              ]
-                                            },
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.CurrentScrollSpeedX",
-                                                "=",
-                                                "Variable(__EdgeScrollCamera.SpeedPercentageX) * Variable(__EdgeScrollCamera.ScrollSpeed)"
-                                              ]
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "BuiltinCommonInstructions::Or"
-                                              },
-                                              "parameters": [],
-                                              "subInstructions": [
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                },
-                                                {
-                                                  "type": {
-                                                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
-                                                  },
-                                                  "parameters": [
-                                                    "",
-                                                    ""
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.SpeedPercentageY",
-                                                "=",
-                                                "1 - (Variable(__EdgeScrollCamera.DistanceFromEdgeY) / Variable(__EdgeScrollCamera.ScreenMargin))"
-                                              ]
-                                            },
-                                            {
-                                              "type": {
-                                                "value": "ModVarScene"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.CurrentScrollSpeedY",
-                                                "=",
-                                                "Variable(__EdgeScrollCamera.SpeedPercentageY) * Variable(__EdgeScrollCamera.ScrollSpeed)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                    "=",
+                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderBottom(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Left",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
                                 {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Move camera",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "colorB": 228,
-                                      "colorG": 176,
-                                      "colorR": 74,
-                                      "creationTime": 0,
-                                      "name": "Up",
-                                      "source": "",
-                                      "type": "BuiltinCommonInstructions::Group",
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "SceneVariableAsBoolean"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.MovingUp",
-                                                "True"
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "SetCameraY"
-                                              },
-                                              "parameters": [
-                                                "",
-                                                "-",
-                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
-                                                "VariableString(__EdgeScrollCamera.Layer)",
-                                                "Variable(__EdgeScrollCamera.Camera)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "parameters": []
-                                    },
-                                    {
-                                      "colorB": 228,
-                                      "colorG": 176,
-                                      "colorR": 74,
-                                      "creationTime": 0,
-                                      "name": "Down",
-                                      "source": "",
-                                      "type": "BuiltinCommonInstructions::Group",
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "SceneVariableAsBoolean"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.MovingDown",
-                                                "True"
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "SetCameraY"
-                                              },
-                                              "parameters": [
-                                                "",
-                                                "+",
-                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
-                                                "VariableString(__EdgeScrollCamera.Layer)",
-                                                "Variable(__EdgeScrollCamera.Camera)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "parameters": []
-                                    },
-                                    {
-                                      "colorB": 228,
-                                      "colorG": 176,
-                                      "colorR": 74,
-                                      "creationTime": 0,
-                                      "name": "Left",
-                                      "source": "",
-                                      "type": "BuiltinCommonInstructions::Group",
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "SceneVariableAsBoolean"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.MovingLeft",
-                                                "True"
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "SetCameraX"
-                                              },
-                                              "parameters": [
-                                                "",
-                                                "-",
-                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
-                                                "VariableString(__EdgeScrollCamera.Layer)",
-                                                "Variable(__EdgeScrollCamera.Camera)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "parameters": []
-                                    },
-                                    {
-                                      "colorB": 228,
-                                      "colorG": 176,
-                                      "colorR": 74,
-                                      "creationTime": 0,
-                                      "name": "Right",
-                                      "source": "",
-                                      "type": "BuiltinCommonInstructions::Group",
-                                      "events": [
-                                        {
-                                          "type": "BuiltinCommonInstructions::Standard",
-                                          "conditions": [
-                                            {
-                                              "type": {
-                                                "value": "SceneVariableAsBoolean"
-                                              },
-                                              "parameters": [
-                                                "__EdgeScrollCamera.MovingRight",
-                                                "True"
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "type": {
-                                                "value": "SetCameraX"
-                                              },
-                                              "parameters": [
-                                                "",
-                                                "+",
-                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
-                                                "VariableString(__EdgeScrollCamera.Layer)",
-                                                "Variable(__EdgeScrollCamera.Camera)"
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "parameters": []
-                                    }
-                                  ],
-                                  "parameters": []
+                                  "type": {
+                                    "value": "MouseX"
+                                  },
+                                  "parameters": [
+                                    "",
+                                    "<=",
+                                    "CameraBorderLeft(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                    "VariableString(__EdgeScrollCamera.Layer)",
+                                    "Variable(__EdgeScrollCamera.Camera)"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                    "=",
+                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderLeft(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Right",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MouseX"
+                                  },
+                                  "parameters": [
+                                    "",
+                                    ">=",
+                                    "CameraBorderRight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                    "VariableString(__EdgeScrollCamera.Layer)",
+                                    "Variable(__EdgeScrollCamera.Camera)"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                    "=",
+                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderRight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                  ]
                                 }
                               ]
                             }
-                          ],
-                          "parameters": []
+                          ]
                         }
-                      ]
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Perform edge scrolling",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "VarScene"
+                              },
+                              "parameters": [
+                                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                "!=",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraX"
+                              },
+                              "parameters": [
+                                "",
+                                "+",
+                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "VarScene"
+                              },
+                              "parameters": [
+                                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                "!=",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraY"
+                              },
+                              "parameters": [
+                                "",
+                                "+",
+                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
                     }
-                  ],
-                  "parameters": []
+                  ]
                 }
               ]
             }
@@ -1278,7 +692,7 @@
                   "parameters": [
                     "__EdgeScrollCamera.ScreenMargin",
                     "=",
-                    "GetArgumentAsNumber(\"ScreenMargin\")"
+                    "max(1, GetArgumentAsNumber(\"ScreenMargin\"))"
                   ]
                 }
               ]
@@ -1352,58 +766,39 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarScene"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
+                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                "=",
+                "0"
               ]
             },
             {
               "type": {
-                "value": "BuiltinCommonInstructions::Or"
+                "value": "VarScene"
               },
-              "parameters": [],
-              "subInstructions": [
-                {
-                  "type": {
-                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
-                  },
-                  "parameters": [
-                    "",
-                    ""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
-                  },
-                  "parameters": [
-                    "",
-                    ""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
-                  },
-                  "parameters": [
-                    "",
-                    ""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
-                  },
-                  "parameters": [
-                    "",
-                    ""
-                  ]
-                }
+              "parameters": [
+                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                "=",
+                "0"
               ]
             }
           ],
@@ -1413,7 +808,7 @@
                 "value": "SetReturnBoolean"
               },
               "parameters": [
-                "True"
+                "False"
               ]
             }
           ]
@@ -1436,20 +831,12 @@
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarScene"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
-              ]
-            },
-            {
-              "type": {
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__EdgeScrollCamera.MovingUp",
-                "True"
+                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                "<",
+                "0"
               ]
             }
           ],
@@ -1482,20 +869,12 @@
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarScene"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
-              ]
-            },
-            {
-              "type": {
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__EdgeScrollCamera.MovingDown",
-                "True"
+                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                ">",
+                "0"
               ]
             }
           ],
@@ -1528,20 +907,12 @@
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarScene"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
-              ]
-            },
-            {
-              "type": {
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__EdgeScrollCamera.MovingLeft",
-                "True"
+                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                "<",
+                "0"
               ]
             }
           ],
@@ -1574,20 +945,12 @@
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "VarScene"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
-              ]
-            },
-            {
-              "type": {
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__EdgeScrollCamera.MovingRight",
-                "True"
+                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                ">",
+                "0"
               ]
             }
           ],
@@ -1620,7 +983,7 @@
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "name": "Draw Edge Scrolling",
+          "name": "Draw edge scrolling border",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
@@ -1644,70 +1007,126 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "name": "Save camera borders as variables",
+                  "name": "Create and initialize shape painter",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
                       "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
+                      "conditions": [
                         {
                           "type": {
-                            "value": "ModVarScene"
+                            "value": "BuiltinCommonInstructions::Once"
                           },
-                          "parameters": [
-                            "__EdgeScrollCamera.CameraTop",
-                            "=",
-                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
-                          ]
+                          "parameters": []
                         }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
+                      ],
+                      "actions": [],
+                      "events": [
                         {
-                          "type": {
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CameraBottom",
-                            "=",
-                            "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneInstancesCount"
+                              },
+                              "parameters": [
+                                "",
+                                "ShapePainter",
+                                "<",
+                                "1"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "Create"
+                              },
+                              "parameters": [
+                                "",
+                                "ShapePainter",
+                                "0",
+                                "0",
+                                "GetArgumentAsString(\"Layer\")"
+                              ]
+                            }
                           ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
+                        },
                         {
-                          "type": {
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CameraLeft",
-                            "=",
-                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "ShapePainter",
+                                "!=",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "ShapePainter",
+                                "=",
+                                "0"
+                              ]
+                            }
                           ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
+                        },
                         {
-                          "type": {
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CameraRight",
-                            "=",
-                            "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::AreCoordinatesRelative"
+                              },
+                              "parameters": [
+                                "ShapePainter"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::UseRelativeCoordinates"
+                              },
+                              "parameters": [
+                                "ShapePainter",
+                                "no"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "PrimitiveDrawing::ClearBetweenFrames"
+                              },
+                              "parameters": [
+                                "ShapePainter"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::ClearBetweenFrames"
+                              },
+                              "parameters": [
+                                "ShapePainter",
+                                "yes"
+                              ]
+                            }
                           ]
                         }
                       ]
@@ -1725,77 +1144,6 @@
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Create an initialize shape painter",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "SceneInstancesCount"
-                          },
-                          "parameters": [
-                            "",
-                            "ShapePainter",
-                            "<",
-                            "1"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "Create"
-                          },
-                          "parameters": [
-                            "",
-                            "ShapePainter",
-                            "0",
-                            "0",
-                            "GetArgumentAsString(\"Layer\")"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "PrimitiveDrawing::FillOpacity"
-                          },
-                          "parameters": [
-                            "ShapePainter",
-                            "=",
-                            "0"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "PrimitiveDrawing::UseRelativeCoordinates"
-                          },
-                          "parameters": [
-                            "ShapePainter",
-                            "no"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "PrimitiveDrawing::ClearBetweenFrames"
-                          },
-                          "parameters": [
-                            "ShapePainter",
-                            "yes"
-                          ]
-                        }
-                      ]
-                    },
-                    {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
@@ -1805,10 +1153,10 @@
                           },
                           "parameters": [
                             "ShapePainter",
-                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)"
+                            "CameraBorderLeft(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "CameraBorderTop(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "CameraBorderRight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                            "CameraBorderBottom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - Variable(__EdgeScrollCamera.ScreenMargin)"
                           ]
                         }
                       ]
@@ -1898,6 +1246,109 @@
         }
       ],
       "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Return the absolute scroll speed according to the mouse distance from the border.",
+      "fullName": "Absolute scroll speed",
+      "functionType": "Expression",
+      "group": "",
+      "name": "AbsoluteScrollSpeed",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__EdgeScrollCamera.ProgressiveSpeedEnabled",
+                "True"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "(1 - abs(GetArgumentAsNumber(\"BorderDistance\")) / Variable(__EdgeScrollCamera.ScreenMargin)) * Variable(__EdgeScrollCamera.ScrollSpeed)"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "The camera borders can have rounding errors, make sure the max speed can be reached.",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Or"
+              },
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.ProgressiveSpeedEnabled",
+                    "False"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "abs(GetArgumentAsNumber(\"BorderDistance\"))",
+                    "<=",
+                    "1"
+                  ]
+                }
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__EdgeScrollCamera.ScrollSpeed)"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Border distance",
+          "longDescription": "",
+          "name": "BorderDistance",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
       "objectGroups": []
     }
   ],

--- a/Extensions/EdgeScrollCamera.json
+++ b/Extensions/EdgeScrollCamera.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "General",
-  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move",
+  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -22,6 +22,1065 @@
   ],
   "dependencies": [],
   "eventsFunctions": [
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onSceneLoaded",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Set default values",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "EdgeScrollCamera::ConfigureEdgeScrollCamera"
+              },
+              "parameters": [
+                "",
+                "32",
+                "300",
+                "\"\"",
+                "0",
+                "yes",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePreEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "colorB": 224,
+          "colorG": 16,
+          "colorR": 189,
+          "creationTime": 0,
+          "name": "Edge Scroll Camera",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__EdgeScrollCamera.Enabled",
+                    "True"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Prevent camera movement until cursor has move away from starting position",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "MouseX"
+                              },
+                              "parameters": [
+                                "",
+                                "!=",
+                                "0",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MouseY"
+                              },
+                              "parameters": [
+                                "",
+                                "!=",
+                                "0",
+                                "VariableString(__EdgeScrollCamera.Layer)",
+                                "Variable(__EdgeScrollCamera.Camera)"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CursorMoved",
+                            "True"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Cursor has moved  from starting position",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__EdgeScrollCamera.CursorMoved",
+                            "True"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Reset variables",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingUp",
+                                    "False"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingDown",
+                                    "False"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingLeft",
+                                    "False"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "SetSceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.MovingRight",
+                                    "False"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                    "=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                    "=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.DistanceFromEdgeX",
+                                    "=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.DistanceFromEdgeY",
+                                    "=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.SpeedPercentageX",
+                                    "=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.SpeedPercentageY",
+                                    "=",
+                                    "0"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Save camera borders as variables",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraTop",
+                                    "=",
+                                    "CameraY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - CameraHeight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraBottom",
+                                    "=",
+                                    "CameraY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + CameraHeight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraLeft",
+                                    "=",
+                                    "CameraX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - CameraWidth(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "ModVarScene"
+                                  },
+                                  "parameters": [
+                                    "__EdgeScrollCamera.CameraRight",
+                                    "=",
+                                    "CameraX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + CameraWidth(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera))/2"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Detect edge scrolling",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Only move camera while mouse is inside game window",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "IsMouseInsideCanvas"
+                                  },
+                                  "parameters": [
+                                    ""
+                                  ]
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Up",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "<",
+                                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingUp",
+                                            "True"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdgeY",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Down",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseY"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            ">",
+                                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingDown",
+                                            "True"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdgeY",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Left",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "<",
+                                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingLeft",
+                                            "True"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdgeX",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Right",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseX"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            ">",
+                                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
+                                            "VariableString(__EdgeScrollCamera.Layer)",
+                                            "Variable(__EdgeScrollCamera.Camera)"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "SetSceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.MovingRight",
+                                            "True"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "ModVarScene"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.DistanceFromEdgeX",
+                                            "=",
+                                            "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        },
+                        {
+                          "colorB": 228,
+                          "colorG": 176,
+                          "colorR": 74,
+                          "creationTime": 0,
+                          "name": "Perform edge scrolling",
+                          "source": "",
+                          "type": "BuiltinCommonInstructions::Group",
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "EdgeScrollCamera::IsCameraScrolling"
+                                  },
+                                  "parameters": [
+                                    "",
+                                    ""
+                                  ]
+                                }
+                              ],
+                              "actions": [],
+                              "events": [
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Calculate current scroll speed",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "False"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [],
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "BuiltinCommonInstructions::Or"
+                                              },
+                                              "parameters": [],
+                                              "subInstructions": [
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                },
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                                "=",
+                                                "Variable(__EdgeScrollCamera.ScrollSpeed)"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "BuiltinCommonInstructions::Or"
+                                              },
+                                              "parameters": [],
+                                              "subInstructions": [
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                },
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                                "=",
+                                                "Variable(__EdgeScrollCamera.ScrollSpeed)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [
+                                        {
+                                          "type": {
+                                            "value": "SceneVariableAsBoolean"
+                                          },
+                                          "parameters": [
+                                            "__EdgeScrollCamera.VariableSpeedEnabled",
+                                            "True"
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [],
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "BuiltinCommonInstructions::Or"
+                                              },
+                                              "parameters": [],
+                                              "subInstructions": [
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingLeft"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                },
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingRight"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.SpeedPercentageX",
+                                                "=",
+                                                "1 - (Variable(__EdgeScrollCamera.DistanceFromEdgeX) / Variable(__EdgeScrollCamera.ScreenMargin))"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                                "=",
+                                                "Variable(__EdgeScrollCamera.SpeedPercentageX) * Variable(__EdgeScrollCamera.ScrollSpeed)"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "BuiltinCommonInstructions::Or"
+                                              },
+                                              "parameters": [],
+                                              "subInstructions": [
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingUp"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                },
+                                                {
+                                                  "type": {
+                                                    "value": "EdgeScrollCamera::IsCameraScrollingDown"
+                                                  },
+                                                  "parameters": [
+                                                    "",
+                                                    ""
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.SpeedPercentageY",
+                                                "=",
+                                                "1 - (Variable(__EdgeScrollCamera.DistanceFromEdgeY) / Variable(__EdgeScrollCamera.ScreenMargin))"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "ModVarScene"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                                "=",
+                                                "Variable(__EdgeScrollCamera.SpeedPercentageY) * Variable(__EdgeScrollCamera.ScrollSpeed)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Move camera",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Up",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "SceneVariableAsBoolean"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.MovingUp",
+                                                "True"
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SetCameraY"
+                                              },
+                                              "parameters": [
+                                                "",
+                                                "-",
+                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
+                                                "VariableString(__EdgeScrollCamera.Layer)",
+                                                "Variable(__EdgeScrollCamera.Camera)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    },
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Down",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "SceneVariableAsBoolean"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.MovingDown",
+                                                "True"
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SetCameraY"
+                                              },
+                                              "parameters": [
+                                                "",
+                                                "+",
+                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
+                                                "VariableString(__EdgeScrollCamera.Layer)",
+                                                "Variable(__EdgeScrollCamera.Camera)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    },
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Left",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "SceneVariableAsBoolean"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.MovingLeft",
+                                                "True"
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SetCameraX"
+                                              },
+                                              "parameters": [
+                                                "",
+                                                "-",
+                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
+                                                "VariableString(__EdgeScrollCamera.Layer)",
+                                                "Variable(__EdgeScrollCamera.Camera)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    },
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Right",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [
+                                            {
+                                              "type": {
+                                                "value": "SceneVariableAsBoolean"
+                                              },
+                                              "parameters": [
+                                                "__EdgeScrollCamera.MovingRight",
+                                                "True"
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SetCameraX"
+                                              },
+                                              "parameters": [
+                                                "",
+                                                "+",
+                                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
+                                                "VariableString(__EdgeScrollCamera.Layer)",
+                                                "Variable(__EdgeScrollCamera.Camera)"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    }
+                                  ],
+                                  "parameters": []
+                                }
+                              ]
+                            }
+                          ],
+                          "parameters": []
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
     {
       "description": "Enable (or disable) edge scrolling camera.  Use \"Configure edge scrolling camera\" to adjust settings.",
       "fullName": "Enable (or disable) edge scrolling camera",
@@ -46,32 +1105,18 @@
         },
         {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": true,
-                "value": "GetArgumentAsBoolean"
-              },
-              "parameters": [
-                "\"EnableEdgeScrolling\""
-              ],
-              "subInstructions": []
-            }
-          ],
+          "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "False"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
           "type": "BuiltinCommonInstructions::Comment",
@@ -91,39 +1136,34 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "GetArgumentAsBoolean"
               },
               "parameters": [
                 "\"EnableEdgeScrolling\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
         {
           "codeOnly": false,
-          "defaultValue": "",
+          "defaultValue": "yes",
           "description": "Enable edge scrolling camera?",
           "longDescription": "",
           "name": "EnableEdgeScrolling",
-          "optional": false,
+          "optional": true,
           "supplementaryInformation": "",
           "type": "yesorno"
         }
@@ -137,14 +1177,14 @@
       "group": "",
       "name": "ConfigureEdgeScrollCamera",
       "private": false,
-      "sentence": "Configure edge scrolling camera on layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, use variable speed? _PARAM5_ ",
+      "sentence": "Configure edge scrolling camera on layer _PARAM3_, screen margin _PARAM1_, scroll speed _PARAM2_, use variable speed? _PARAM5_ ",
       "events": [
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "name": "Save values to use in pre-events lifecycle function",
+          "name": "Save values to use in the pre-events lifecycle function",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
@@ -158,53 +1198,44 @@
                   },
                   "parameters": [
                     "\"VariableSpeed\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetSceneVariableAsBoolean"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.VariableSpeedEnabled",
                     "False"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"VariableSpeed\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetSceneVariableAsBoolean"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.VariableSpeedEnabled",
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -212,75 +1243,45 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.Layer",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                  ]
+                },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.Camera",
                     "=",
                     "GetArgumentAsNumber(\"Camera\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                  ]
+                },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.ScrollSpeed",
                     "=",
                     "GetArgumentAsNumber(\"ScrollSpeed\")"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                  ]
+                },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.ScreenMargin",
                     "=",
                     "GetArgumentAsNumber(\"ScreenMargin\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": []
@@ -342,7 +1343,7 @@
     },
     {
       "description": "Check if the camera is scrolling.",
-      "fullName": "Is camera scrolling?",
+      "fullName": "Camera is scrolling",
       "functionType": "Condition",
       "group": "",
       "name": "IsCameraScrolling",
@@ -354,65 +1355,54 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::Or"
               },
               "parameters": [],
               "subInstructions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "EdgeScrollCamera::IsCameraScrollingUp"
                   },
                   "parameters": [
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "EdgeScrollCamera::IsCameraScrollingDown"
                   },
                   "parameters": [
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "EdgeScrollCamera::IsCameraScrollingLeft"
                   },
                   "parameters": [
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "EdgeScrollCamera::IsCameraScrollingRight"
                   },
                   "parameters": [
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ]
             }
@@ -420,16 +1410,13 @@
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -437,7 +1424,7 @@
     },
     {
       "description": "Check if the camera is scrolling up.",
-      "fullName": "Is camera scrolling up?",
+      "fullName": "Camera is scrolling up",
       "functionType": "Condition",
       "group": "",
       "name": "IsCameraScrollingUp",
@@ -449,40 +1436,33 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.MovingUp",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -490,7 +1470,7 @@
     },
     {
       "description": "Check if the camera is scrolling down.",
-      "fullName": "Is camera scrolling down?",
+      "fullName": "Camera is scrolling down",
       "functionType": "Condition",
       "group": "",
       "name": "IsCameraScrollingDown",
@@ -502,40 +1482,33 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.MovingDown",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -543,7 +1516,7 @@
     },
     {
       "description": "Check if the camera is scrolling left.",
-      "fullName": "Is camera scrolling left?",
+      "fullName": "Camera is scrolling left",
       "functionType": "Condition",
       "group": "",
       "name": "IsCameraScrollingLeft",
@@ -555,40 +1528,33 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.MovingLeft",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -596,7 +1562,7 @@
     },
     {
       "description": "Check if the camera is scrolling right.",
-      "fullName": "Is camera scrolling right?",
+      "fullName": "Camera is scrolling right",
       "functionType": "Condition",
       "group": "",
       "name": "IsCameraScrollingRight",
@@ -608,40 +1574,33 @@
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.Enabled",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__EdgeScrollCamera.MovingRight",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -670,14 +1629,12 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
                     "__EdgeScrollCamera.Enabled",
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
@@ -697,18 +1654,15 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarScene"
                           },
                           "parameters": [
                             "__EdgeScrollCamera.CameraTop",
                             "=",
                             "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -716,18 +1670,15 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarScene"
                           },
                           "parameters": [
                             "__EdgeScrollCamera.CameraBottom",
                             "=",
                             "CameraY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraHeight(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -735,18 +1686,15 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarScene"
                           },
                           "parameters": [
                             "__EdgeScrollCamera.CameraLeft",
                             "=",
                             "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) - CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -754,18 +1702,15 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarScene"
                           },
                           "parameters": [
                             "__EdgeScrollCamera.CameraRight",
                             "=",
                             "CameraX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")) + CameraWidth(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))/2"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -797,7 +1742,6 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SceneInstancesCount"
                           },
                           "parameters": [
@@ -805,14 +1749,12 @@
                             "ShapePainter",
                             "<",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Create"
                           },
                           "parameters": [
@@ -821,45 +1763,37 @@
                             "0",
                             "0",
                             "GetArgumentAsString(\"Layer\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::FillOpacity"
                           },
                           "parameters": [
                             "ShapePainter",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::UseRelativeCoordinates"
                           },
                           "parameters": [
                             "ShapePainter",
                             "no"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::ClearBetweenFrames"
                           },
                           "parameters": [
                             "ShapePainter",
                             "yes"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -867,7 +1801,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::Rectangle"
                           },
                           "parameters": [
@@ -876,11 +1809,9 @@
                             "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
                             "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
                             "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -916,1016 +1847,54 @@
       "objectGroups": []
     },
     {
-      "description": "",
-      "fullName": "",
-      "functionType": "Action",
+      "description": "Speed the camera is currently scrolling in horizontal direction (in pixels per second)",
+      "fullName": "Current edge scroll speed (horizontal)",
+      "functionType": "Expression",
       "group": "",
-      "name": "onScenePreEvents",
+      "name": "EdgeScrollSpeedX",
       "private": false,
       "sentence": "",
       "events": [
         {
-          "colorB": 224,
-          "colorG": 16,
-          "colorR": 189,
-          "creationTime": 0,
-          "name": "Edge Scroll Camera",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Enabled",
-                    "True"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Prevent camera movement until cursor has move away from starting position",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "BuiltinCommonInstructions::Or"
-                          },
-                          "parameters": [],
-                          "subInstructions": [
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "MouseX"
-                              },
-                              "parameters": [
-                                "",
-                                "!=",
-                                "0",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
-                              ],
-                              "subInstructions": []
-                            },
-                            {
-                              "type": {
-                                "inverted": false,
-                                "value": "MouseY"
-                              },
-                              "parameters": [
-                                "",
-                                "!=",
-                                "0",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
-                              ],
-                              "subInstructions": []
-                            }
-                          ]
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "BuiltinCommonInstructions::Once"
-                          },
-                          "parameters": [],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CursorMoved",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Cursor has moved  from starting position",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__EdgeScrollCamera.CursorMoved",
-                            "True"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Reset detections",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingUp",
-                                    "False"
-                                  ],
-                                  "subInstructions": []
-                                },
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingDown",
-                                    "False"
-                                  ],
-                                  "subInstructions": []
-                                },
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingLeft",
-                                    "False"
-                                  ],
-                                  "subInstructions": []
-                                },
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SetSceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.MovingRight",
-                                    "False"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Save camera borders as variables",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraTop",
-                                    "=",
-                                    "CameraY(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) - CameraHeight(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraBottom",
-                                    "=",
-                                    "CameraY(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) + CameraHeight(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraLeft",
-                                    "=",
-                                    "CameraX(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) - CameraWidth(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.CameraRight",
-                                    "=",
-                                    "CameraX(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera)) + CameraWidth(VariableString(__EdgeScrollCamera.Layer),Variable(__EdgeScrollCamera.Camera))/2"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Detect Edge Scrolling",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Only move camera while mouse is inside game window",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "IsMouseInsideCanvas"
-                                  },
-                                  "parameters": [
-                                    ""
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "actions": [],
-                              "events": [
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Up",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "MouseY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "<",
-                                            "Variable(__EdgeScrollCamera.CameraTop) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingUp",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        },
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdge",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraTop) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Down",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "MouseY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            ">",
-                                            "Variable(__EdgeScrollCamera.CameraBottom) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingDown",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        },
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdge",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraBottom) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Left",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "MouseX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "<",
-                                            "Variable(__EdgeScrollCamera.CameraLeft) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingLeft",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        },
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdge",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraLeft) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ],
-                                  "parameters": []
-                                },
-                                {
-                                  "colorB": 228,
-                                  "colorG": 176,
-                                  "colorR": 74,
-                                  "creationTime": 0,
-                                  "name": "Right",
-                                  "source": "",
-                                  "type": "BuiltinCommonInstructions::Group",
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "MouseX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            ">",
-                                            "Variable(__EdgeScrollCamera.CameraRight) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetSceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.MovingRight",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        },
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "ModVarScene"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.DistanceFromEdge",
-                                            "=",
-                                            "abs(Variable(__EdgeScrollCamera.CameraRight) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ],
-                                  "parameters": []
-                                }
-                              ]
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Calculate variable speed percentage",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "SceneVariableAsBoolean"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.VariableSpeedEnabled",
-                                    "True"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "inverted": false,
-                                    "value": "ModVarScene"
-                                  },
-                                  "parameters": [
-                                    "__EdgeScrollCamera.SpeedPercentage",
-                                    "=",
-                                    "1 - (Variable(__EdgeScrollCamera.DistanceFromEdge) / Variable(__EdgeScrollCamera.ScreenMargin))"
-                                  ],
-                                  "subInstructions": []
-                                }
-                              ],
-                              "events": []
-                            }
-                          ],
-                          "parameters": []
-                        },
-                        {
-                          "colorB": 228,
-                          "colorG": 176,
-                          "colorR": 74,
-                          "creationTime": 0,
-                          "name": "Move camera",
-                          "source": "",
-                          "type": "BuiltinCommonInstructions::Group",
-                          "events": [
-                            {
-                              "colorB": 228,
-                              "colorG": 176,
-                              "colorR": 74,
-                              "creationTime": 0,
-                              "name": "Up",
-                              "source": "",
-                              "type": "BuiltinCommonInstructions::Group",
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingUp",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": true,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "-",
-                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "-",
-                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              "parameters": []
-                            },
-                            {
-                              "colorB": 228,
-                              "colorG": 176,
-                              "colorR": 74,
-                              "creationTime": 0,
-                              "name": "Down",
-                              "source": "",
-                              "type": "BuiltinCommonInstructions::Group",
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingDown",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": true,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "+",
-                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraY"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "+",
-                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              "parameters": []
-                            },
-                            {
-                              "colorB": 228,
-                              "colorG": 176,
-                              "colorR": 74,
-                              "creationTime": 0,
-                              "name": "Left",
-                              "source": "",
-                              "type": "BuiltinCommonInstructions::Group",
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingLeft",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": true,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "-",
-                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "-",
-                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              "parameters": []
-                            },
-                            {
-                              "colorB": 228,
-                              "colorG": 176,
-                              "colorR": 74,
-                              "creationTime": 0,
-                              "name": "Right",
-                              "source": "",
-                              "type": "BuiltinCommonInstructions::Group",
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "inverted": false,
-                                        "value": "SceneVariableAsBoolean"
-                                      },
-                                      "parameters": [
-                                        "__EdgeScrollCamera.MovingRight",
-                                        "True"
-                                      ],
-                                      "subInstructions": []
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": true,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "+",
-                                            "Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SceneVariableAsBoolean"
-                                          },
-                                          "parameters": [
-                                            "__EdgeScrollCamera.VariableSpeedEnabled",
-                                            "True"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "inverted": false,
-                                            "value": "SetCameraX"
-                                          },
-                                          "parameters": [
-                                            "",
-                                            "+",
-                                            "Variable(__EdgeScrollCamera.SpeedPercentage) * Variable(__EdgeScrollCamera.ScrollSpeed) * TimeDelta()",
-                                            "VariableString(__EdgeScrollCamera.Layer)",
-                                            "Variable(__EdgeScrollCamera.Camera)"
-                                          ],
-                                          "subInstructions": []
-                                        }
-                                      ],
-                                      "events": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              "parameters": []
-                            }
-                          ],
-                          "parameters": []
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                }
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX)"
               ]
             }
-          ],
-          "parameters": []
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Speed the camera is currently scrolling in vertical direction (in pixels per second)",
+      "fullName": "Current edge scroll speed (vertical)",
+      "functionType": "Expression",
+      "group": "",
+      "name": "EdgeScrollSpeedY",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY)"
+              ]
+            }
+          ]
         }
       ],
       "parameters": [],


### PR DESCRIPTION
Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.

How to use:
- Run the action "Enable (or disable) edge camera scrolling" at the beginning of scene
- Run the action "Configure edge camera scrolling" at the beginning of scene

Tips:
- Variable speed makes the camera scroll faster the closer the cursor gets to the edge of screen
- Use the action "Enable (or disable) edge camera scrolling" to turn the scrolling ON or OFF
- Use the action "Enforce camera boundaries" to restrict what the player can see
- Use the extension "Copy camera settings" if you want multiple layers to move

## Playable demo

~https://liluo.io/games/d29e90cd-058c-42ef-bc00-819361146082~

## Project files

~[EdgeScrollCamera_Extension.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/8367173/EdgeScrollCamera_Extension.zip)~

## Video

https://user-images.githubusercontent.com/8879811/160510078-aeb49e5f-834d-4637-a3ce-3a315275c4b3.mp4


