### PR TITLE
New extension: CloneCamera - Copy the camera settings of a layer and apply them to another layer

### DIFF
--- a/Extensions/CloneCamera.json
+++ b/Extensions/CloneCamera.json
@@ -1,0 +1,257 @@
+{
+  "author": "",
+  "category": "General",
+  "description": "Useful when multiple layers need to use the same camera values.\n\nHow to use:\n- Run the \"Clone camera settings\" action after all other camera actions have been performed\n\nTips:\n- Do not use on layers that implement a parallax effect",
+  "extensionNamespace": "",
+  "fullName": "Clone camera",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNhbWVyYS1lbmhhbmNlIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTksM0w3LjE3LDVINEEyLDIgMCAwLDAgMiw3VjE5QTIsMiAwIDAsMCA0LDIxSDIwQTIsMiAwIDAsMCAyMiwxOVY3QTIsMiAwIDAsMCAyMCw1SDE2LjgzTDE1LDNNMTIsMThBNSw1IDAgMCwxIDcsMTNBNSw1IDAgMCwxIDEyLDhBNSw1IDAgMCwxIDE3LDEzQTUsNSAwIDAsMSAxMiwxOE0xMiwxN0wxMy4yNSwxNC4yNUwxNiwxM0wxMy4yNSwxMS43NUwxMiw5TDEwLjc1LDExLjc1TDgsMTNMMTAuNzUsMTQuMjUiIC8+PC9zdmc+",
+  "name": "CloneCamera",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-enhance.svg",
+  "shortDescription": "Copy the camera settings of a layer and apply them to another layer.",
+  "version": "1.0.0",
+  "tags": [
+    "camera",
+    "clone",
+    "zoom",
+    "position",
+    "layer",
+    "angle"
+  ],
+  "authorIds": [
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Copy camera settings of a layer and apply them to another layer.",
+      "fullName": "Clone camera",
+      "functionType": "Action",
+      "group": "",
+      "name": "CloneCamera",
+      "private": false,
+      "sentence": "Copy camera settings of _PARAM1_ layer and apply them to _PARAM3_ layer",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"CloneX\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetCameraX"
+              },
+              "parameters": [
+                "",
+                "=",
+                "CameraX(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                "GetArgumentAsString(\"DestinationLayer\")",
+                "GetArgumentAsNumber(\"DestinationCamera\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"CloneY\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetCameraY"
+              },
+              "parameters": [
+                "",
+                "=",
+                "CameraY(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                "GetArgumentAsString(\"DestinationLayer\")",
+                "GetArgumentAsNumber(\"DestinationCamera\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"CloneZoom\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ZoomCamera"
+              },
+              "parameters": [
+                "",
+                "CameraZoom(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                "GetArgumentAsString(\"DestinationLayer\")",
+                "GetArgumentAsNumber(\"DestinationCamera\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"CloneAngle\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetCameraAngle"
+              },
+              "parameters": [
+                "",
+                "=",
+                "CameraAngle(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                "GetArgumentAsString(\"DestinationLayer\")",
+                "GetArgumentAsNumber(\"DestinationCamera\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Source layer",
+          "longDescription": "",
+          "name": "SourceLayer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Source camera",
+          "longDescription": "",
+          "name": "SourceCamera",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Destination layer",
+          "longDescription": "",
+          "name": "DestinationLayer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Destination camera",
+          "longDescription": "",
+          "name": "DestinationCamera",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Clone X position",
+          "longDescription": "",
+          "name": "CloneX",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Clone Y position",
+          "longDescription": "",
+          "name": "CloneY",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Clone zoom",
+          "longDescription": "",
+          "name": "CloneZoom",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Clone angle",
+          "longDescription": "",
+          "name": "CloneAngle",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/Extensions/CopyCameraSettings.json
+++ b/Extensions/CopyCameraSettings.json
@@ -1,13 +1,13 @@
 {
   "author": "",
-  "category": "General",
-  "description": "Useful when multiple layers need to use the same camera values.\n\nHow to use:\n- Run the \"Clone camera settings\" action after all other camera actions have been performed\n\nTips:\n- Do not use on layers that implement a parallax effect",
+  "category": "",
+  "description": "Useful when multiple layers need to use the same camera values.\n\nHow to use:\n- Run the \"Copy camera settings\" action after all other camera actions have been performed\n\nTips:\n- Do not use on layers that implement a parallax effect",
   "extensionNamespace": "",
-  "fullName": "Clone camera",
+  "fullName": "Copy camera settings",
   "helpPath": "",
-  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNhbWVyYS1lbmhhbmNlIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTksM0w3LjE3LDVINEEyLDIgMCAwLDAgMiw3VjE5QTIsMiAwIDAsMCA0LDIxSDIwQTIsMiAwIDAsMCAyMiwxOVY3QTIsMiAwIDAsMCAyMCw1SDE2LjgzTDE1LDNNMTIsMThBNSw1IDAgMCwxIDcsMTNBNSw1IDAgMCwxIDEyLDhBNSw1IDAgMCwxIDE3LDEzQTUsNSAwIDAsMSAxMiwxOE0xMiwxN0wxMy4yNSwxNC4yNUwxNiwxM0wxMy4yNSwxMS43NUwxMiw5TDEwLjc1LDExLjc1TDgsMTNMMTAuNzUsMTQuMjUiIC8+PC9zdmc+",
-  "name": "CloneCamera",
-  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-enhance.svg",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWxheWVycy10cmlwbGUtb3V0bGluZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xMiAxNi41NEwxOS4zNyAxMC44TDIxIDEyLjA3TDEyIDE5LjA3TDMgMTIuMDdMNC42MiAxMC44MUwxMiAxNi41NE0xMiAxNEwzIDdMMTIgMEwyMSA3TDEyIDE0TTEyIDIuNTNMNi4yNiA3TDEyIDExLjQ3TDE3Ljc0IDdMMTIgMi41M00xMiAyMS40N0wxOS4zNyAxNS43M0wyMSAxN0wxMiAyNEwzIDE3TDQuNjIgMTUuNzRMMTIgMjEuNDciIC8+PC9zdmc+",
+  "name": "CopyCameraSettings",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/layers-triple-outline.svg",
   "shortDescription": "Copy the camera settings of a layer and apply them to another layer.",
   "version": "1.0.0",
   "tags": [
@@ -16,7 +16,8 @@
     "zoom",
     "position",
     "layer",
-    "angle"
+    "angle",
+    "copy"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
@@ -25,12 +26,12 @@
   "eventsFunctions": [
     {
       "description": "Copy camera settings of a layer and apply them to another layer.",
-      "fullName": "Clone camera",
+      "fullName": "Copy camera settings",
       "functionType": "Action",
       "group": "",
-      "name": "CloneCamera",
+      "name": "CopyCameraSettings",
       "private": false,
-      "sentence": "Copy camera settings of _PARAM1_ layer and apply them to _PARAM3_ layer",
+      "sentence": "Copy camera settings of _PARAM1_ layer and apply them to _PARAM3_ layer (X position: _PARAM5_, Y position: _PARAM6_, Zoom: _PARAM7_,  Angle: _PARAM8_)",
       "events": [
         {
           "disabled": false,


### PR DESCRIPTION
Useful when multiple layers need to use the same camera values.

How to use:
- Run the "Clone camera settings" action after all other camera actions have been performed

Tips:
- Do not use on layers that implement a parallax effect

## Playable game

https://liluo.io/games/1e988edc-a480-42c9-a6b4-b6454fb2454a

## Project file

[CloneCamera.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/8393393/CloneCamera.zip)

## Video

https://user-images.githubusercontent.com/8879811/161161165-8342e1d3-cf29-46ee-b69e-71011d29aa7b.mp4





