### PR TITLE
[ScreenShaking] Multi-layer, noise based shaking, scrolling-compatible.

### DIFF
--- a/extensions/reviewed/CameraShake.json
+++ b/extensions/reviewed/CameraShake.json
@@ -1,10 +1,10 @@
 {
   "author": "westboy31, Tristan Rhodes (https://victrisgames.itch.io/)",
   "category": "",
-  "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitly to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth",
+  "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitely to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth\n\nRelease notes:\n- Version 3.0.0\n  - No adaptation of the game events is needed.\n  - It fixes an issue when used with scrolling, the amplitude will feel bigger in this case.\n  - The shaking relies on noise which could feel a bit different.",
   "extensionNamespace": "",
   "fullName": "Camera shake",
-  "helpPath": "https://victrisgames.itch.io/gdevelop-camera-shake-example",
+  "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXZlY3Rvci1kaWZmZXJlbmNlLWFiIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTMsMUMxLjg5LDEgMSwxLjg5IDEsM1Y1SDNWM0g1VjFIM003LDFWM0gxMFYxSDdNMTIsMVYzSDE0VjVIMTZWM0MxNiwxLjg5IDE1LjExLDEgMTQsMUgxMk0xLDdWMTBIM1Y3SDFNMTQsN0MxNCw3IDE0LDExLjY3IDE0LDE0QzExLjY3LDE0IDcsMTQgNywxNEM3LDE0IDcsMTggNywyMEM3LDIxLjExIDcuODksMjIgOSwyMkgyMEMyMS4xMSwyMiAyMiwyMS4xMSAyMiwyMFY5QzIyLDcuODkgMjEuMTEsNyAyMCw3QzE4LDcgMTQsNyAxNCw3TTE2LDlIMjBWMjBIOVYxNkgxNEMxNS4xMSwxNiAxNiwxNS4xMSAxNiwxNFY5TTEsMTJWMTRDMSwxNS4xMSAxLjg5LDE2IDMsMTZINVYxNEgzVjEySDFaIiAvPjwvc3ZnPg==",
   "name": "CameraShake",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-difference-ab.svg",
@@ -117,7 +117,7 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "This variable is needed because the time will shift before next onScenePreEvents call.",
+          "comment": "Step time counters.",
           "comment2": ""
         },
         {
@@ -126,11 +126,12 @@
           "actions": [
             {
               "type": {
-                "value": "SetSceneVariableAsBoolean"
+                "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_NeedToRevertCameraChanges",
-                "False"
+                "__CameraShake.Time",
+                "+",
+                "TimeDelta()"
               ]
             }
           ]
@@ -151,19 +152,10 @@
           "actions": [
             {
               "type": {
-                "value": "SetSceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__CameraShake_NeedToRevertCameraChanges",
-                "True"
-              ]
-            },
-            {
-              "type": {
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_EaseFactor",
+                "__CameraShake.EaseFactor",
                 "=",
                 "1"
               ]
@@ -175,25 +167,23 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareTimer"
+                    "value": "VarScene"
                   },
                   "parameters": [
-                    "",
-                    "\"__CameraShake_DurationTimer\"",
+                    "__CameraShake.Time",
                     "<",
-                    "Variable(__CameraShake_StartEaseDuration)"
+                    "Variable(__CameraShake.StartEaseDuration)"
                   ]
                 },
                 {
                   "type": {
                     "inverted": true,
-                    "value": "CompareTimer"
+                    "value": "VarScene"
                   },
                   "parameters": [
-                    "",
-                    "\"__CameraShake_DurationTimer\"",
+                    "__CameraShake.Time",
                     ">",
-                    "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
+                    "Variable(__CameraShake.Duration) - Variable(__CameraShake.StopEaseDuration)"
                   ]
                 }
               ],
@@ -203,9 +193,9 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_EaseFactor",
+                    "__CameraShake.EaseFactor",
                     "=",
-                    "clamp(0, 1, TimerElapsedTime(\"__CameraShake_DurationTimer\") / Variable(__CameraShake_StartEaseDuration))"
+                    "clamp(0, 1, Variable(__CameraShake.Time) / Variable(__CameraShake.StartEaseDuration))"
                   ]
                 }
               ]
@@ -215,13 +205,12 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareTimer"
+                    "value": "VarScene"
                   },
                   "parameters": [
-                    "",
-                    "\"__CameraShake_DurationTimer\"",
+                    "__CameraShake.Time",
                     ">",
-                    "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
+                    "Variable(__CameraShake.Duration) - Variable(__CameraShake.StopEaseDuration)"
                   ]
                 }
               ],
@@ -231,25 +220,25 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_EaseFactor",
+                    "__CameraShake.EaseFactor",
                     "=",
-                    "clamp(0, 1, (Variable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / Variable(__CameraShake_StopEaseDuration))"
+                    "clamp(0, 1, (Variable(__CameraShake.Duration) - Variable(__CameraShake.Time)) / Variable(__CameraShake.StopEaseDuration))"
                   ]
                 }
               ]
             },
             {
               "type": "BuiltinCommonInstructions::ForEachChildVariable",
-              "iterableVariableName": "__CameraShake_Layers",
-              "valueIteratorVariableName": "__CameraShake_Layer",
-              "keyIteratorVariableName": "__CameraShake_LayerName",
+              "iterableVariableName": "__CameraShake.Layers",
+              "valueIteratorVariableName": "__CameraShake.Layer",
+              "keyIteratorVariableName": "__CameraShake.LayerName",
               "conditions": [
                 {
                   "type": {
                     "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                    "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].Shakable",
                     "True"
                   ]
                 }
@@ -265,9 +254,9 @@
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_ActualLayerName",
+                        "__CameraShake.ActualLayerName",
                         "=",
-                        "VariableString(__CameraShake_LayerName)"
+                        "VariableString(__CameraShake.LayerName)"
                       ]
                     }
                   ]
@@ -280,7 +269,7 @@
                         "value": "VarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_LayerName",
+                        "__CameraShake.LayerName",
                         "=",
                         "\"__BaseLayer\""
                       ]
@@ -292,7 +281,7 @@
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_ActualLayerName",
+                        "__CameraShake.ActualLayerName",
                         "=",
                         "\"\""
                       ]
@@ -322,7 +311,7 @@
                       },
                       "parameters": [
                         "",
-                        "Variable(__CameraShake_DefaultFrequency)",
+                        "Variable(__CameraShake.DefaultFrequency)",
                         "\"\"",
                         ""
                       ]
@@ -332,9 +321,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeX",
+                        "__CameraShake.AmplitudeX",
                         "=",
-                        "Variable(__CameraShake_DefaultAmplitudeX)"
+                        "Variable(__CameraShake.DefaultAmplitudeX)"
                       ]
                     },
                     {
@@ -342,9 +331,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeY",
+                        "__CameraShake.AmplitudeY",
                         "=",
-                        "Variable(__CameraShake_DefaultAmplitudeY)"
+                        "Variable(__CameraShake.DefaultAmplitudeY)"
                       ]
                     },
                     {
@@ -352,9 +341,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeAngle",
+                        "__CameraShake.AmplitudeAngle",
                         "=",
-                        "Variable(__CameraShake_DefaultAmplitudeAngle)"
+                        "Variable(__CameraShake.DefaultAmplitudeAngle)"
                       ]
                     },
                     {
@@ -362,9 +351,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeZoom",
+                        "__CameraShake.AmplitudeZoom",
                         "=",
-                        "Variable(__CameraShake_DefaultAmplitudeZoom)"
+                        "Variable(__CameraShake.DefaultAmplitudeZoom)"
                       ]
                     }
                   ]
@@ -377,7 +366,7 @@
                         "value": "VariableChildExists"
                       },
                       "parameters": [
-                        "__CameraShake_Layer",
+                        "__CameraShake.Layer",
                         "\"Frequency\""
                       ]
                     }
@@ -389,7 +378,7 @@
                       },
                       "parameters": [
                         "",
-                        "Variable(__CameraShake_Layer.Frequency)",
+                        "Variable(__CameraShake.Layer.Frequency)",
                         "\"\"",
                         ""
                       ]
@@ -404,7 +393,7 @@
                         "value": "VariableChildExists"
                       },
                       "parameters": [
-                        "__CameraShake_Layer",
+                        "__CameraShake.Layer",
                         "\"AmplitudeX\""
                       ]
                     }
@@ -415,9 +404,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeX",
+                        "__CameraShake.AmplitudeX",
                         "=",
-                        "Variable(__CameraShake_Layer.AmplitudeX)"
+                        "Variable(__CameraShake.Layer.AmplitudeX)"
                       ]
                     }
                   ]
@@ -430,7 +419,7 @@
                         "value": "VariableChildExists"
                       },
                       "parameters": [
-                        "__CameraShake_Layer",
+                        "__CameraShake.Layer",
                         "\"AmplitudeY\""
                       ]
                     }
@@ -441,9 +430,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeY",
+                        "__CameraShake.AmplitudeY",
                         "=",
-                        "Variable(__CameraShake_Layer.AmplitudeY)"
+                        "Variable(__CameraShake.Layer.AmplitudeY)"
                       ]
                     }
                   ]
@@ -456,7 +445,7 @@
                         "value": "VariableChildExists"
                       },
                       "parameters": [
-                        "__CameraShake_Layer",
+                        "__CameraShake.Layer",
                         "\"AmplitudeAngle\""
                       ]
                     }
@@ -467,9 +456,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeAngle",
+                        "__CameraShake.AmplitudeAngle",
                         "=",
-                        "Variable(__CameraShake_Layer.AmplitudeAngle)"
+                        "Variable(__CameraShake.Layer.AmplitudeAngle)"
                       ]
                     }
                   ]
@@ -482,7 +471,7 @@
                         "value": "VariableChildExists"
                       },
                       "parameters": [
-                        "__CameraShake_Layer",
+                        "__CameraShake.Layer",
                         "\"AmplitudeZoom\""
                       ]
                     }
@@ -493,9 +482,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeZoom",
+                        "__CameraShake.AmplitudeZoom",
                         "=",
-                        "Variable(__CameraShake_Layer.AmplitudeZoom)"
+                        "Variable(__CameraShake.Layer.AmplitudeZoom)"
                       ]
                     }
                   ]
@@ -510,7 +499,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Shake the layer camera.",
+                  "comment": "Shake the layer camera.\nSave the camera displacement to revert it in onScenePostEvents.",
                   "comment2": ""
                 },
                 {
@@ -521,7 +510,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeX",
+                        "__CameraShake.AmplitudeX",
                         "!=",
                         "0"
                       ]
@@ -533,9 +522,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX",
+                        "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaX",
                         "=",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 1000) * Variable(__CameraShake_AmplitudeX) * Variable(__CameraShake_EaseFactor)"
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 1000) * Variable(__CameraShake.AmplitudeX) * Variable(__CameraShake.EaseFactor)"
                       ]
                     },
                     {
@@ -545,8 +534,8 @@
                       "parameters": [
                         "",
                         "+",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaX)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -560,7 +549,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeY",
+                        "__CameraShake.AmplitudeY",
                         "!=",
                         "0"
                       ]
@@ -572,9 +561,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY",
+                        "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaY",
                         "=",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 2000) * Variable(__CameraShake_AmplitudeY) * Variable(__CameraShake_EaseFactor)"
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 2000) * Variable(__CameraShake.AmplitudeY) * Variable(__CameraShake.EaseFactor)"
                       ]
                     },
                     {
@@ -584,8 +573,8 @@
                       "parameters": [
                         "",
                         "+",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaY)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -599,7 +588,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeAngle",
+                        "__CameraShake.AmplitudeAngle",
                         "!=",
                         "0"
                       ]
@@ -611,9 +600,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle",
+                        "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaAngle",
                         "=",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 3000) * Variable(__CameraShake_AmplitudeAngle) * Variable(__CameraShake_EaseFactor)"
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 3000) * Variable(__CameraShake.AmplitudeAngle) * Variable(__CameraShake.EaseFactor)"
                       ]
                     },
                     {
@@ -623,8 +612,8 @@
                       "parameters": [
                         "",
                         "+",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaAngle)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -638,7 +627,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeZoom",
+                        "__CameraShake.AmplitudeZoom",
                         "!=",
                         "1"
                       ]
@@ -650,9 +639,9 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom",
+                        "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaZoom",
                         "=",
-                        "pow(Variable(__CameraShake_AmplitudeZoom), CameraShake::Noise2d(\"\", TimeFromStart(), 4000) * Variable(__CameraShake_EaseFactor))"
+                        "pow(Variable(__CameraShake.AmplitudeZoom), CameraShake::Noise2d(\"\", TimeFromStart(), 4000) * Variable(__CameraShake.EaseFactor))"
                       ]
                     },
                     {
@@ -661,8 +650,8 @@
                       },
                       "parameters": [
                         "",
-                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) * Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "CameraZoom(VariableString(__CameraShake.ActualLayerName), 0) * Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaZoom)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -703,11 +692,11 @@
           "conditions": [
             {
               "type": {
-                "value": "SceneVariableAsBoolean"
+                "value": "CameraShake::IsShaking"
               },
               "parameters": [
-                "__CameraShake_NeedToRevertCameraChanges",
-                "True"
+                "",
+                ""
               ]
             }
           ],
@@ -715,16 +704,16 @@
           "events": [
             {
               "type": "BuiltinCommonInstructions::ForEachChildVariable",
-              "iterableVariableName": "__CameraShake_Layers",
-              "valueIteratorVariableName": "__CameraShake_Layer",
-              "keyIteratorVariableName": "__CameraShake_LayerName",
+              "iterableVariableName": "__CameraShake.Layers",
+              "valueIteratorVariableName": "__CameraShake.Layer",
+              "keyIteratorVariableName": "__CameraShake.LayerName",
               "conditions": [
                 {
                   "type": {
                     "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                    "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].Shakable",
                     "True"
                   ]
                 }
@@ -740,9 +729,9 @@
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_ActualLayerName",
+                        "__CameraShake.ActualLayerName",
                         "=",
-                        "VariableString(__CameraShake_LayerName)"
+                        "VariableString(__CameraShake.LayerName)"
                       ]
                     }
                   ]
@@ -755,7 +744,7 @@
                         "value": "VarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_LayerName",
+                        "__CameraShake.LayerName",
                         "=",
                         "\"__BaseLayer\""
                       ]
@@ -767,7 +756,7 @@
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
-                        "__CameraShake_ActualLayerName",
+                        "__CameraShake.ActualLayerName",
                         "=",
                         "\"\""
                       ]
@@ -782,7 +771,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeX",
+                        "__CameraShake.AmplitudeX",
                         "!=",
                         "0"
                       ]
@@ -796,8 +785,8 @@
                       "parameters": [
                         "",
                         "-",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaX)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -811,7 +800,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeY",
+                        "__CameraShake.AmplitudeY",
                         "!=",
                         "0"
                       ]
@@ -825,8 +814,8 @@
                       "parameters": [
                         "",
                         "-",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaY)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -840,7 +829,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeAngle",
+                        "__CameraShake.AmplitudeAngle",
                         "!=",
                         "0"
                       ]
@@ -854,8 +843,8 @@
                       "parameters": [
                         "",
                         "-",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaAngle)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -869,7 +858,7 @@
                         "value": "VarScene"
                       },
                       "parameters": [
-                        "__CameraShake_AmplitudeZoom",
+                        "__CameraShake.AmplitudeZoom",
                         "!=",
                         "1"
                       ]
@@ -882,8 +871,8 @@
                       },
                       "parameters": [
                         "",
-                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) / Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom)",
-                        "VariableString(__CameraShake_ActualLayerName)",
+                        "CameraZoom(VariableString(__CameraShake.ActualLayerName), 0) / Variable(__CameraShake.Layers[VariableString(__CameraShake.LayerName)].CameraDeltaZoom)",
+                        "VariableString(__CameraShake.ActualLayerName)",
                         "0"
                       ]
                     }
@@ -1033,11 +1022,12 @@
           "actions": [
             {
               "type": {
-                "value": "ResetTimer"
+                "value": "ModVarScene"
               },
               "parameters": [
-                "",
-                "\"__CameraShake_DurationTimer\""
+                "__CameraShake.Time",
+                "=",
+                "0"
               ]
             },
             {
@@ -1045,7 +1035,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Duration",
+                "__CameraShake.Duration",
                 "=",
                 "GetArgumentAsNumber(\"Duration\")"
               ]
@@ -1055,7 +1045,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StartEaseDuration",
+                "__CameraShake.StartEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StartEaseDuration\")"
               ]
@@ -1065,7 +1055,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StopEaseDuration",
+                "__CameraShake.StopEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StopEaseDuration\")"
               ]
@@ -1080,9 +1070,9 @@
                 "value": "VarScene"
               },
               "parameters": [
-                "__CameraShake_Duration",
+                "__CameraShake.Duration",
                 "<",
-                "Variable(__CameraShake_StartEaseDuration) + Variable(__CameraShake_StopEaseDuration)"
+                "Variable(__CameraShake.StartEaseDuration) + Variable(__CameraShake.StopEaseDuration)"
               ]
             }
           ],
@@ -1092,9 +1082,9 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StartEaseDuration",
+                "__CameraShake.StartEaseDuration",
                 "=",
-                "GetArgumentAsNumber(\"StartEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
+                "GetArgumentAsNumber(\"StartEaseDuration\") * Variable(__CameraShake.Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
               ]
             },
             {
@@ -1102,9 +1092,9 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StopEaseDuration",
+                "__CameraShake.StopEaseDuration",
                 "=",
-                "GetArgumentAsNumber(\"StopEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
+                "GetArgumentAsNumber(\"StopEaseDuration\") * Variable(__CameraShake.Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
               ]
             }
           ]
@@ -1292,7 +1282,7 @@
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
-                    "__CameraShake_LayerName",
+                    "__CameraShake.LayerName",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
                   ]
@@ -1329,7 +1319,7 @@
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
-                    "__CameraShake_LayerName",
+                    "__CameraShake.LayerName",
                     "=",
                     "\"__BaseLayer\""
                   ]
@@ -1345,7 +1335,7 @@
                     "value": "VariableClearChildren"
                   },
                   "parameters": [
-                    "__CameraShake_Layers"
+                    "__CameraShake.Layers"
                   ]
                 },
                 {
@@ -1355,7 +1345,7 @@
                   "parameters": [
                     "",
                     "",
-                    "VariableString(__CameraShake_LayerName)",
+                    "VariableString(__CameraShake.LayerName)",
                     ""
                   ]
                 }
@@ -1371,7 +1361,7 @@
                   },
                   "parameters": [
                     "",
-                    "\"__CameraShake_DurationTimer\""
+                    "\"__CameraShake.DurationTimer\""
                   ]
                 },
                 {
@@ -1379,7 +1369,7 @@
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
-                    "__CameraShake_Layer",
+                    "__CameraShake.Layer",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
                   ]
@@ -1389,7 +1379,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_Duration",
+                    "__CameraShake.Duration",
                     "=",
                     "GetArgumentAsNumber(\"Duration\")"
                   ]
@@ -1399,7 +1389,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_StartEaseDuration",
+                    "__CameraShake.StartEaseDuration",
                     "=",
                     "0"
                   ]
@@ -1409,7 +1399,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_StopEaseDuration",
+                    "__CameraShake.StopEaseDuration",
                     "=",
                     "GetArgumentAsNumber(\"Duration\")"
                   ]
@@ -1419,7 +1409,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_DefaultAmplitudeX",
+                    "__CameraShake.DefaultAmplitudeX",
                     "=",
                     "abs(GetArgumentAsNumber(\"AmplitudeX\"))"
                   ]
@@ -1429,7 +1419,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_DefaultAmplitudeY",
+                    "__CameraShake.DefaultAmplitudeY",
                     "=",
                     "abs(GetArgumentAsNumber(\"AmplitudeY\"))"
                   ]
@@ -1439,7 +1429,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_DefaultAmplitudeAngle",
+                    "__CameraShake.DefaultAmplitudeAngle",
                     "=",
                     "GetArgumentAsNumber(\"AmplitudeAngle\")"
                   ]
@@ -1449,7 +1439,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_DefaultAmplitudeZoom",
+                    "__CameraShake.DefaultAmplitudeZoom",
                     "=",
                     "1 + GetArgumentAsNumber(\"AmplitudeZoom\") / 100"
                   ]
@@ -1476,7 +1466,7 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_DefaultFrequency",
+                        "__CameraShake.DefaultFrequency",
                         "=",
                         "1 / GetArgumentAsNumber(\"ShakePeriod\")"
                       ]
@@ -1503,7 +1493,7 @@
                         "value": "ModVarScene"
                       },
                       "parameters": [
-                        "__CameraShake_DefaultFrequency",
+                        "__CameraShake.DefaultFrequency",
                         "=",
                         "1 / 0.08"
                       ]
@@ -1543,7 +1533,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_Duration",
+                    "__CameraShake.Duration",
                     "=",
                     "1234567890"
                   ]
@@ -1571,7 +1561,7 @@
                     "value": "VarScene"
                   },
                   "parameters": [
-                    "__CameraShake_Duration",
+                    "__CameraShake.Duration",
                     "=",
                     "0"
                   ]
@@ -1583,7 +1573,7 @@
                     "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_Duration",
+                    "__CameraShake.Duration",
                     "=",
                     "0.5"
                   ]
@@ -1668,7 +1658,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Periode between shakes (in seconds) (Default: 0.08)",
+          "description": "Period between shakes (in seconds) (Default: 0.08)",
           "longDescription": "",
           "name": "ShakePeriod",
           "optional": false,
@@ -1689,7 +1679,7 @@
       "objectGroups": []
     },
     {
-      "description": "Start shaking the camera undefinitly.",
+      "description": "Start shaking the camera indefinitely.",
       "fullName": "Start camera shaking",
       "functionType": "Action",
       "group": "",
@@ -1703,11 +1693,12 @@
           "actions": [
             {
               "type": {
-                "value": "ResetTimer"
+                "value": "ModVarScene"
               },
               "parameters": [
-                "",
-                "\"__CameraShake_DurationTimer\""
+                "__CameraShake.Time",
+                "=",
+                "0"
               ]
             },
             {
@@ -1715,7 +1706,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Duration",
+                "__CameraShake.Duration",
                 "=",
                 "1234567890"
               ]
@@ -1725,7 +1716,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StartEaseDuration",
+                "__CameraShake.StartEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
               ]
@@ -1762,11 +1753,12 @@
           "actions": [
             {
               "type": {
-                "value": "ResetTimer"
+                "value": "ModVarScene"
               },
               "parameters": [
-                "",
-                "\"__CameraShake_DurationTimer\""
+                "__CameraShake.Time",
+                "=",
+                "0"
               ]
             },
             {
@@ -1774,7 +1766,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Duration",
+                "__CameraShake.Duration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
               ]
@@ -1784,7 +1776,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_StopEaseDuration",
+                "__CameraShake.StopEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
               ]
@@ -1824,7 +1816,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
               ]
@@ -1851,7 +1843,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "\"__BaseLayer\""
               ]
@@ -1877,7 +1869,7 @@
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].Shakable",
                 "="
               ]
             }
@@ -1901,7 +1893,7 @@
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].Shakable",
                 "True"
               ]
             }
@@ -1946,13 +1938,12 @@
           "conditions": [
             {
               "type": {
-                "value": "CompareTimer"
+                "value": "VarScene"
               },
               "parameters": [
-                "",
-                "\"__CameraShake_DurationTimer\"",
+                "__CameraShake.Time",
                 "<",
-                "Variable(__CameraShake_Duration)"
+                "Variable(__CameraShake.Duration)"
               ]
             }
           ],
@@ -1989,7 +1980,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
               ]
@@ -2016,7 +2007,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "\"__BaseLayer\""
               ]
@@ -2032,7 +2023,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeX",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].AmplitudeX",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeX\")"
               ]
@@ -2042,7 +2033,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeY",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].AmplitudeY",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeY\")"
               ]
@@ -2102,7 +2093,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
               ]
@@ -2129,7 +2120,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "\"__BaseLayer\""
               ]
@@ -2145,7 +2136,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeAngle",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].AmplitudeAngle",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeAngle\")"
               ]
@@ -2195,7 +2186,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
               ]
@@ -2222,7 +2213,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "\"__BaseLayer\""
               ]
@@ -2238,7 +2229,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeZoom",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].AmplitudeZoom",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeZoom\")"
               ]
@@ -2288,7 +2279,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
               ]
@@ -2315,7 +2306,7 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_LayerName",
+                "__CameraShake.LayerName",
                 "=",
                 "\"__BaseLayer\""
               ]
@@ -2331,7 +2322,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Frequency",
+                "__CameraShake.Layers[VariableString(__CameraShake.LayerName)].Frequency",
                 "=",
                 "GetArgumentAsNumber(\"Frequency\")"
               ]
@@ -2381,7 +2372,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_DefaultAmplitudeX",
+                "__CameraShake.DefaultAmplitudeX",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeX\")"
               ]
@@ -2391,7 +2382,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_DefaultAmplitudeY",
+                "__CameraShake.DefaultAmplitudeY",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeY\")"
               ]
@@ -2441,7 +2432,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_DefaultAmplitudeAngle",
+                "__CameraShake.DefaultAmplitudeAngle",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeAngle\")"
               ]
@@ -2481,7 +2472,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_DefaultAmplitudeZoom",
+                "__CameraShake.DefaultAmplitudeZoom",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeZoom\")"
               ]
@@ -2521,7 +2512,7 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__CameraShake_DefaultFrequency",
+                "__CameraShake.DefaultFrequency",
                 "=",
                 "GetArgumentAsNumber(\"Frequency\")"
               ]
@@ -2778,7 +2769,7 @@
       "objectGroups": []
     },
     {
-      "description": "Delete a noise generators and loose its settings.",
+      "description": "Delete a noise generator and loose its settings.",
       "fullName": "Delete a noise generator",
       "functionType": "Action",
       "group": "",

--- a/extensions/reviewed/CameraShake.json
+++ b/extensions/reviewed/CameraShake.json
@@ -1,5 +1,5 @@
 {
-  "author": "Add00",
+  "author": "westboy31, Tristan Rhodes (https://victrisgames.itch.io/)",
   "category": "",
   "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitly to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth",
   "extensionNamespace": "",
@@ -9,7 +9,7 @@
   "name": "CameraShake",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-difference-ab.svg",
   "shortDescription": "Shake layer cameras with translation, rotation and zoom.",
-  "version": "2.6.5",
+  "version": "3.0.0",
   "tags": [
     "shaking",
     "camera",
@@ -22,7 +22,8 @@
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
-    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2",
+    "m4hBMBTUilft4s1V4FQQPakVDGx1"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -36,14 +37,11 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetLayerShakable"
               },
               "parameters": [
@@ -51,24 +49,20 @@
                 "",
                 "\"\"",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultShakingFrequency"
               },
               "parameters": [
                 "",
                 "12",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultTranslationAmplitude"
               },
               "parameters": [
@@ -76,44 +70,29 @@
                 "4",
                 "4",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultRotationAmplitude"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultZoomAmplitude"
               },
               "parameters": [
                 "",
                 "1",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "// It Avoids conflicts with other extensions that also use the camera.\n// If something changes in the engine it will no longer do anything.\nif (runtimeScene._updateObjectsPreEvents\n    && gdjs\n    && gdjs.evtsExt__CameraShake__onScenePreEvents\n    && gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks\n    && gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks.length\n    && gdjs.callbacksRuntimeScenePreEvents) {\n\n    // Force preEvent execution before behavior ones.\n    if (!runtimeScene.__camerShake_hasAlreadyAddHook) {\n        runtimeScene.__camerShake_hasAlreadyAddHook = true;\n        const superUpdateObjectsPreEvents = runtimeScene._updateObjectsPreEvents.bind(runtimeScene);\n        runtimeScene._updateObjectsPreEvents = function () {\n            gdjs.evtsExt__CameraShake__onScenePreEvents.func(runtimeScene, runtimeScene);\n            superUpdateObjectsPreEvents();\n        }\n    }\n\n    // Avoid to run preEvent a second time.\n    const callback = gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks[gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks.length - 1];\n    const callBackIndex = gdjs.callbacksRuntimeScenePreEvents.indexOf(callback);\n    if (callBackIndex >= 0) {\n        gdjs.callbacksRuntimeScenePreEvents.splice(callBackIndex, 1);\n    }\n}",
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": true
+          ]
         }
       ],
       "parameters": [],
@@ -129,8 +108,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -144,76 +121,60 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__CameraShake_NeedToRevertCameraChanges",
                 "False"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::IsShaking"
               },
               "parameters": [
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__CameraShake_NeedToRevertCameraChanges",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_EaseFactor",
                 "=",
                 "1"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "CompareTimer"
                   },
                   "parameters": [
@@ -221,8 +182,7 @@
                     "\"__CameraShake_DurationTimer\"",
                     "<",
                     "Variable(__CameraShake_StartEaseDuration)"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
@@ -234,34 +194,27 @@
                     "\"__CameraShake_DurationTimer\"",
                     ">",
                     "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_EaseFactor",
                     "=",
                     "clamp(0, 1, TimerElapsedTime(\"__CameraShake_DurationTimer\") / Variable(__CameraShake_StartEaseDuration))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "CompareTimer"
                   },
                   "parameters": [
@@ -269,29 +222,23 @@
                     "\"__CameraShake_DurationTimer\"",
                     ">",
                     "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_EaseFactor",
                     "=",
                     "clamp(0, 1, (Variable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / Variable(__CameraShake_StopEaseDuration))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::ForEachChildVariable",
               "iterableVariableName": "__CameraShake_Layers",
               "valueIteratorVariableName": "__CameraShake_Layer",
@@ -299,148 +246,60 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
                     "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_ActualLayerName",
                         "=",
                         "VariableString(__CameraShake_LayerName)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_LayerName",
                         "=",
                         "\"__BaseLayer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_ActualLayerName",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Save the layer camera position.",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraX",
-                        "=",
-                        "CameraX(VariableString(__CameraShake_ActualLayerName), 0)"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraY",
-                        "=",
-                        "CameraY(VariableString(__CameraShake_ActualLayerName), 0)"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraAngle",
-                        "=",
-                        "CameraAngle(VariableString(__CameraShake_ActualLayerName), 0)"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraZoom",
-                        "=",
-                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0)"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -454,14 +313,11 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraShake::SetFrequency"
                       },
                       "parameters": [
@@ -469,81 +325,66 @@
                         "Variable(__CameraShake_DefaultFrequency)",
                         "\"\"",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeX",
                         "=",
                         "Variable(__CameraShake_DefaultAmplitudeX)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeY",
                         "=",
                         "Variable(__CameraShake_DefaultAmplitudeY)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeAngle",
                         "=",
                         "Variable(__CameraShake_DefaultAmplitudeAngle)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeZoom",
                         "=",
                         "Variable(__CameraShake_DefaultAmplitudeZoom)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VariableChildExists"
                       },
                       "parameters": [
                         "__CameraShake_Layer",
                         "\"Frequency\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraShake::SetFrequency"
                       },
                       "parameters": [
@@ -551,147 +392,115 @@
                         "Variable(__CameraShake_Layer.Frequency)",
                         "\"\"",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VariableChildExists"
                       },
                       "parameters": [
                         "__CameraShake_Layer",
                         "\"AmplitudeX\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeX",
                         "=",
                         "Variable(__CameraShake_Layer.AmplitudeX)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VariableChildExists"
                       },
                       "parameters": [
                         "__CameraShake_Layer",
                         "\"AmplitudeY\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeY",
                         "=",
                         "Variable(__CameraShake_Layer.AmplitudeY)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VariableChildExists"
                       },
                       "parameters": [
                         "__CameraShake_Layer",
                         "\"AmplitudeAngle\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeAngle",
                         "=",
                         "Variable(__CameraShake_Layer.AmplitudeAngle)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VariableChildExists"
                       },
                       "parameters": [
                         "__CameraShake_Layer",
                         "\"AmplitudeZoom\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeZoom",
                         "=",
                         "Variable(__CameraShake_Layer.AmplitudeZoom)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -705,147 +514,159 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeX",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX",
+                        "=",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 1000) * Variable(__CameraShake_AmplitudeX) * Variable(__CameraShake_EaseFactor)"
+                      ]
+                    },
+                    {
+                      "type": {
                         "value": "SetCameraX"
                       },
                       "parameters": [
                         "",
                         "+",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 1000) * Variable(__CameraShake_AmplitudeX) * Variable(__CameraShake_EaseFactor)",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeY",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY",
+                        "=",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 2000) * Variable(__CameraShake_AmplitudeY) * Variable(__CameraShake_EaseFactor)"
+                      ]
+                    },
+                    {
+                      "type": {
                         "value": "SetCameraY"
                       },
                       "parameters": [
                         "",
                         "+",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 2000) * Variable(__CameraShake_AmplitudeY) * Variable(__CameraShake_EaseFactor)",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeAngle",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle",
+                        "=",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 3000) * Variable(__CameraShake_AmplitudeAngle) * Variable(__CameraShake_EaseFactor)"
+                      ]
+                    },
+                    {
+                      "type": {
                         "value": "RotateCamera"
                       },
                       "parameters": [
                         "",
                         "+",
-                        "CameraShake::Noise2d(\"\", TimeFromStart(), 3000) * Variable(__CameraShake_AmplitudeAngle) * Variable(__CameraShake_EaseFactor)",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarScene"
                       },
                       "parameters": [
                         "__CameraShake_AmplitudeZoom",
                         "!=",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom",
+                        "=",
+                        "pow(Variable(__CameraShake_AmplitudeZoom), CameraShake::Noise2d(\"\", TimeFromStart(), 4000) * Variable(__CameraShake_EaseFactor))"
+                      ]
+                    },
+                    {
+                      "type": {
                         "value": "ZoomCamera"
                       },
                       "parameters": [
                         "",
-                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) * pow(Variable(__CameraShake_AmplitudeZoom), CameraShake::Noise2d(\"\", TimeFromStart(), 4000) * Variable(__CameraShake_EaseFactor))",
+                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) * Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -865,27 +686,34 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Revert the shaking.",
+          "comment2": ""
+        },
+        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SceneVariableAsBoolean"
               },
               "parameters": [
                 "__CameraShake_NeedToRevertCameraChanges",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [],
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::ForEachChildVariable",
               "iterableVariableName": "__CameraShake_Layers",
               "valueIteratorVariableName": "__CameraShake_Layer",
@@ -893,136 +721,173 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
                     "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_ActualLayerName",
                         "=",
                         "VariableString(__CameraShake_LayerName)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_LayerName",
                         "=",
                         "\"__BaseLayer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarSceneTxt"
                       },
                       "parameters": [
                         "__CameraShake_ActualLayerName",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeX",
+                        "!=",
+                        "0"
+                      ]
+                    }
+                  ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraX"
                       },
                       "parameters": [
                         "",
-                        "=",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraX)",
+                        "-",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaX)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
-                    },
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeY",
+                        "!=",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
                         "value": "SetCameraY"
                       },
                       "parameters": [
                         "",
-                        "=",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraY)",
+                        "-",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaY)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
-                    },
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "SetCameraAngle"
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeAngle",
+                        "!=",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "RotateCamera"
                       },
                       "parameters": [
                         "",
-                        "=",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraAngle)",
+                        "-",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaAngle)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
-                    },
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeZoom",
+                        "!=",
+                        "1"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
                         "value": "ZoomCamera"
                       },
                       "parameters": [
                         "",
-                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraZoom)",
+                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) / Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].CameraDeltaZoom)",
                         "VariableString(__CameraShake_ActualLayerName)",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -1042,8 +907,6 @@
       "sentence": "Shake camera for _PARAM1_ seconds with _PARAM2_ seconds of easing to start and _PARAM3_ seconds to stop",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -1057,8 +920,6 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -1068,37 +929,31 @@
               },
               "parameters": [
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::IsShaking"
               },
               "parameters": [
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "test",
                 "=",
                 "CameraShake::Noise2d(\"\", 0, 0)"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetLayerShakable"
               },
               "parameters": [
@@ -1106,24 +961,20 @@
                 "no",
                 "\"\"",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultShakingFrequency"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultTranslationAmplitude"
               },
               "parameters": [
@@ -1131,36 +982,30 @@
                 "0",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultRotationAmplitude"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultZoomAmplitude"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetFrequency"
               },
               "parameters": [
@@ -1168,125 +1013,101 @@
                 "0",
                 "\"\"",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "DebuggerTools::ConsoleLog"
               },
               "parameters": [
                 "\"\"",
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ResetTimer"
               },
               "parameters": [
                 "",
                 "\"__CameraShake_DurationTimer\""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Duration",
                 "=",
                 "GetArgumentAsNumber(\"Duration\")"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StartEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StartEaseDuration\")"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StopEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StopEaseDuration\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "VarScene"
               },
               "parameters": [
                 "__CameraShake_Duration",
                 "<",
                 "Variable(__CameraShake_StartEaseDuration) + Variable(__CameraShake_StopEaseDuration)"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StartEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StartEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StopEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"StopEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -1333,8 +1154,6 @@
       "sentence": "Shake camera on _PARAM3_ layer for _PARAM5_ seconds. Use an amplitude of _PARAM1_px on X axis and _PARAM2_px on Y axis, angle rotation amplitude _PARAM6_ degrees, and zoom amplitude _PARAM7_ percent.  Wait _PARAM8_ seconds between shakes. Keep shaking until stopped: _PARAM9_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -1348,8 +1167,6 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -1359,37 +1176,31 @@
               },
               "parameters": [
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::IsShaking"
               },
               "parameters": [
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "test",
                 "=",
                 "CameraShake::Noise2d(\"\", 0, 0)"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetLayerShakable"
               },
               "parameters": [
@@ -1397,24 +1208,20 @@
                 "no",
                 "\"\"",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultShakingFrequency"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultTranslationAmplitude"
               },
               "parameters": [
@@ -1422,36 +1229,30 @@
                 "0",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultRotationAmplitude"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetDefaultZoomAmplitude"
               },
               "parameters": [
                 "",
                 "0",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "CameraShake::SetFrequency"
               },
               "parameters": [
@@ -1459,121 +1260,96 @@
                 "0",
                 "\"\"",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "DebuggerTools::ConsoleLog"
               },
               "parameters": [
                 "\"\"",
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
           "name": "Camera Shake",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
                     "__CameraShake_LayerName",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DebuggerTools::ConsoleLog"
                   },
                   "parameters": [
                     "\"Start\"",
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::CompareStrings"
                   },
                   "parameters": [
                     "GetArgumentAsString(\"Layer\")",
                     "=",
                     "\"\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
                     "__CameraShake_LayerName",
                     "=",
                     "\"__BaseLayer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VariableClearChildren"
                   },
                   "parameters": [
                     "__CameraShake_Layers"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "CameraShake::SetLayerShakable"
                   },
                   "parameters": [
@@ -1581,200 +1357,162 @@
                     "",
                     "VariableString(__CameraShake_LayerName)",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetTimer"
                   },
                   "parameters": [
                     "",
                     "\"__CameraShake_DurationTimer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarSceneTxt"
                   },
                   "parameters": [
                     "__CameraShake_Layer",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "GetArgumentAsNumber(\"Duration\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_StartEaseDuration",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_StopEaseDuration",
                     "=",
                     "GetArgumentAsNumber(\"Duration\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_DefaultAmplitudeX",
                     "=",
                     "abs(GetArgumentAsNumber(\"AmplitudeX\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_DefaultAmplitudeY",
                     "=",
                     "abs(GetArgumentAsNumber(\"AmplitudeY\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_DefaultAmplitudeAngle",
                     "=",
                     "GetArgumentAsNumber(\"AmplitudeAngle\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_DefaultAmplitudeZoom",
                     "=",
                     "1 + GetArgumentAsNumber(\"AmplitudeZoom\") / 100"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::CompareNumbers"
                       },
                       "parameters": [
                         "GetArgumentAsNumber(\"ShakePeriod\")",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_DefaultFrequency",
                         "=",
                         "1 / GetArgumentAsNumber(\"ShakePeriod\")"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::CompareNumbers"
                       },
                       "parameters": [
                         "GetArgumentAsNumber(\"ShakePeriod\")",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarScene"
                       },
                       "parameters": [
                         "__CameraShake_DefaultFrequency",
                         "=",
                         "1 / 0.08"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1788,40 +1526,31 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"ShakeForever\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "1234567890"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1835,38 +1564,31 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "0.5"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": []
@@ -1976,48 +1698,39 @@
       "sentence": "Start shaking the camera with _PARAM1_ seconds of easing",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ResetTimer"
               },
               "parameters": [
                 "",
                 "\"__CameraShake_DurationTimer\""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Duration",
                 "=",
                 "1234567890"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StartEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2044,48 +1757,39 @@
       "sentence": "Stop shaking the camera with _PARAM1_ seconds of easing",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ResetTimer"
               },
               "parameters": [
                 "",
                 "\"__CameraShake_DurationTimer\""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Duration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_StopEaseDuration",
                 "=",
                 "GetArgumentAsNumber(\"EaseDuration\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2112,63 +1816,49 @@
       "sentence": "Mark the layer: _PARAM2_ as shakable: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
                 "GetArgumentAsString(\"Layer\")",
                 "=",
                 "\"\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "\"__BaseLayer\""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
@@ -2178,55 +1868,44 @@
               },
               "parameters": [
                 "\"Shakable\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
                 "="
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "GetArgumentAsBoolean"
               },
               "parameters": [
                 "\"Shakable\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetSceneVariableAsBoolean"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2263,13 +1942,10 @@
       "sentence": "Camera is shaking",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "CompareTimer"
               },
               "parameters": [
@@ -2277,23 +1953,19 @@
                 "\"__CameraShake_DurationTimer\"",
                 "<",
                 "Variable(__CameraShake_Duration)"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
@@ -2309,92 +1981,73 @@
       "sentence": "Change the translation amplitude of the shaking to _PARAM1_; _PARAM2_ (layer: _PARAM3_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
                 "GetArgumentAsString(\"Layer\")",
                 "=",
                 "\"\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "\"__BaseLayer\""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeX",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeX\")"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeY",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeY\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2441,80 +2094,63 @@
       "sentence": "Change the rotation amplitude of the shaking to _PARAM1_ degrees (layer: _PARAM2_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
                 "GetArgumentAsString(\"Layer\")",
                 "=",
                 "\"\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "\"__BaseLayer\""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeAngle",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeAngle\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2551,80 +2187,63 @@
       "sentence": "Change the zoom factor amplitude of the shaking to _PARAM1_ (layer: _PARAM2_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
                 "GetArgumentAsString(\"Layer\")",
                 "=",
                 "\"\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "\"__BaseLayer\""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeZoom",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeZoom\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2661,80 +2280,63 @@
       "sentence": "Change the shaking frequency to _PARAM1_ (layer: _PARAM2_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "GetArgumentAsString(\"Layer\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
                 "GetArgumentAsString(\"Layer\")",
                 "=",
                 "\"\""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
                 "__CameraShake_LayerName",
                 "=",
                 "\"__BaseLayer\""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Frequency",
                 "=",
                 "GetArgumentAsNumber(\"Frequency\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2771,37 +2373,30 @@
       "sentence": "Change the default translation amplitude of the shaking to _PARAM1_; _PARAM2_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_DefaultAmplitudeX",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeX\")"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_DefaultAmplitudeY",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeY\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2838,25 +2433,20 @@
       "sentence": "Change the default rotation amplitude of the shaking to _PARAM1_ degrees",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_DefaultAmplitudeAngle",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeAngle\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2883,25 +2473,20 @@
       "sentence": "Change the default zoom factor amplitude of the shaking to _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_DefaultAmplitudeZoom",
                 "=",
                 "GetArgumentAsNumber(\"AmplitudeZoom\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2928,25 +2513,20 @@
       "sentence": "Change the default shaking frequency to _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__CameraShake_DefaultFrequency",
                 "=",
                 "GetArgumentAsNumber(\"Frequency\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -2973,8 +2553,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "\ngdjs._cameraShakeExtension = gdjs._cameraShakeExtension || {};\n\n/** Noise generator manager. */\ngdjs._cameraShakeExtension.NoiseManager = /** @class */ (function () {\n    /**\n     * Create the manager of noise generators.\n     */\n    function NoiseManager() {\n        this.seed = gdjs.randomInRange(1, Number.MAX_SAFE_INTEGER);\n        /** @type {Map<string, gdjs._cameraShakeExtension.NoiseGenerator>} */\n        this.generators = new Map();\n    }\n\n    /**\n     * @param name {string}\n     * @return {gdjs._cameraShakeExtension.NoiseGenerator}\n     */\n    NoiseManager.prototype.getGenerator = function (name) {\n        let generator = this.generators.get(name);\n        if (!generator) {\n            generator = new gdjs._cameraShakeExtension.NoiseGenerator(name + this.seed);\n            this.generators.set(name, generator);\n        }\n        return generator;\n    }\n\n    /**\n     * @param seed {number}\n     */\n    NoiseManager.prototype.setSeed = function (seed) {\n        this.seed = seed;\n        this.generators.forEach(generator => generator.setSeed(seed));\n    }\n\n    /**\n     * @param name {string}\n     */\n    NoiseManager.prototype.deleteGenerator = function (name) {\n        this.generators.delete(name);\n    }\n\n    /**\n     */\n    NoiseManager.prototype.deleteAllGenerators = function () {\n        this.generators.clear();\n    }\n\n    return NoiseManager;\n}());\n\n/** Noise generator with octaves. */\ngdjs._cameraShakeExtension.NoiseGenerator = /** @class */ (function () {\n    /**\n     * Create a noise generator with a seed.\n     * @param seed {string}\n     */\n    function NoiseGenerator(seed) {\n        this.simplexNoise = new gdjs._cameraShakeExtension.SimplexNoise(seed);\n        this.frequency = 1;\n        this.octaves = 1;\n        this.persistence = 0.5;\n        this.lacunarity = 2;\n        this.xLoopPeriod = 0;\n        this.yLoopPeriod = 0;\n    }\n\n    /**\n     * @param seed {string}\n     */\n    NoiseGenerator.prototype.setSeed = function(seed) {\n        this.simplexNoise = new gdjs._cameraShakeExtension.SimplexNoise(seed);\n    }\n\n    /**\n     * @param x {float}\n     * @param y {float}\n     * @param z {float} optionnal\n     * @param w {float} optionnal\n     * @return {float}\n     */\n    NoiseGenerator.prototype.noise = function (x, y, z, w) {\n        if (this.xLoopPeriod && this.yLoopPeriod) {\n            const circleRatioX = 2 * Math.PI / this.xLoopPeriod;\n            const circleRatioY = 2 * Math.PI / this.yLoopPeriod;\n            const angleX = circleRatioX * x;\n            const angleY = circleRatioY * y;\n            x = Math.cos(angleX) / circleRatioX;\n            y = Math.sin(angleX) / circleRatioX;\n            z = Math.cos(angleY) / circleRatioY;\n            w = Math.sin(angleY) / circleRatioY;\n        }\n        else if (this.xLoopPeriod) {\n            const circleRatio = 2 * Math.PI / this.xLoopPeriod;\n            const angleX = circleRatio * x;\n            w = z;\n            z = y; \n            x = Math.cos(angleX) / circleRatio;\n            y = Math.sin(angleX) / circleRatio;\n        }\n        else if (this.yLoopPeriod) {\n            const circleRatio = 2 * Math.PI / this.xLoopPeriod;\n            const angleX = circleRatio * x;\n            w = z;\n            // Make the circle perimeter equals to the looping period\n            // to keep the same perceived frequency with or without looping.\n            y = Math.cos(angleX) / circleRatio;\n            z = Math.sin(angleX) / circleRatio;\n        }\n        let noiseFunction = this.simplexNoise.noise4D.bind(this.simplexNoise);\n        if (z === undefined) {\n            noiseFunction = this.simplexNoise.noise2D.bind(this.simplexNoise);\n        }\n        else if (w === undefined) {\n            noiseFunction = this.simplexNoise.noise3D.bind(this.simplexNoise);\n        }\n        let frequency = this.frequency;\n        let noiseSum = 0;\n        let amplitudeSum = 0;\n        let amplitude = 1;\n        for (let i = 0; i < this.octaves; i++) {\n            noiseSum += noiseFunction(x * frequency, y * frequency, z * frequency, w * frequency) * amplitude;\n            amplitudeSum += Math.abs(amplitude);\n            amplitude *= this.persistence;\n            frequency *= this.lacunarity;\n        }\n        return noiseSum / amplitudeSum;\n    }\n\n    return NoiseGenerator;\n}());\n\n/*\nA fast javascript implementation of simplex noise by Jonas Wagner\nhttps://github.com/jwagner/simplex-noise.js\n\nBased on a speed-improved simplex noise algorithm for 2D, 3D and 4D in Java.\nWhich is based on example code by Stefan Gustavson (stegu@itn.liu.se).\nWith Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).\nBetter rank ordering method by Stefan Gustavson in 2012.\n\n Copyright (c) 2021 Jonas Wagner\n\n Permission is hereby granted, free of charge, to any person obtaining a copy\n of this software and associated documentation files (the \"Software\"), to deal\n in the Software without restriction, including without limitation the rights\n to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n copies of the Software, and to permit persons to whom the Software is\n furnished to do so, subject to the following conditions:\n\n The above copyright notice and this permission notice shall be included in all\n copies or substantial portions of the Software.\n\n THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n SOFTWARE.\n */\n\nconst F2 = 0.5 * (Math.sqrt(3.0) - 1.0);\nconst G2 = (3.0 - Math.sqrt(3.0)) / 6.0;\nconst F3 = 1.0 / 3.0;\nconst G3 = 1.0 / 6.0;\nconst F4 = (Math.sqrt(5.0) - 1.0) / 4.0;\nconst G4 = (5.0 - Math.sqrt(5.0)) / 20.0;\nconst grad3 = new Float32Array([1, 1, 0,\n    -1, 1, 0,\n    1, -1, 0,\n    -1, -1, 0,\n    1, 0, 1,\n    -1, 0, 1,\n    1, 0, -1,\n    -1, 0, -1,\n    0, 1, 1,\n    0, -1, 1,\n    0, 1, -1,\n    0, -1, -1]);\nconst grad4 = new Float32Array([0, 1, 1, 1, 0, 1, 1, -1, 0, 1, -1, 1, 0, 1, -1, -1,\n    0, -1, 1, 1, 0, -1, 1, -1, 0, -1, -1, 1, 0, -1, -1, -1,\n    1, 0, 1, 1, 1, 0, 1, -1, 1, 0, -1, 1, 1, 0, -1, -1,\n    -1, 0, 1, 1, -1, 0, 1, -1, -1, 0, -1, 1, -1, 0, -1, -1,\n    1, 1, 0, 1, 1, 1, 0, -1, 1, -1, 0, 1, 1, -1, 0, -1,\n    -1, 1, 0, 1, -1, 1, 0, -1, -1, -1, 0, 1, -1, -1, 0, -1,\n    1, 1, 1, 0, 1, 1, -1, 0, 1, -1, 1, 0, 1, -1, -1, 0,\n    -1, 1, 1, 0, -1, 1, -1, 0, -1, -1, 1, 0, -1, -1, -1, 0]);\n\n/** Deterministic simplex noise generator suitable for 2D, 3D and 4D spaces. */\ngdjs._cameraShakeExtension.SimplexNoise = /** @class */ (function () {\n    /**\n     * Creates a new `SimplexNoise` instance.\n     * This involves some setup. You can save a few cpu cycles by reusing the same instance.\n     * @param {(() => number)|string|number} randomOrSeed A random number generator or a seed (string|number).\n     * Defaults to Math.random (random irreproducible initialization).\n     */\n    function SimplexNoise(randomOrSeed) {\n        if (randomOrSeed === void 0) { randomOrSeed = Math.random; }\n        const random = typeof randomOrSeed == 'function' ? randomOrSeed : alea(randomOrSeed);\n        this.p = buildPermutationTable(random);\n        this.perm = new Uint8Array(512);\n        this.permMod12 = new Uint8Array(512);\n        for (let i = 0; i < 512; i++) {\n            this.perm[i] = this.p[i & 255];\n            this.permMod12[i] = this.perm[i] % 12;\n        }\n    }\n\n    /**\n     * Samples the noise field in 2 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise2D = function (x, y) {\n        const permMod12 = this.permMod12;\n        const perm = this.perm;\n        let n0 = 0; // Noise contributions from the three corners\n        let n1 = 0;\n        let n2 = 0;\n        // Skew the input space to determine which simplex cell we're in\n        const s = (x + y) * F2; // Hairy factor for 2D\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const t = (i + j) * G2;\n        const X0 = i - t; // Unskew the cell origin back to (x,y) space\n        const Y0 = j - t;\n        const x0 = x - X0; // The x,y distances from the cell origin\n        const y0 = y - Y0;\n        // For the 2D case, the simplex shape is an equilateral triangle.\n        // Determine which simplex we are in.\n        let i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords\n        if (x0 > y0) {\n            i1 = 1;\n            j1 = 0;\n        } // lower triangle, XY order: (0,0)->(1,0)->(1,1)\n        else {\n            i1 = 0;\n            j1 = 1;\n        } // upper triangle, YX order: (0,0)->(0,1)->(1,1)\n        // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and\n        // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where\n        // c = (3-sqrt(3))/6\n        const x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords\n        const y1 = y0 - j1 + G2;\n        const x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y) unskewed coords\n        const y2 = y0 - 1.0 + 2.0 * G2;\n        // Work out the hashed gradient indices of the three simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        // Calculate the contribution from the three corners\n        let t0 = 0.5 - x0 * x0 - y0 * y0;\n        if (t0 >= 0) {\n            const gi0 = permMod12[ii + perm[jj]] * 3;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad3[gi0] * x0 + grad3[gi0 + 1] * y0); // (x,y) of grad3 used for 2D gradient\n        }\n        let t1 = 0.5 - x1 * x1 - y1 * y1;\n        if (t1 >= 0) {\n            const gi1 = permMod12[ii + i1 + perm[jj + j1]] * 3;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad3[gi1] * x1 + grad3[gi1 + 1] * y1);\n        }\n        let t2 = 0.5 - x2 * x2 - y2 * y2;\n        if (t2 >= 0) {\n            const gi2 = permMod12[ii + 1 + perm[jj + 1]] * 3;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad3[gi2] * x2 + grad3[gi2 + 1] * y2);\n        }\n        // Add contributions from each corner to get the final noise value.\n        // The result is scaled to return values in the interval [-1,1].\n        return 70.0 * (n0 + n1 + n2);\n    }\n\n    /**\n     * Samples the noise field in 3 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @param {number} z\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise3D = function (x, y, z) {\n        const permMod12 = this.permMod12;\n        const perm = this.perm;\n        let n0, n1, n2, n3; // Noise contributions from the four corners\n        // Skew the input space to determine which simplex cell we're in\n        const s = (x + y + z) * F3; // Very nice and simple skew factor for 3D\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const k = Math.floor(z + s);\n        const t = (i + j + k) * G3;\n        const X0 = i - t; // Unskew the cell origin back to (x,y,z) space\n        const Y0 = j - t;\n        const Z0 = k - t;\n        const x0 = x - X0; // The x,y,z distances from the cell origin\n        const y0 = y - Y0;\n        const z0 = z - Z0;\n        // For the 3D case, the simplex shape is a slightly irregular tetrahedron.\n        // Determine which simplex we are in.\n        let i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords\n        let i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords\n        if (x0 >= y0) {\n            if (y0 >= z0) {\n                i1 = 1;\n                j1 = 0;\n                k1 = 0;\n                i2 = 1;\n                j2 = 1;\n                k2 = 0;\n            } // X Y Z order\n            else if (x0 >= z0) {\n                i1 = 1;\n                j1 = 0;\n                k1 = 0;\n                i2 = 1;\n                j2 = 0;\n                k2 = 1;\n            } // X Z Y order\n            else {\n                i1 = 0;\n                j1 = 0;\n                k1 = 1;\n                i2 = 1;\n                j2 = 0;\n                k2 = 1;\n            } // Z X Y order\n        }\n        else { // x0<y0\n            if (y0 < z0) {\n                i1 = 0;\n                j1 = 0;\n                k1 = 1;\n                i2 = 0;\n                j2 = 1;\n                k2 = 1;\n            } // Z Y X order\n            else if (x0 < z0) {\n                i1 = 0;\n                j1 = 1;\n                k1 = 0;\n                i2 = 0;\n                j2 = 1;\n                k2 = 1;\n            } // Y Z X order\n            else {\n                i1 = 0;\n                j1 = 1;\n                k1 = 0;\n                i2 = 1;\n                j2 = 1;\n                k2 = 0;\n            } // Y X Z order\n        }\n        // A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),\n        // a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and\n        // a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z), where\n        // c = 1/6.\n        const x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords\n        const y1 = y0 - j1 + G3;\n        const z1 = z0 - k1 + G3;\n        const x2 = x0 - i2 + 2.0 * G3; // Offsets for third corner in (x,y,z) coords\n        const y2 = y0 - j2 + 2.0 * G3;\n        const z2 = z0 - k2 + 2.0 * G3;\n        const x3 = x0 - 1.0 + 3.0 * G3; // Offsets for last corner in (x,y,z) coords\n        const y3 = y0 - 1.0 + 3.0 * G3;\n        const z3 = z0 - 1.0 + 3.0 * G3;\n        // Work out the hashed gradient indices of the four simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        const kk = k & 255;\n        // Calculate the contribution from the four corners\n        let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;\n        if (t0 < 0)\n            n0 = 0.0;\n        else {\n            const gi0 = permMod12[ii + perm[jj + perm[kk]]] * 3;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad3[gi0] * x0 + grad3[gi0 + 1] * y0 + grad3[gi0 + 2] * z0);\n        }\n        let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;\n        if (t1 < 0)\n            n1 = 0.0;\n        else {\n            const gi1 = permMod12[ii + i1 + perm[jj + j1 + perm[kk + k1]]] * 3;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad3[gi1] * x1 + grad3[gi1 + 1] * y1 + grad3[gi1 + 2] * z1);\n        }\n        let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;\n        if (t2 < 0)\n            n2 = 0.0;\n        else {\n            const gi2 = permMod12[ii + i2 + perm[jj + j2 + perm[kk + k2]]] * 3;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad3[gi2] * x2 + grad3[gi2 + 1] * y2 + grad3[gi2 + 2] * z2);\n        }\n        let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;\n        if (t3 < 0)\n            n3 = 0.0;\n        else {\n            const gi3 = permMod12[ii + 1 + perm[jj + 1 + perm[kk + 1]]] * 3;\n            t3 *= t3;\n            n3 = t3 * t3 * (grad3[gi3] * x3 + grad3[gi3 + 1] * y3 + grad3[gi3 + 2] * z3);\n        }\n        // Add contributions from each corner to get the final noise value.\n        // The result is scaled to stay just inside [-1,1]\n        return 32.0 * (n0 + n1 + n2 + n3);\n    }\n\n    /**\n     * Samples the noise field in 4 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @param {number} z\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise4D = function (x, y, z, w) {\n        const perm = this.perm;\n        let n0, n1, n2, n3, n4; // Noise contributions from the five corners\n        // Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in\n        const s = (x + y + z + w) * F4; // Factor for 4D skewing\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const k = Math.floor(z + s);\n        const l = Math.floor(w + s);\n        const t = (i + j + k + l) * G4; // Factor for 4D unskewing\n        const X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space\n        const Y0 = j - t;\n        const Z0 = k - t;\n        const W0 = l - t;\n        const x0 = x - X0; // The x,y,z,w distances from the cell origin\n        const y0 = y - Y0;\n        const z0 = z - Z0;\n        const w0 = w - W0;\n        // For the 4D case, the simplex is a 4D shape I won't even try to describe.\n        // To find out which of the 24 possible simplices we're in, we need to\n        // determine the magnitude ordering of x0, y0, z0 and w0.\n        // Six pair-wise comparisons are performed between each possible pair\n        // of the four coordinates, and the results are used to rank the numbers.\n        let rankx = 0;\n        let ranky = 0;\n        let rankz = 0;\n        let rankw = 0;\n        if (x0 > y0)\n            rankx++;\n        else\n            ranky++;\n        if (x0 > z0)\n            rankx++;\n        else\n            rankz++;\n        if (x0 > w0)\n            rankx++;\n        else\n            rankw++;\n        if (y0 > z0)\n            ranky++;\n        else\n            rankz++;\n        if (y0 > w0)\n            ranky++;\n        else\n            rankw++;\n        if (z0 > w0)\n            rankz++;\n        else\n            rankw++;\n        // simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some order.\n        // Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w and x<w\n        // impossible. Only the 24 indices which have non-zero entries make any sense.\n        // We use a thresholding to set the coordinates in turn from the largest magnitude.\n        // Rank 3 denotes the largest coordinate.\n        // Rank 2 denotes the second largest coordinate.\n        // Rank 1 denotes the second smallest coordinate.\n        // The integer offsets for the second simplex corner\n        const i1 = rankx >= 3 ? 1 : 0;\n        const j1 = ranky >= 3 ? 1 : 0;\n        const k1 = rankz >= 3 ? 1 : 0;\n        const l1 = rankw >= 3 ? 1 : 0;\n        // The integer offsets for the third simplex corner\n        const i2 = rankx >= 2 ? 1 : 0;\n        const j2 = ranky >= 2 ? 1 : 0;\n        const k2 = rankz >= 2 ? 1 : 0;\n        const l2 = rankw >= 2 ? 1 : 0;\n        // The integer offsets for the fourth simplex corner\n        const i3 = rankx >= 1 ? 1 : 0;\n        const j3 = ranky >= 1 ? 1 : 0;\n        const k3 = rankz >= 1 ? 1 : 0;\n        const l3 = rankw >= 1 ? 1 : 0;\n        // The fifth corner has all coordinate offsets = 1, so no need to compute that.\n        const x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coords\n        const y1 = y0 - j1 + G4;\n        const z1 = z0 - k1 + G4;\n        const w1 = w0 - l1 + G4;\n        const x2 = x0 - i2 + 2.0 * G4; // Offsets for third corner in (x,y,z,w) coords\n        const y2 = y0 - j2 + 2.0 * G4;\n        const z2 = z0 - k2 + 2.0 * G4;\n        const w2 = w0 - l2 + 2.0 * G4;\n        const x3 = x0 - i3 + 3.0 * G4; // Offsets for fourth corner in (x,y,z,w) coords\n        const y3 = y0 - j3 + 3.0 * G4;\n        const z3 = z0 - k3 + 3.0 * G4;\n        const w3 = w0 - l3 + 3.0 * G4;\n        const x4 = x0 - 1.0 + 4.0 * G4; // Offsets for last corner in (x,y,z,w) coords\n        const y4 = y0 - 1.0 + 4.0 * G4;\n        const z4 = z0 - 1.0 + 4.0 * G4;\n        const w4 = w0 - 1.0 + 4.0 * G4;\n        // Work out the hashed gradient indices of the five simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        const kk = k & 255;\n        const ll = l & 255;\n        // Calculate the contribution from the five corners\n        let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;\n        if (t0 < 0)\n            n0 = 0.0;\n        else {\n            const gi0 = (perm[ii + perm[jj + perm[kk + perm[ll]]]] % 32) * 4;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad4[gi0] * x0 + grad4[gi0 + 1] * y0 + grad4[gi0 + 2] * z0 + grad4[gi0 + 3] * w0);\n        }\n        let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;\n        if (t1 < 0)\n            n1 = 0.0;\n        else {\n            const gi1 = (perm[ii + i1 + perm[jj + j1 + perm[kk + k1 + perm[ll + l1]]]] % 32) * 4;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad4[gi1] * x1 + grad4[gi1 + 1] * y1 + grad4[gi1 + 2] * z1 + grad4[gi1 + 3] * w1);\n        }\n        let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;\n        if (t2 < 0)\n            n2 = 0.0;\n        else {\n            const gi2 = (perm[ii + i2 + perm[jj + j2 + perm[kk + k2 + perm[ll + l2]]]] % 32) * 4;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad4[gi2] * x2 + grad4[gi2 + 1] * y2 + grad4[gi2 + 2] * z2 + grad4[gi2 + 3] * w2);\n        }\n        let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;\n        if (t3 < 0)\n            n3 = 0.0;\n        else {\n            const gi3 = (perm[ii + i3 + perm[jj + j3 + perm[kk + k3 + perm[ll + l3]]]] % 32) * 4;\n            t3 *= t3;\n            n3 = t3 * t3 * (grad4[gi3] * x3 + grad4[gi3 + 1] * y3 + grad4[gi3 + 2] * z3 + grad4[gi3 + 3] * w3);\n        }\n        let t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;\n        if (t4 < 0)\n            n4 = 0.0;\n        else {\n            const gi4 = (perm[ii + 1 + perm[jj + 1 + perm[kk + 1 + perm[ll + 1]]]] % 32) * 4;\n            t4 *= t4;\n            n4 = t4 * t4 * (grad4[gi4] * x4 + grad4[gi4 + 1] * y4 + grad4[gi4 + 2] * z4 + grad4[gi4 + 3] * w4);\n        }\n        // Sum up and scale the result to cover the range [-1,1]\n        return 27.0 * (n0 + n1 + n2 + n3 + n4);\n    };\n\n    /**\n     * Builds a random permutation table.\n     * This is exported only for (internal) testing purposes.\n     * Do not rely on this export.\n     * @param {() => number} random\n     * @private\n     */\n    function buildPermutationTable(random) {\n        const p = new Uint8Array(256);\n        for (let i = 0; i < 256; i++) {\n            p[i] = i;\n        }\n        for (let i = 0; i < 255; i++) {\n            const r = i + ~~(random() * (256 - i));\n            const aux = p[i];\n            p[i] = p[r];\n            p[r] = aux;\n        }\n        return p;\n    }\n\n    /*\n    The ALEA PRNG and masher code used by simplex-noise.js\n    is based on code by Johannes Baagøe, modified by Jonas Wagner.\n    See alea.md for the full license.\n    @param {string|number} seed\n    */\n    function alea(seed) {\n        let s0 = 0;\n        let s1 = 0;\n        let s2 = 0;\n        let c = 1;\n        const mash = masher();\n        s0 = mash(' ');\n        s1 = mash(' ');\n        s2 = mash(' ');\n        s0 -= mash(seed);\n        if (s0 < 0) {\n            s0 += 1;\n        }\n        s1 -= mash(seed);\n        if (s1 < 0) {\n            s1 += 1;\n        }\n        s2 -= mash(seed);\n        if (s2 < 0) {\n            s2 += 1;\n        }\n        return function () {\n            const t = 2091639 * s0 + c * 2.3283064365386963e-10; // 2^-32\n            s0 = s1;\n            s1 = s2;\n            return s2 = t - (c = t | 0);\n        };\n    }\n\n    function masher() {\n        let n = 0xefc8249d;\n        return function (data) {\n            data = data.toString();\n            for (let i = 0; i < data.length; i++) {\n                n += data.charCodeAt(i);\n                let h = 0.02519603282416938 * n;\n                n = h >>> 0;\n                h -= n;\n                h *= n;\n                n = h >>> 0;\n                h -= n;\n                n += h * 0x100000000; // 2^32\n            }\n            return (n >>> 0) * 2.3283064365386963e-10; // 2^-32\n        };\n    }\n    return SimplexNoise;\n}());\n\ngdjs._cameraShakeExtension.noiseManager = new gdjs._cameraShakeExtension.NoiseManager();",
           "parameterObjects": "",
@@ -2995,8 +2573,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y);",
           "parameterObjects": "",
@@ -3048,8 +2624,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\nconst z = eventsFunctionContext.getArgument(\"Z\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y, z);",
           "parameterObjects": "",
@@ -3111,8 +2685,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\nconst z = eventsFunctionContext.getArgument(\"Z\");\r\nconst w = eventsFunctionContext.getArgument(\"W\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y, z, w);",
           "parameterObjects": "",
@@ -3184,8 +2756,6 @@
       "sentence": "Create a noise generator named _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name);",
           "parameterObjects": "",
@@ -3217,8 +2787,6 @@
       "sentence": "Delete _PARAM1_ noise generator",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.deleteGenerator(name);",
           "parameterObjects": "",
@@ -3250,8 +2818,6 @@
       "sentence": "Delete all noise generators",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "gdjs._cameraShakeExtension.noiseManager.deleteAllGenerators();",
           "parameterObjects": "",
@@ -3272,8 +2838,6 @@
       "sentence": "Change the noise seed to _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "gdjs._cameraShakeExtension.noiseManager.setSeed(eventsFunctionContext.getArgument(\"Seed\"));",
           "parameterObjects": "",
@@ -3305,8 +2869,6 @@
       "sentence": "Change the looping period on X of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).xLoopPeriod = eventsFunctionContext.getArgument(\"LoopPeriod\");",
           "parameterObjects": "",
@@ -3348,8 +2910,6 @@
       "sentence": "Change the looping period on Y of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).yLoopPeriod = eventsFunctionContext.getArgument(\"LoopPeriod\");",
           "parameterObjects": "",
@@ -3391,8 +2951,6 @@
       "sentence": "Change the noise frequency of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).frequency = eventsFunctionContext.getArgument(\"Frequency\");",
           "parameterObjects": "",
@@ -3434,8 +2992,6 @@
       "sentence": "Change the number of noise octaves of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).octaves = eventsFunctionContext.getArgument(\"Octaves\");",
           "parameterObjects": "",
@@ -3477,8 +3033,6 @@
       "sentence": "Change the noise persistence of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).persistence = eventsFunctionContext.getArgument(\"Persistence\");",
           "parameterObjects": "",
@@ -3520,8 +3074,6 @@
       "sentence": "Change the noise lacunarity of _PARAM2_: _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).lacunarity = eventsFunctionContext.getArgument(\"Lacunarity\");",
           "parameterObjects": "",
@@ -3563,8 +3115,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "eventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.seed;",
           "parameterObjects": "",
@@ -3585,8 +3135,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).frequency;",
           "parameterObjects": "",
@@ -3618,8 +3166,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).octaves;",
           "parameterObjects": "",
@@ -3651,8 +3197,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).persistence;",
           "parameterObjects": "",
@@ -3684,8 +3228,6 @@
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).lacunarity;",
           "parameterObjects": "",

--- a/extensions/reviewed/CameraShake.json
+++ b/extensions/reviewed/CameraShake.json
@@ -1,19 +1,15 @@
 {
-  "author": "westboy31, Tristan Rhodes (https://victrisgames.itch.io/)",
+  "author": "Add00",
   "category": "",
-  "description": "Ideal for explosions, hit/impacts, earthquake, etc.\n\nSelect one or more methods of shaking:\n- Position:  Shake the X and/or Y position of the camera \n- Angle: Shake the rotation of the camera \n- Zoom: Shake the zoom level of the camera \n\nControl how the camera shakes:\n- Amplitude: How far the camera moves during each shake\n- Duration: Amount of time to shake the camera\n- Time between shakes: Amount of time between each change of the movement of the camera\n- Keep shaking until stopped (boolean)\n\nTips:\n- For a single-shake effect, set the \"Time between shakes\" to be equal to \"Duration\"  (great for a hit or impact)\n- To make the single-shake move in the opposite direction, use negative numbers \n- To repeat a single-shake effect in a loop, add a condition \"Camera is not shaking\" \n- Use a long \"Time between shakes\" to simulate a slow moving object (like a ship rocking back and forth)\n- Make sure to \"Stop shaking\" before starting a new shake if it uses different parameters. \n- Use \"Shake until stopped\" to simulate engine vibration, earthquake, or pulsing\n",
+  "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitly to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth",
   "extensionNamespace": "",
-  "fullName": "Camera Shake",
+  "fullName": "Camera shake",
   "helpPath": "https://victrisgames.itch.io/gdevelop-camera-shake-example",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXZlY3Rvci1kaWZmZXJlbmNlLWFiIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTMsMUMxLjg5LDEgMSwxLjg5IDEsM1Y1SDNWM0g1VjFIM003LDFWM0gxMFYxSDdNMTIsMVYzSDE0VjVIMTZWM0MxNiwxLjg5IDE1LjExLDEgMTQsMUgxMk0xLDdWMTBIM1Y3SDFNMTQsN0MxNCw3IDE0LDExLjY3IDE0LDE0QzExLjY3LDE0IDcsMTQgNywxNEM3LDE0IDcsMTggNywyMEM3LDIxLjExIDcuODksMjIgOSwyMkgyMEMyMS4xMSwyMiAyMiwyMS4xMSAyMiwyMFY5QzIyLDcuODkgMjEuMTEsNyAyMCw3QzE4LDcgMTQsNyAxNCw3TTE2LDlIMjBWMjBIOVYxNkgxNEMxNS4xMSwxNiAxNiwxNS4xMSAxNiwxNFY5TTEsMTJWMTRDMSwxNS4xMSAxLjg5LDE2IDMsMTZINVYxNEgzVjEySDFaIiAvPjwvc3ZnPg==",
   "name": "CameraShake",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-difference-ab.svg",
-  "shortDescription": "Shake the camera on the specified layer using one or more methods of shaking (position, angle, zoom).",
-  "version": "2.6.6",
-  "origin": {
-    "identifier": "CameraShake",
-    "name": "gdevelop-extension-store"
-  },
+  "shortDescription": "Shake layer cameras with translation, rotation and zoom.",
+  "version": "2.6.5",
   "tags": [
     "shaking",
     "camera",
@@ -21,161 +17,1764 @@
     "screen",
     "shake",
     "zoom",
-    "position",
+    "translate",
     "rotate"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
-    "m4hBMBTUilft4s1V4FQQPakVDGx1"
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Shake the camera on the specified layer, using one or more ways to shake (position, angle, zoom).",
-      "fullName": "Camera Shake",
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onSceneLoaded",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetLayerShakable"
+              },
+              "parameters": [
+                "",
+                "",
+                "\"\"",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultShakingFrequency"
+              },
+              "parameters": [
+                "",
+                "12",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultTranslationAmplitude"
+              },
+              "parameters": [
+                "",
+                "4",
+                "4",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultRotationAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultZoomAmplitude"
+              },
+              "parameters": [
+                "",
+                "1",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "// It Avoids conflicts with other extensions that also use the camera.\n// If something changes in the engine it will no longer do anything.\nif (runtimeScene._updateObjectsPreEvents\n    && gdjs\n    && gdjs.evtsExt__CameraShake__onScenePreEvents\n    && gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks\n    && gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks.length\n    && gdjs.callbacksRuntimeScenePreEvents) {\n\n    // Force preEvent execution before behavior ones.\n    if (!runtimeScene.__camerShake_hasAlreadyAddHook) {\n        runtimeScene.__camerShake_hasAlreadyAddHook = true;\n        const superUpdateObjectsPreEvents = runtimeScene._updateObjectsPreEvents.bind(runtimeScene);\n        runtimeScene._updateObjectsPreEvents = function () {\n            gdjs.evtsExt__CameraShake__onScenePreEvents.func(runtimeScene, runtimeScene);\n            superUpdateObjectsPreEvents();\n        }\n    }\n\n    // Avoid to run preEvent a second time.\n    const callback = gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks[gdjs.evtsExt__CameraShake__onScenePreEvents.registeredGdjsCallbacks.length - 1];\n    const callBackIndex = gdjs.callbacksRuntimeScenePreEvents.indexOf(callback);\n    if (callBackIndex >= 0) {\n        gdjs.callbacksRuntimeScenePreEvents.splice(callBackIndex, 1);\n    }\n}",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePostEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "This variable is needed because the time will shift before next onScenePreEvents call.",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__CameraShake_NeedToRevertCameraChanges",
+                "False"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::IsShaking"
+              },
+              "parameters": [
+                "",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__CameraShake_NeedToRevertCameraChanges",
+                "True"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_EaseFactor",
+                "=",
+                "1"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "CompareTimer"
+                  },
+                  "parameters": [
+                    "",
+                    "\"__CameraShake_DurationTimer\"",
+                    "<",
+                    "Variable(__CameraShake_StartEaseDuration)"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "CompareTimer"
+                  },
+                  "parameters": [
+                    "",
+                    "\"__CameraShake_DurationTimer\"",
+                    ">",
+                    "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraShake_EaseFactor",
+                    "=",
+                    "clamp(0, 1, TimerElapsedTime(\"__CameraShake_DurationTimer\") / Variable(__CameraShake_StartEaseDuration))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "CompareTimer"
+                  },
+                  "parameters": [
+                    "",
+                    "\"__CameraShake_DurationTimer\"",
+                    ">",
+                    "Variable(__CameraShake_Duration) - Variable(__CameraShake_StopEaseDuration)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraShake_EaseFactor",
+                    "=",
+                    "clamp(0, 1, (Variable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / Variable(__CameraShake_StopEaseDuration))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::ForEachChildVariable",
+              "iterableVariableName": "__CameraShake_Layers",
+              "valueIteratorVariableName": "__CameraShake_Layer",
+              "keyIteratorVariableName": "__CameraShake_LayerName",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_ActualLayerName",
+                        "=",
+                        "VariableString(__CameraShake_LayerName)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_LayerName",
+                        "=",
+                        "\"__BaseLayer\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_ActualLayerName",
+                        "=",
+                        "\"\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Save the layer camera position.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraX",
+                        "=",
+                        "CameraX(VariableString(__CameraShake_ActualLayerName), 0)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraY",
+                        "=",
+                        "CameraY(VariableString(__CameraShake_ActualLayerName), 0)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraAngle",
+                        "=",
+                        "CameraAngle(VariableString(__CameraShake_ActualLayerName), 0)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraZoom",
+                        "=",
+                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Use user defined default values when there is no layer specific value set.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraShake::SetFrequency"
+                      },
+                      "parameters": [
+                        "",
+                        "Variable(__CameraShake_DefaultFrequency)",
+                        "\"\"",
+                        ""
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeX",
+                        "=",
+                        "Variable(__CameraShake_DefaultAmplitudeX)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeY",
+                        "=",
+                        "Variable(__CameraShake_DefaultAmplitudeY)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeAngle",
+                        "=",
+                        "Variable(__CameraShake_DefaultAmplitudeAngle)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeZoom",
+                        "=",
+                        "Variable(__CameraShake_DefaultAmplitudeZoom)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VariableChildExists"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layer",
+                        "\"Frequency\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "CameraShake::SetFrequency"
+                      },
+                      "parameters": [
+                        "",
+                        "Variable(__CameraShake_Layer.Frequency)",
+                        "\"\"",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VariableChildExists"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layer",
+                        "\"AmplitudeX\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeX",
+                        "=",
+                        "Variable(__CameraShake_Layer.AmplitudeX)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VariableChildExists"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layer",
+                        "\"AmplitudeY\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeY",
+                        "=",
+                        "Variable(__CameraShake_Layer.AmplitudeY)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VariableChildExists"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layer",
+                        "\"AmplitudeAngle\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeAngle",
+                        "=",
+                        "Variable(__CameraShake_Layer.AmplitudeAngle)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VariableChildExists"
+                      },
+                      "parameters": [
+                        "__CameraShake_Layer",
+                        "\"AmplitudeZoom\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeZoom",
+                        "=",
+                        "Variable(__CameraShake_Layer.AmplitudeZoom)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Shake the layer camera.",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeX",
+                        "!=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 1000) * Variable(__CameraShake_AmplitudeX) * Variable(__CameraShake_EaseFactor)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeY",
+                        "!=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 2000) * Variable(__CameraShake_AmplitudeY) * Variable(__CameraShake_EaseFactor)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeAngle",
+                        "!=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "RotateCamera"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "CameraShake::Noise2d(\"\", TimeFromStart(), 3000) * Variable(__CameraShake_AmplitudeAngle) * Variable(__CameraShake_EaseFactor)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_AmplitudeZoom",
+                        "!=",
+                        "1"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ZoomCamera"
+                      },
+                      "parameters": [
+                        "",
+                        "CameraZoom(VariableString(__CameraShake_ActualLayerName), 0) * pow(Variable(__CameraShake_AmplitudeZoom), CameraShake::Noise2d(\"\", TimeFromStart(), 4000) * Variable(__CameraShake_EaseFactor))",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePreEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__CameraShake_NeedToRevertCameraChanges",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::ForEachChildVariable",
+              "iterableVariableName": "__CameraShake_Layers",
+              "valueIteratorVariableName": "__CameraShake_Layer",
+              "keyIteratorVariableName": "__CameraShake_LayerName",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                    "True"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_ActualLayerName",
+                        "=",
+                        "VariableString(__CameraShake_LayerName)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_LayerName",
+                        "=",
+                        "\"__BaseLayer\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__CameraShake_ActualLayerName",
+                        "=",
+                        "\"\""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraX)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraY)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SetCameraAngle"
+                      },
+                      "parameters": [
+                        "",
+                        "=",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraAngle)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ZoomCamera"
+                      },
+                      "parameters": [
+                        "",
+                        "Variable(__CameraShake_Layers[VariableString(__CameraShake_LayerName)].NoShakeCameraZoom)",
+                        "VariableString(__CameraShake_ActualLayerName)",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Shake the camera on layers chosen with configuration actions.",
+      "fullName": "Shake camera",
+      "functionType": "Action",
+      "group": "",
+      "name": "ShakeCamera",
+      "private": false,
+      "sentence": "Shake camera for _PARAM1_ seconds with _PARAM2_ seconds of easing to start and _PARAM3_ seconds to stop",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "It \"imports\" the function. A bug doesn't include functions that are only called in life-cycle one.",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "BuiltinCommonInstructions::Always"
+              },
+              "parameters": [
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::IsShaking"
+              },
+              "parameters": [
+                "",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "test",
+                "=",
+                "CameraShake::Noise2d(\"\", 0, 0)"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetLayerShakable"
+              },
+              "parameters": [
+                "",
+                "no",
+                "\"\"",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultShakingFrequency"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultTranslationAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultRotationAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultZoomAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetFrequency"
+              },
+              "parameters": [
+                "",
+                "0",
+                "\"\"",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "DebuggerTools::ConsoleLog"
+              },
+              "parameters": [
+                "\"\"",
+                "",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ResetTimer"
+              },
+              "parameters": [
+                "",
+                "\"__CameraShake_DurationTimer\""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Duration",
+                "=",
+                "GetArgumentAsNumber(\"Duration\")"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StartEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"StartEaseDuration\")"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StopEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"StopEaseDuration\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "VarScene"
+              },
+              "parameters": [
+                "__CameraShake_Duration",
+                "<",
+                "Variable(__CameraShake_StartEaseDuration) + Variable(__CameraShake_StopEaseDuration)"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StartEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"StartEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StopEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"StopEaseDuration\") * Variable(__CameraShake_Duration) / (GetArgumentAsNumber(\"StartEaseDuration\") + GetArgumentAsNumber(\"StopEaseDuration\"))"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Duration (in seconds)",
+          "longDescription": "",
+          "name": "Duration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Ease duration to start (in seconds)",
+          "longDescription": "",
+          "name": "StartEaseDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Ease duration to stop (in seconds)",
+          "longDescription": "",
+          "name": "StopEaseDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Shake the camera on the specified layer, using one or more ways to shake (position, angle, zoom). This action is deprecated. Please use the other one with the same name.",
+      "fullName": "Shake camera (deprecated)",
       "functionType": "Action",
       "group": "",
       "name": "CameraShake",
-      "private": false,
+      "private": true,
       "sentence": "Shake camera on _PARAM3_ layer for _PARAM5_ seconds. Use an amplitude of _PARAM1_px on X axis and _PARAM2_px on Y axis, angle rotation amplitude _PARAM6_ degrees, and zoom amplitude _PARAM7_ percent.  Wait _PARAM8_ seconds between shakes. Keep shaking until stopped: _PARAM9_",
       "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "It \"imports\" the noise function. A bug doesn't include functions that are only called in life-cycle one.",
+          "comment2": ""
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "BuiltinCommonInstructions::Always"
+              },
+              "parameters": [
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::IsShaking"
+              },
+              "parameters": [
+                "",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "test",
+                "=",
+                "CameraShake::Noise2d(\"\", 0, 0)"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetLayerShakable"
+              },
+              "parameters": [
+                "",
+                "no",
+                "\"\"",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultShakingFrequency"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultTranslationAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultRotationAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetDefaultZoomAmplitude"
+              },
+              "parameters": [
+                "",
+                "0",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "CameraShake::SetFrequency"
+              },
+              "parameters": [
+                "",
+                "0",
+                "\"\"",
+                ""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "DebuggerTools::ConsoleLog"
+              },
+              "parameters": [
+                "\"\"",
+                "",
+                ""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
+          "disabled": false,
+          "folded": false,
           "name": "Camera Shake",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Start/Reset duration timer",
-              "comment2": ""
-            },
-            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
+                    "inverted": false,
+                    "value": "ModVarSceneTxt"
+                  },
+                  "parameters": [
+                    "__CameraShake_LayerName",
+                    "=",
+                    "GetArgumentAsString(\"Layer\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DebuggerTools::ConsoleLog"
+                  },
+                  "parameters": [
+                    "\"Start\"",
+                    "",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::CompareStrings"
+                  },
+                  "parameters": [
+                    "GetArgumentAsString(\"Layer\")",
+                    "=",
+                    "\"\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarSceneTxt"
+                  },
+                  "parameters": [
+                    "__CameraShake_LayerName",
+                    "=",
+                    "\"__BaseLayer\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "VariableClearChildren"
+                  },
+                  "parameters": [
+                    "__CameraShake_Layers"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "CameraShake::SetLayerShakable"
+                  },
+                  "parameters": [
+                    "",
+                    "",
+                    "VariableString(__CameraShake_LayerName)",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "ResetTimer"
                   },
                   "parameters": [
                     "",
                     "\"__CameraShake_DurationTimer\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Pass input parameters to global variables so that onScenePostEvents can use them",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_PowerX",
-                    "=",
-                    "GetArgumentAsNumber(\"PowerX\")"
-                  ]
+                  ],
+                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_PowerY",
-                    "=",
-                    "GetArgumentAsNumber(\"PowerY\")"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarGlobalTxt"
+                    "inverted": false,
+                    "value": "ModVarSceneTxt"
                   },
                   "parameters": [
                     "__CameraShake_Layer",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
-                  ]
+                  ],
+                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_Camera",
-                    "=",
-                    "GetArgumentAsNumber(\"Camera\")"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "GetArgumentAsNumber(\"Duration\")"
-                  ]
+                  ],
+                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "value": "ModVarGlobal"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_PowerAngle",
+                    "__CameraShake_StartEaseDuration",
                     "=",
-                    "GetArgumentAsNumber(\"PowerAngle\")"
-                  ]
+                    "0"
+                  ],
+                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "value": "ModVarGlobal"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_PowerZoom",
+                    "__CameraShake_StopEaseDuration",
                     "=",
-                    "GetArgumentAsNumber(\"PowerZoom\")"
-                  ]
+                    "GetArgumentAsNumber(\"Duration\")"
+                  ],
+                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "value": "ModVarGlobal"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_TimeBetweenShakes",
+                    "__CameraShake_DefaultAmplitudeX",
                     "=",
-                    "GetArgumentAsNumber(\"TimeBetweenShakes\")"
-                  ]
+                    "abs(GetArgumentAsNumber(\"AmplitudeX\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraShake_DefaultAmplitudeY",
+                    "=",
+                    "abs(GetArgumentAsNumber(\"AmplitudeY\"))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraShake_DefaultAmplitudeAngle",
+                    "=",
+                    "GetArgumentAsNumber(\"AmplitudeAngle\")"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraShake_DefaultAmplitudeZoom",
+                    "=",
+                    "1 + GetArgumentAsNumber(\"AmplitudeZoom\") / 100"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "GetArgumentAsNumber(\"ShakePeriod\")",
+                        "!=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_DefaultFrequency",
+                        "=",
+                        "1 / GetArgumentAsNumber(\"ShakePeriod\")"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "GetArgumentAsNumber(\"ShakePeriod\")",
+                        "=",
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraShake_DefaultFrequency",
+                        "=",
+                        "1 / 0.08"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
                 }
               ]
             },
             {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -189,45 +1788,40 @@
               "comment2": ""
             },
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "SetGlobalVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__CameraShake_ShakeForever",
-                    "False"
-                  ]
-                }
-              ]
-            },
-            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
+                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"ShakeForever\""
-                  ]
+                  ],
+                  "subInstructions": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "SetGlobalVariableAsBoolean"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
-                    "__CameraShake_ShakeForever",
-                    "True"
-                  ]
+                    "__CameraShake_Duration",
+                    "=",
+                    "1234567890"
+                  ],
+                  "subInstructions": []
                 }
-              ]
+              ],
+              "events": []
             },
             {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -241,167 +1835,38 @@
               "comment2": ""
             },
             {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "VarGlobal"
+                    "inverted": false,
+                    "value": "VarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "0"
-                  ]
+                  ],
+                  "subInstructions": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarGlobal"
+                    "inverted": false,
+                    "value": "ModVarScene"
                   },
                   "parameters": [
                     "__CameraShake_Duration",
                     "=",
                     "0.5"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_TimeBetweenShakes",
-                    "=",
-                    "0"
-                  ]
+                  ],
+                  "subInstructions": []
                 }
               ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_TimeBetweenShakes",
-                    "=",
-                    "0.08"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "If duration is less than a single shake, increase duration to make 1 full shake",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_Duration",
-                    "<",
-                    "GlobalVariable(__CameraShake_TimeBetweenShakes)"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_Duration",
-                    "=",
-                    "GlobalVariable(__CameraShake_TimeBetweenShakes)"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Detect initial shake",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_ShakeInProgress",
-                    "=",
-                    "0"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_InitialShake",
-                    "=",
-                    "1"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Initiate the onScenePostEvents function",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarGlobal"
-                  },
-                  "parameters": [
-                    "__CameraShake_ShakeInProgress",
-                    "=",
-                    "1"
-                  ]
-                }
-              ]
+              "events": []
             }
           ],
           "parameters": []
@@ -411,9 +1876,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Amplitude of shaking on the X axis (pixels) (For example: 5)",
+          "description": "Amplitude of shaking on the X axis (in pixels)",
           "longDescription": "",
-          "name": "PowerX",
+          "name": "AmplitudeX",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -421,9 +1886,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Amplitude of shaking on the Y axis (pixels) (For example: 5)",
+          "description": "Amplitude of shaking on the Y axis (in pixels)",
           "longDescription": "",
-          "name": "PowerY",
+          "name": "AmplitudeY",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -451,7 +1916,7 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Duration (seconds) (Default: 0.5)",
+          "description": "Duration (in seconds) (Default: 0.5)",
           "longDescription": "",
           "name": "Duration",
           "optional": false,
@@ -461,9 +1926,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Angle rotation amplitude (degrees) (For example: 2)",
+          "description": "Angle rotation amplitude (in degrees) (For example: 2)",
           "longDescription": "",
-          "name": "PowerAngle",
+          "name": "AmplitudeAngle",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -471,9 +1936,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Zoom amplitude (percent change) (For example: 3)",
+          "description": "Zoom factor amplitude",
           "longDescription": "",
-          "name": "PowerZoom",
+          "name": "AmplitudeZoom",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -481,9 +1946,9 @@
         {
           "codeOnly": false,
           "defaultValue": "",
-          "description": "Amount of time between shakes (seconds) (Default: 0.08)",
+          "description": "Periode between shakes (in seconds) (Default: 0.08)",
           "longDescription": "",
-          "name": "TimeBetweenShakes",
+          "name": "ShakePeriod",
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
@@ -502,1921 +1967,1744 @@
       "objectGroups": []
     },
     {
-      "description": "",
-      "fullName": "",
+      "description": "Start shaking the camera undefinitly.",
+      "fullName": "Start camera shaking",
       "functionType": "Action",
       "group": "",
-      "name": "onScenePostEvents",
+      "name": "StartShaking",
       "private": false,
-      "sentence": "",
+      "sentence": "Start shaking the camera with _PARAM1_ seconds of easing",
       "events": [
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "name": "Camera Shake",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "name": "Start shaking",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "VarGlobal"
-                      },
-                      "parameters": [
-                        "__CameraShake_ShakeInProgress",
-                        "=",
-                        "1"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Keep shaking forever (if desired)",
-                      "comment2": ""
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "GlobalVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__CameraShake_ShakeForever",
-                            "True"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "ModVarGlobal"
-                          },
-                          "parameters": [
-                            "__CameraShake_Duration",
-                            "=",
-                            "100"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "ResetTimer"
-                          },
-                          "parameters": [
-                            "",
-                            "\"__CameraShake_DurationTimer\""
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Calculate movement of the shake",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Run once before every shake movement",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::Or"
-                              },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "VarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_InitialShake",
-                                    "=",
-                                    "1"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "Timer"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "GlobalVariable(__CameraShake_TimeBetweenShakes)",
-                                    "\"__CameraShake_ShakeTimer\""
-                                  ]
-                                }
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "ResetTimer"
-                              },
-                              "parameters": [
-                                "",
-                                "\"__CameraShake_ShakeTimer\""
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_ShakeCounter",
-                                "+",
-                                "1"
-                              ]
-                            }
-                          ],
-                          "events": [
-                            {
-                              "colorB": 228,
-                              "colorG": 176,
-                              "colorR": 74,
-                              "creationTime": 0,
-                              "folded": true,
-                              "name": "Correct for drift and reset drift tracking variables",
-                              "source": "",
-                              "type": "BuiltinCommonInstructions::Group",
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Move to correct any drift from previous shake",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerAngle",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "RotateCamera"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "-",
-                                        "GlobalVariable(__CameraShake_AngleTravelled)",
-                                        "GlobalVariableString(__CameraShake_Layer)",
-                                        "GlobalVariable(__CameraShake_Camera)"
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerZoom",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ZoomCamera"
-                                      },
-                                      "parameters": [
-                                        "",
-                                        "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) - GlobalVariable(__CameraShake_ZoomTravelled)",
-                                        "GlobalVariableString(__CameraShake_Layer)",
-                                        "GlobalVariable(__CameraShake_Camera)"
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "BuiltinCommonInstructions::Or"
-                                      },
-                                      "parameters": [],
-                                      "subInstructions": [
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerX",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerY",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "SetCameraX"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "-",
-                                        "GlobalVariable(__CameraShake_DisplacementTravelledX)",
-                                        "GlobalVariableString(__CameraShake_Layer)",
-                                        "GlobalVariable(__CameraShake_Camera)"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "SetCameraY"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "-",
-                                        "GlobalVariable(__CameraShake_DisplacementTravelledY)",
-                                        "GlobalVariableString(__CameraShake_Layer)",
-                                        "GlobalVariable(__CameraShake_Camera)"
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Reset drift detection variables",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledX",
-                                        "=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledY",
-                                        "=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_AngleTravelled",
-                                        "=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_ZoomTravelled",
-                                        "=",
-                                        "0"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "parameters": []
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Calculate Position Shake",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::Or"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerX",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerY",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "actions": [],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "PositionDisplacement = (DesiredDuration - RunningTimer) / DesiredDuration * Amplitude * [-1 or 1]",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Make initial shake NOT random so users can set a direction for a one-shake effect",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_InitialShake",
-                                        "=",
-                                        "1"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerX",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "ModVarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_DisplacementX",
-                                            "=",
-                                            "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerX)"
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerY",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "ModVarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_DisplacementY",
-                                            "=",
-                                            "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerY)"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "After initial shake pick a random direction",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_InitialShake",
-                                        "=",
-                                        "0"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [],
-                                  "events": [
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerX",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "ModVarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_DisplacementX",
-                                            "=",
-                                            "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerX) * RandomWithStep(-1, 1, 2)"
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "BuiltinCommonInstructions::Standard",
-                                      "conditions": [
-                                        {
-                                          "type": {
-                                            "value": "VarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_PowerY",
-                                            "!=",
-                                            "0"
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "type": {
-                                            "value": "ModVarGlobal"
-                                          },
-                                          "parameters": [
-                                            "__CameraShake_DisplacementY",
-                                            "=",
-                                            "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerY) * RandomWithStep(-1, 1, 2)"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Calculate Rotation (angle) shake ",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "VarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_PowerAngle",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Every \"even\" shake, rotate counter-clockwise",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "DisplacementAngle = ((DesiredDuration - RunningTimer) / DesiredDuration) * Amplitude",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "Egal"
-                                      },
-                                      "parameters": [
-                                        "mod(GlobalVariable(__CameraShake_ShakeCounter),2)",
-                                        "=",
-                                        "0"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementAngle",
-                                        "=",
-                                        "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) *  GlobalVariable(__CameraShake_PowerAngle)"
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Every \"odd\" shake, rotate clockwise (this includes the initial shake and can be used for a one shake effect)",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "DisplacementAngle = -1 * ((DesiredDuration - RunningTimer) / DesiredDuration) * Amplitude",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "Egal"
-                                      },
-                                      "parameters": [
-                                        "mod(GlobalVariable(__CameraShake_ShakeCounter),2)",
-                                        "=",
-                                        "1"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementAngle",
-                                        "=",
-                                        "-1 * (GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) *  GlobalVariable(__CameraShake_PowerAngle)"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Calculate Zoom shake",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "VarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_PowerZoom",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Calculate camera zoom displacement, with linear decay over time",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "ZoomDisplacement = ((DesiredDuration - RunningTimer) / DesiredDuration) * Amplitude *  1/100",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Every even shake, increase zoom",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "Egal"
-                                      },
-                                      "parameters": [
-                                        "mod(GlobalVariable(__CameraShake_ShakeCounter),2)",
-                                        "=",
-                                        "0"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementZoom",
-                                        "=",
-                                        "-1 * (GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerZoom) * (1/100)"
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Every \"odd\" shake, decrease scale",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "ZoomDisplacement = -1 * ((DesiredDuration - RunningTimer) / DesiredDuration) * Amplitude *  1/100",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [
-                                    {
-                                      "type": {
-                                        "value": "Egal"
-                                      },
-                                      "parameters": [
-                                        "mod(GlobalVariable(__CameraShake_ShakeCounter),2)",
-                                        "=",
-                                        "1"
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementZoom",
-                                        "=",
-                                        "(GlobalVariable(__CameraShake_Duration) - TimerElapsedTime(\"__CameraShake_DurationTimer\")) / GlobalVariable(__CameraShake_Duration) * GlobalVariable(__CameraShake_PowerZoom) * (1/100)"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Save that initial shake has been processed",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ModVarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_InitialShake",
-                                    "=",
-                                    "0"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Move camera",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Calculate the fraction of shake that occured during this frame",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "ModVarScene"
-                              },
-                              "parameters": [
-                                "__CameraShake_PercentTimeElapsedThisFrame",
-                                "=",
-                                "min(1,TimeDelta()/GlobalVariable(__CameraShake_TimeBetweenShakes))"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Increase change for the first half of the shake (move away from original values)",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "Timer"
-                              },
-                              "parameters": [
-                                "",
-                                "GlobalVariable(__CameraShake_TimeBetweenShakes)/2",
-                                "\"__CameraShake_ShakeTimer\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change position",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::Or"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerX",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerY",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "CameraX"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "-",
-                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "CameraY"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "-",
-                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save movement to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledX",
-                                        "-",
-                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledY",
-                                        "-",
-                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change angle",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "Egal"
-                                  },
-                                  "parameters": [
-                                    "GlobalVariable(__CameraShake_PowerAngle)",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "RotateCamera"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "+",
-                                    "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    ""
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save movement to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_AngleTravelled",
-                                        "+",
-                                        "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change zoom",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "Egal"
-                                  },
-                                  "parameters": [
-                                    "GlobalVariable(__CameraShake_PowerZoom)",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ZoomCamera"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) + round(1024 * GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save movement to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_ZoomTravelled",
-                                        "+",
-                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Decrease change the second half of the shake (return to original position)",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "Timer"
-                              },
-                              "parameters": [
-                                "",
-                                "GlobalVariable(__CameraShake_TimeBetweenShakes)/2",
-                                "\"__CameraShake_ShakeTimer\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change position",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::Or"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerX",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "VarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_PowerY",
-                                        "!=",
-                                        "0"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "CameraX"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "+",
-                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "CameraY"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "+",
-                                    "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save the amount of change to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledX",
-                                        "+",
-                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementX) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_DisplacementTravelledY",
-                                        "+",
-                                        "round(1024 * GlobalVariable(__CameraShake_DisplacementY) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change angle",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "Egal"
-                                  },
-                                  "parameters": [
-                                    "GlobalVariable(__CameraShake_PowerAngle)",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "RotateCamera"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "-",
-                                    "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    ""
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save the amount of change to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_AngleTravelled",
-                                        "-",
-                                        "round(1024 * (GlobalVariable(__CameraShake_DisplacementAngle) * Variable(__CameraShake_PercentTimeElapsedThisFrame))) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Comment",
-                              "color": {
-                                "b": 109,
-                                "g": 230,
-                                "r": 255,
-                                "textB": 0,
-                                "textG": 0,
-                                "textR": 0
-                              },
-                              "comment": "Change zoom",
-                              "comment2": ""
-                            },
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "Egal"
-                                  },
-                                  "parameters": [
-                                    "GlobalVariable(__CameraShake_PowerZoom)",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "ZoomCamera"
-                                  },
-                                  "parameters": [
-                                    "",
-                                    "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) - round(1024 *  GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024",
-                                    "GlobalVariableString(__CameraShake_Layer)",
-                                    "GlobalVariable(__CameraShake_Camera)"
-                                  ]
-                                }
-                              ],
-                              "events": [
-                                {
-                                  "type": "BuiltinCommonInstructions::Comment",
-                                  "color": {
-                                    "b": 109,
-                                    "g": 230,
-                                    "r": 255,
-                                    "textB": 0,
-                                    "textG": 0,
-                                    "textR": 0
-                                  },
-                                  "comment": "Save the amount of change to calculate drift",
-                                  "comment2": ""
-                                },
-                                {
-                                  "type": "BuiltinCommonInstructions::Standard",
-                                  "conditions": [],
-                                  "actions": [
-                                    {
-                                      "type": {
-                                        "value": "ModVarGlobal"
-                                      },
-                                      "parameters": [
-                                        "__CameraShake_ZoomTravelled",
-                                        "-",
-                                        "round(1024 *  GlobalVariable(__CameraShake_DisplacementZoom) * Variable(__CameraShake_PercentTimeElapsedThisFrame)) / 1024"
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "name": "Stop shaking",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Stop shaking when the duration has been reached or if stop shaking has been requested",
-                  "comment2": ""
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Or"
-                      },
-                      "parameters": [],
-                      "subInstructions": [
-                        {
-                          "type": {
-                            "value": "Timer"
-                          },
-                          "parameters": [
-                            "",
-                            "GlobalVariable(__CameraShake_Duration)",
-                            "\"__CameraShake_DurationTimer\""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "VarGlobal"
-                          },
-                          "parameters": [
-                            "__CameraShake_ShakeInProgress",
-                            "=",
-                            "-1"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarGlobal"
-                      },
-                      "parameters": [
-                        "__CameraShake_ShakeInProgress",
-                        "=",
-                        "0"
-                      ]
-                    }
-                  ],
-                  "events": [
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Correct for drift and reset drift tracking variables",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Move to correct drift from previous shake",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "VarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_PowerAngle",
-                                "!=",
-                                "0"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "RotateCamera"
-                              },
-                              "parameters": [
-                                "",
-                                "-",
-                                "GlobalVariable(__CameraShake_AngleTravelled)",
-                                "GlobalVariableString(__CameraShake_Layer)",
-                                "GlobalVariable(__CameraShake_Camera)"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "VarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_PowerZoom",
-                                "!=",
-                                "0"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "ZoomCamera"
-                              },
-                              "parameters": [
-                                "",
-                                "CameraZoom(GlobalVariableString(__CameraShake_Layer),GlobalVariable(__CameraShake_Camera)) - GlobalVariable(__CameraShake_ZoomTravelled)",
-                                "GlobalVariableString(__CameraShake_Layer)",
-                                "GlobalVariable(__CameraShake_Camera)"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::Or"
-                              },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "VarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_PowerX",
-                                    "!=",
-                                    "0"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "VarGlobal"
-                                  },
-                                  "parameters": [
-                                    "__CameraShake_PowerY",
-                                    "!=",
-                                    "0"
-                                  ]
-                                }
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetCameraX"
-                              },
-                              "parameters": [
-                                "Object",
-                                "-",
-                                "GlobalVariable(__CameraShake_DisplacementTravelledX)",
-                                "GlobalVariableString(__CameraShake_Layer)",
-                                "GlobalVariable(__CameraShake_Camera)"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "SetCameraY"
-                              },
-                              "parameters": [
-                                "Object",
-                                "-",
-                                "GlobalVariable(__CameraShake_DisplacementTravelledY)",
-                                "GlobalVariableString(__CameraShake_Layer)",
-                                "GlobalVariable(__CameraShake_Camera)"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Comment",
-                          "color": {
-                            "b": 109,
-                            "g": 230,
-                            "r": 255,
-                            "textB": 0,
-                            "textG": 0,
-                            "textR": 0
-                          },
-                          "comment": "Reset drift detection variables",
-                          "comment2": ""
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_DisplacementTravelledX",
-                                "=",
-                                "0"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_DisplacementTravelledY",
-                                "=",
-                                "0"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_AngleTravelled",
-                                "=",
-                                "0"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_ZoomTravelled",
-                                "=",
-                                "0"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "ModVarGlobal"
-                              },
-                              "parameters": [
-                                "__CameraShake_ShakeCounter",
-                                "=",
-                                "0"
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    }
-                  ]
-                }
-              ],
-              "parameters": []
-            }
-          ],
-          "parameters": []
-        }
-      ],
-      "parameters": [],
-      "objectGroups": []
-    },
-    {
-      "description": "Check if camera is shaking.",
-      "fullName": "Check if camera is shaking",
-      "functionType": "Condition",
-      "group": "",
-      "name": "IsShaking",
-      "private": false,
-      "sentence": " Camera is shaking",
-      "events": [
-        {
+          "disabled": false,
+          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarGlobal"
-              },
-              "parameters": [
-                "__CameraShake_ShakeInProgress",
-                "=",
-                "1"
-              ]
-            }
-          ],
+          "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "SetReturnBoolean"
+                "inverted": false,
+                "value": "ResetTimer"
               },
               "parameters": [
-                "True"
-              ]
+                "",
+                "\"__CameraShake_DurationTimer\""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Duration",
+                "=",
+                "1234567890"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StartEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"EaseDuration\")"
+              ],
+              "subInstructions": []
             }
-          ]
+          ],
+          "events": []
         }
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Ease duration (in seconds)",
+          "longDescription": "",
+          "name": "EaseDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
       "objectGroups": []
     },
     {
       "description": "Stop shaking the camera.",
-      "fullName": "Stop shaking the camera",
+      "fullName": "Stop camera shaking",
       "functionType": "Action",
       "group": "",
       "name": "StopShaking",
       "private": false,
-      "sentence": "Stop shaking the camera",
+      "sentence": "Stop shaking the camera with _PARAM1_ seconds of easing",
       "events": [
         {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ResetTimer"
+              },
+              "parameters": [
+                "",
+                "\"__CameraShake_DurationTimer\""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Duration",
+                "=",
+                "GetArgumentAsNumber(\"EaseDuration\")"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_StopEaseDuration",
+                "=",
+                "GetArgumentAsNumber(\"EaseDuration\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Ease duration (in seconds)",
+          "longDescription": "",
+          "name": "EaseDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Mark a layer as shakable.",
+      "fullName": "Shakable layer",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetLayerShakable",
+      "private": false,
+      "sentence": "Mark the layer: _PARAM2_ as shakable: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "value": "CameraShake::IsShaking"
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::CompareStrings"
               },
               "parameters": [
-                "",
-                ""
-              ]
+                "GetArgumentAsString(\"Layer\")",
+                "=",
+                "\"\""
+              ],
+              "subInstructions": []
             }
           ],
           "actions": [
             {
               "type": {
-                "value": "ModVarGlobal"
+                "inverted": false,
+                "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__CameraShake_ShakeInProgress",
+                "__CameraShake_LayerName",
                 "=",
-                "-1"
-              ]
+                "\"__BaseLayer\""
+              ],
+              "subInstructions": []
             }
-          ]
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"Shakable\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                "="
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"Shakable\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Shakable",
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "yes",
+          "description": "Shakable",
+          "longDescription": "",
+          "name": "Shakable",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if the camera is shaking.",
+      "fullName": "Camera is shaking",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsShaking",
+      "private": false,
+      "sentence": "Camera is shaking",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "CompareTimer"
+              },
+              "parameters": [
+                "",
+                "\"__CameraShake_DurationTimer\"",
+                "<",
+                "Variable(__CameraShake_Duration)"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
         }
       ],
       "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the translation amplitude of the shaking (in pixels).",
+      "fullName": "Layer translation amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetLayerTranslationAmplitude",
+      "private": false,
+      "sentence": "Change the translation amplitude of the shaking to _PARAM1_; _PARAM2_ (layer: _PARAM3_)",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Layer\")",
+                "=",
+                "\"\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "\"__BaseLayer\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeX",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeX\")"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeY",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeY\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Amplitude of shaking on the X axis (in pixels)",
+          "longDescription": "",
+          "name": "AmplitudeX",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Amplitude of shaking on the Y axis (in pixels)",
+          "longDescription": "",
+          "name": "AmplitudeY",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the rotation amplitude of the shaking (in degrees).",
+      "fullName": "Layer rotation amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetLayerRotationAmplitude",
+      "private": false,
+      "sentence": "Change the rotation amplitude of the shaking to _PARAM1_ degrees (layer: _PARAM2_)",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Layer\")",
+                "=",
+                "\"\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "\"__BaseLayer\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeAngle",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeAngle\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Angle (in degree)",
+          "longDescription": "",
+          "name": "AmplitudeAngle",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the zoom factor amplitude of the shaking. The shaking will zoom and unzoom by this factor (for instance 1.0625 is a valid value).",
+      "fullName": "Layer zoom amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetLayerZoomAmplitude",
+      "private": false,
+      "sentence": "Change the zoom factor amplitude of the shaking to _PARAM1_ (layer: _PARAM2_)",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Layer\")",
+                "=",
+                "\"\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "\"__BaseLayer\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].AmplitudeZoom",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeZoom\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Zoom factor",
+          "longDescription": "",
+          "name": "AmplitudeZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the number of back and forth per seconds.",
+      "fullName": "Layer shaking frequency",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetLayerShakingFrequency",
+      "private": false,
+      "sentence": "Change the shaking frequency to _PARAM1_ (layer: _PARAM2_)",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Layer\")",
+                "=",
+                "\"\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraShake_LayerName",
+                "=",
+                "\"__BaseLayer\""
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        },
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_Layers[VariableString(__CameraShake_LayerName)].Frequency",
+                "=",
+                "GetArgumentAsNumber(\"Frequency\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Frequency",
+          "longDescription": "",
+          "name": "Frequency",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the default translation amplitude of the shaking (in pixels).",
+      "fullName": "Default translation amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetDefaultTranslationAmplitude",
+      "private": false,
+      "sentence": "Change the default translation amplitude of the shaking to _PARAM1_; _PARAM2_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_DefaultAmplitudeX",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeX\")"
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_DefaultAmplitudeY",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeY\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Amplitude of shaking on the X axis (in pixels)",
+          "longDescription": "",
+          "name": "AmplitudeX",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Amplitude of shaking on the Y axis (in pixels)",
+          "longDescription": "",
+          "name": "AmplitudeY",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the default rotation amplitude of the shaking (in degrees).",
+      "fullName": "Default rotation amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetDefaultRotationAmplitude",
+      "private": false,
+      "sentence": "Change the default rotation amplitude of the shaking to _PARAM1_ degrees",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_DefaultAmplitudeAngle",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeAngle\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Angle (in degree)",
+          "longDescription": "",
+          "name": "AmplitudeAngle",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the default zoom factor amplitude of the shaking. The shaking will zoom and unzoom by this factor (for instance 1.0625 is a valid value).",
+      "fullName": "Default zoom amplitude",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetDefaultZoomAmplitude",
+      "private": false,
+      "sentence": "Change the default zoom factor amplitude of the shaking to _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_DefaultAmplitudeZoom",
+                "=",
+                "GetArgumentAsNumber(\"AmplitudeZoom\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Zoom factor",
+          "longDescription": "",
+          "name": "AmplitudeZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the default number of back and forth per seconds.",
+      "fullName": "Default shaking frequency",
+      "functionType": "Action",
+      "group": "Camera shake configuration",
+      "name": "SetDefaultShakingFrequency",
+      "private": false,
+      "sentence": "Change the default shaking frequency to _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraShake_DefaultFrequency",
+                "=",
+                "GetArgumentAsNumber(\"Frequency\")"
+              ],
+              "subInstructions": []
+            }
+          ],
+          "events": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Frequency",
+          "longDescription": "",
+          "name": "Frequency",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onFirstSceneLoaded",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "\ngdjs._cameraShakeExtension = gdjs._cameraShakeExtension || {};\n\n/** Noise generator manager. */\ngdjs._cameraShakeExtension.NoiseManager = /** @class */ (function () {\n    /**\n     * Create the manager of noise generators.\n     */\n    function NoiseManager() {\n        this.seed = gdjs.randomInRange(1, Number.MAX_SAFE_INTEGER);\n        /** @type {Map<string, gdjs._cameraShakeExtension.NoiseGenerator>} */\n        this.generators = new Map();\n    }\n\n    /**\n     * @param name {string}\n     * @return {gdjs._cameraShakeExtension.NoiseGenerator}\n     */\n    NoiseManager.prototype.getGenerator = function (name) {\n        let generator = this.generators.get(name);\n        if (!generator) {\n            generator = new gdjs._cameraShakeExtension.NoiseGenerator(name + this.seed);\n            this.generators.set(name, generator);\n        }\n        return generator;\n    }\n\n    /**\n     * @param seed {number}\n     */\n    NoiseManager.prototype.setSeed = function (seed) {\n        this.seed = seed;\n        this.generators.forEach(generator => generator.setSeed(seed));\n    }\n\n    /**\n     * @param name {string}\n     */\n    NoiseManager.prototype.deleteGenerator = function (name) {\n        this.generators.delete(name);\n    }\n\n    /**\n     */\n    NoiseManager.prototype.deleteAllGenerators = function () {\n        this.generators.clear();\n    }\n\n    return NoiseManager;\n}());\n\n/** Noise generator with octaves. */\ngdjs._cameraShakeExtension.NoiseGenerator = /** @class */ (function () {\n    /**\n     * Create a noise generator with a seed.\n     * @param seed {string}\n     */\n    function NoiseGenerator(seed) {\n        this.simplexNoise = new gdjs._cameraShakeExtension.SimplexNoise(seed);\n        this.frequency = 1;\n        this.octaves = 1;\n        this.persistence = 0.5;\n        this.lacunarity = 2;\n        this.xLoopPeriod = 0;\n        this.yLoopPeriod = 0;\n    }\n\n    /**\n     * @param seed {string}\n     */\n    NoiseGenerator.prototype.setSeed = function(seed) {\n        this.simplexNoise = new gdjs._cameraShakeExtension.SimplexNoise(seed);\n    }\n\n    /**\n     * @param x {float}\n     * @param y {float}\n     * @param z {float} optionnal\n     * @param w {float} optionnal\n     * @return {float}\n     */\n    NoiseGenerator.prototype.noise = function (x, y, z, w) {\n        if (this.xLoopPeriod && this.yLoopPeriod) {\n            const circleRatioX = 2 * Math.PI / this.xLoopPeriod;\n            const circleRatioY = 2 * Math.PI / this.yLoopPeriod;\n            const angleX = circleRatioX * x;\n            const angleY = circleRatioY * y;\n            x = Math.cos(angleX) / circleRatioX;\n            y = Math.sin(angleX) / circleRatioX;\n            z = Math.cos(angleY) / circleRatioY;\n            w = Math.sin(angleY) / circleRatioY;\n        }\n        else if (this.xLoopPeriod) {\n            const circleRatio = 2 * Math.PI / this.xLoopPeriod;\n            const angleX = circleRatio * x;\n            w = z;\n            z = y; \n            x = Math.cos(angleX) / circleRatio;\n            y = Math.sin(angleX) / circleRatio;\n        }\n        else if (this.yLoopPeriod) {\n            const circleRatio = 2 * Math.PI / this.xLoopPeriod;\n            const angleX = circleRatio * x;\n            w = z;\n            // Make the circle perimeter equals to the looping period\n            // to keep the same perceived frequency with or without looping.\n            y = Math.cos(angleX) / circleRatio;\n            z = Math.sin(angleX) / circleRatio;\n        }\n        let noiseFunction = this.simplexNoise.noise4D.bind(this.simplexNoise);\n        if (z === undefined) {\n            noiseFunction = this.simplexNoise.noise2D.bind(this.simplexNoise);\n        }\n        else if (w === undefined) {\n            noiseFunction = this.simplexNoise.noise3D.bind(this.simplexNoise);\n        }\n        let frequency = this.frequency;\n        let noiseSum = 0;\n        let amplitudeSum = 0;\n        let amplitude = 1;\n        for (let i = 0; i < this.octaves; i++) {\n            noiseSum += noiseFunction(x * frequency, y * frequency, z * frequency, w * frequency) * amplitude;\n            amplitudeSum += Math.abs(amplitude);\n            amplitude *= this.persistence;\n            frequency *= this.lacunarity;\n        }\n        return noiseSum / amplitudeSum;\n    }\n\n    return NoiseGenerator;\n}());\n\n/*\nA fast javascript implementation of simplex noise by Jonas Wagner\nhttps://github.com/jwagner/simplex-noise.js\n\nBased on a speed-improved simplex noise algorithm for 2D, 3D and 4D in Java.\nWhich is based on example code by Stefan Gustavson (stegu@itn.liu.se).\nWith Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).\nBetter rank ordering method by Stefan Gustavson in 2012.\n\n Copyright (c) 2021 Jonas Wagner\n\n Permission is hereby granted, free of charge, to any person obtaining a copy\n of this software and associated documentation files (the \"Software\"), to deal\n in the Software without restriction, including without limitation the rights\n to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n copies of the Software, and to permit persons to whom the Software is\n furnished to do so, subject to the following conditions:\n\n The above copyright notice and this permission notice shall be included in all\n copies or substantial portions of the Software.\n\n THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n SOFTWARE.\n */\n\nconst F2 = 0.5 * (Math.sqrt(3.0) - 1.0);\nconst G2 = (3.0 - Math.sqrt(3.0)) / 6.0;\nconst F3 = 1.0 / 3.0;\nconst G3 = 1.0 / 6.0;\nconst F4 = (Math.sqrt(5.0) - 1.0) / 4.0;\nconst G4 = (5.0 - Math.sqrt(5.0)) / 20.0;\nconst grad3 = new Float32Array([1, 1, 0,\n    -1, 1, 0,\n    1, -1, 0,\n    -1, -1, 0,\n    1, 0, 1,\n    -1, 0, 1,\n    1, 0, -1,\n    -1, 0, -1,\n    0, 1, 1,\n    0, -1, 1,\n    0, 1, -1,\n    0, -1, -1]);\nconst grad4 = new Float32Array([0, 1, 1, 1, 0, 1, 1, -1, 0, 1, -1, 1, 0, 1, -1, -1,\n    0, -1, 1, 1, 0, -1, 1, -1, 0, -1, -1, 1, 0, -1, -1, -1,\n    1, 0, 1, 1, 1, 0, 1, -1, 1, 0, -1, 1, 1, 0, -1, -1,\n    -1, 0, 1, 1, -1, 0, 1, -1, -1, 0, -1, 1, -1, 0, -1, -1,\n    1, 1, 0, 1, 1, 1, 0, -1, 1, -1, 0, 1, 1, -1, 0, -1,\n    -1, 1, 0, 1, -1, 1, 0, -1, -1, -1, 0, 1, -1, -1, 0, -1,\n    1, 1, 1, 0, 1, 1, -1, 0, 1, -1, 1, 0, 1, -1, -1, 0,\n    -1, 1, 1, 0, -1, 1, -1, 0, -1, -1, 1, 0, -1, -1, -1, 0]);\n\n/** Deterministic simplex noise generator suitable for 2D, 3D and 4D spaces. */\ngdjs._cameraShakeExtension.SimplexNoise = /** @class */ (function () {\n    /**\n     * Creates a new `SimplexNoise` instance.\n     * This involves some setup. You can save a few cpu cycles by reusing the same instance.\n     * @param {(() => number)|string|number} randomOrSeed A random number generator or a seed (string|number).\n     * Defaults to Math.random (random irreproducible initialization).\n     */\n    function SimplexNoise(randomOrSeed) {\n        if (randomOrSeed === void 0) { randomOrSeed = Math.random; }\n        const random = typeof randomOrSeed == 'function' ? randomOrSeed : alea(randomOrSeed);\n        this.p = buildPermutationTable(random);\n        this.perm = new Uint8Array(512);\n        this.permMod12 = new Uint8Array(512);\n        for (let i = 0; i < 512; i++) {\n            this.perm[i] = this.p[i & 255];\n            this.permMod12[i] = this.perm[i] % 12;\n        }\n    }\n\n    /**\n     * Samples the noise field in 2 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise2D = function (x, y) {\n        const permMod12 = this.permMod12;\n        const perm = this.perm;\n        let n0 = 0; // Noise contributions from the three corners\n        let n1 = 0;\n        let n2 = 0;\n        // Skew the input space to determine which simplex cell we're in\n        const s = (x + y) * F2; // Hairy factor for 2D\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const t = (i + j) * G2;\n        const X0 = i - t; // Unskew the cell origin back to (x,y) space\n        const Y0 = j - t;\n        const x0 = x - X0; // The x,y distances from the cell origin\n        const y0 = y - Y0;\n        // For the 2D case, the simplex shape is an equilateral triangle.\n        // Determine which simplex we are in.\n        let i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords\n        if (x0 > y0) {\n            i1 = 1;\n            j1 = 0;\n        } // lower triangle, XY order: (0,0)->(1,0)->(1,1)\n        else {\n            i1 = 0;\n            j1 = 1;\n        } // upper triangle, YX order: (0,0)->(0,1)->(1,1)\n        // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and\n        // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where\n        // c = (3-sqrt(3))/6\n        const x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords\n        const y1 = y0 - j1 + G2;\n        const x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y) unskewed coords\n        const y2 = y0 - 1.0 + 2.0 * G2;\n        // Work out the hashed gradient indices of the three simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        // Calculate the contribution from the three corners\n        let t0 = 0.5 - x0 * x0 - y0 * y0;\n        if (t0 >= 0) {\n            const gi0 = permMod12[ii + perm[jj]] * 3;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad3[gi0] * x0 + grad3[gi0 + 1] * y0); // (x,y) of grad3 used for 2D gradient\n        }\n        let t1 = 0.5 - x1 * x1 - y1 * y1;\n        if (t1 >= 0) {\n            const gi1 = permMod12[ii + i1 + perm[jj + j1]] * 3;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad3[gi1] * x1 + grad3[gi1 + 1] * y1);\n        }\n        let t2 = 0.5 - x2 * x2 - y2 * y2;\n        if (t2 >= 0) {\n            const gi2 = permMod12[ii + 1 + perm[jj + 1]] * 3;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad3[gi2] * x2 + grad3[gi2 + 1] * y2);\n        }\n        // Add contributions from each corner to get the final noise value.\n        // The result is scaled to return values in the interval [-1,1].\n        return 70.0 * (n0 + n1 + n2);\n    }\n\n    /**\n     * Samples the noise field in 3 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @param {number} z\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise3D = function (x, y, z) {\n        const permMod12 = this.permMod12;\n        const perm = this.perm;\n        let n0, n1, n2, n3; // Noise contributions from the four corners\n        // Skew the input space to determine which simplex cell we're in\n        const s = (x + y + z) * F3; // Very nice and simple skew factor for 3D\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const k = Math.floor(z + s);\n        const t = (i + j + k) * G3;\n        const X0 = i - t; // Unskew the cell origin back to (x,y,z) space\n        const Y0 = j - t;\n        const Z0 = k - t;\n        const x0 = x - X0; // The x,y,z distances from the cell origin\n        const y0 = y - Y0;\n        const z0 = z - Z0;\n        // For the 3D case, the simplex shape is a slightly irregular tetrahedron.\n        // Determine which simplex we are in.\n        let i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords\n        let i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords\n        if (x0 >= y0) {\n            if (y0 >= z0) {\n                i1 = 1;\n                j1 = 0;\n                k1 = 0;\n                i2 = 1;\n                j2 = 1;\n                k2 = 0;\n            } // X Y Z order\n            else if (x0 >= z0) {\n                i1 = 1;\n                j1 = 0;\n                k1 = 0;\n                i2 = 1;\n                j2 = 0;\n                k2 = 1;\n            } // X Z Y order\n            else {\n                i1 = 0;\n                j1 = 0;\n                k1 = 1;\n                i2 = 1;\n                j2 = 0;\n                k2 = 1;\n            } // Z X Y order\n        }\n        else { // x0<y0\n            if (y0 < z0) {\n                i1 = 0;\n                j1 = 0;\n                k1 = 1;\n                i2 = 0;\n                j2 = 1;\n                k2 = 1;\n            } // Z Y X order\n            else if (x0 < z0) {\n                i1 = 0;\n                j1 = 1;\n                k1 = 0;\n                i2 = 0;\n                j2 = 1;\n                k2 = 1;\n            } // Y Z X order\n            else {\n                i1 = 0;\n                j1 = 1;\n                k1 = 0;\n                i2 = 1;\n                j2 = 1;\n                k2 = 0;\n            } // Y X Z order\n        }\n        // A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),\n        // a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and\n        // a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z), where\n        // c = 1/6.\n        const x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords\n        const y1 = y0 - j1 + G3;\n        const z1 = z0 - k1 + G3;\n        const x2 = x0 - i2 + 2.0 * G3; // Offsets for third corner in (x,y,z) coords\n        const y2 = y0 - j2 + 2.0 * G3;\n        const z2 = z0 - k2 + 2.0 * G3;\n        const x3 = x0 - 1.0 + 3.0 * G3; // Offsets for last corner in (x,y,z) coords\n        const y3 = y0 - 1.0 + 3.0 * G3;\n        const z3 = z0 - 1.0 + 3.0 * G3;\n        // Work out the hashed gradient indices of the four simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        const kk = k & 255;\n        // Calculate the contribution from the four corners\n        let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;\n        if (t0 < 0)\n            n0 = 0.0;\n        else {\n            const gi0 = permMod12[ii + perm[jj + perm[kk]]] * 3;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad3[gi0] * x0 + grad3[gi0 + 1] * y0 + grad3[gi0 + 2] * z0);\n        }\n        let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;\n        if (t1 < 0)\n            n1 = 0.0;\n        else {\n            const gi1 = permMod12[ii + i1 + perm[jj + j1 + perm[kk + k1]]] * 3;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad3[gi1] * x1 + grad3[gi1 + 1] * y1 + grad3[gi1 + 2] * z1);\n        }\n        let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;\n        if (t2 < 0)\n            n2 = 0.0;\n        else {\n            const gi2 = permMod12[ii + i2 + perm[jj + j2 + perm[kk + k2]]] * 3;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad3[gi2] * x2 + grad3[gi2 + 1] * y2 + grad3[gi2 + 2] * z2);\n        }\n        let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;\n        if (t3 < 0)\n            n3 = 0.0;\n        else {\n            const gi3 = permMod12[ii + 1 + perm[jj + 1 + perm[kk + 1]]] * 3;\n            t3 *= t3;\n            n3 = t3 * t3 * (grad3[gi3] * x3 + grad3[gi3 + 1] * y3 + grad3[gi3 + 2] * z3);\n        }\n        // Add contributions from each corner to get the final noise value.\n        // The result is scaled to stay just inside [-1,1]\n        return 32.0 * (n0 + n1 + n2 + n3);\n    }\n\n    /**\n     * Samples the noise field in 4 dimensions\n     * @param {number} x\n     * @param {number} y\n     * @param {number} z\n     * @returns a number in the interval [-1, 1]\n     */\n    SimplexNoise.prototype.noise4D = function (x, y, z, w) {\n        const perm = this.perm;\n        let n0, n1, n2, n3, n4; // Noise contributions from the five corners\n        // Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in\n        const s = (x + y + z + w) * F4; // Factor for 4D skewing\n        const i = Math.floor(x + s);\n        const j = Math.floor(y + s);\n        const k = Math.floor(z + s);\n        const l = Math.floor(w + s);\n        const t = (i + j + k + l) * G4; // Factor for 4D unskewing\n        const X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space\n        const Y0 = j - t;\n        const Z0 = k - t;\n        const W0 = l - t;\n        const x0 = x - X0; // The x,y,z,w distances from the cell origin\n        const y0 = y - Y0;\n        const z0 = z - Z0;\n        const w0 = w - W0;\n        // For the 4D case, the simplex is a 4D shape I won't even try to describe.\n        // To find out which of the 24 possible simplices we're in, we need to\n        // determine the magnitude ordering of x0, y0, z0 and w0.\n        // Six pair-wise comparisons are performed between each possible pair\n        // of the four coordinates, and the results are used to rank the numbers.\n        let rankx = 0;\n        let ranky = 0;\n        let rankz = 0;\n        let rankw = 0;\n        if (x0 > y0)\n            rankx++;\n        else\n            ranky++;\n        if (x0 > z0)\n            rankx++;\n        else\n            rankz++;\n        if (x0 > w0)\n            rankx++;\n        else\n            rankw++;\n        if (y0 > z0)\n            ranky++;\n        else\n            rankz++;\n        if (y0 > w0)\n            ranky++;\n        else\n            rankw++;\n        if (z0 > w0)\n            rankz++;\n        else\n            rankw++;\n        // simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some order.\n        // Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w and x<w\n        // impossible. Only the 24 indices which have non-zero entries make any sense.\n        // We use a thresholding to set the coordinates in turn from the largest magnitude.\n        // Rank 3 denotes the largest coordinate.\n        // Rank 2 denotes the second largest coordinate.\n        // Rank 1 denotes the second smallest coordinate.\n        // The integer offsets for the second simplex corner\n        const i1 = rankx >= 3 ? 1 : 0;\n        const j1 = ranky >= 3 ? 1 : 0;\n        const k1 = rankz >= 3 ? 1 : 0;\n        const l1 = rankw >= 3 ? 1 : 0;\n        // The integer offsets for the third simplex corner\n        const i2 = rankx >= 2 ? 1 : 0;\n        const j2 = ranky >= 2 ? 1 : 0;\n        const k2 = rankz >= 2 ? 1 : 0;\n        const l2 = rankw >= 2 ? 1 : 0;\n        // The integer offsets for the fourth simplex corner\n        const i3 = rankx >= 1 ? 1 : 0;\n        const j3 = ranky >= 1 ? 1 : 0;\n        const k3 = rankz >= 1 ? 1 : 0;\n        const l3 = rankw >= 1 ? 1 : 0;\n        // The fifth corner has all coordinate offsets = 1, so no need to compute that.\n        const x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coords\n        const y1 = y0 - j1 + G4;\n        const z1 = z0 - k1 + G4;\n        const w1 = w0 - l1 + G4;\n        const x2 = x0 - i2 + 2.0 * G4; // Offsets for third corner in (x,y,z,w) coords\n        const y2 = y0 - j2 + 2.0 * G4;\n        const z2 = z0 - k2 + 2.0 * G4;\n        const w2 = w0 - l2 + 2.0 * G4;\n        const x3 = x0 - i3 + 3.0 * G4; // Offsets for fourth corner in (x,y,z,w) coords\n        const y3 = y0 - j3 + 3.0 * G4;\n        const z3 = z0 - k3 + 3.0 * G4;\n        const w3 = w0 - l3 + 3.0 * G4;\n        const x4 = x0 - 1.0 + 4.0 * G4; // Offsets for last corner in (x,y,z,w) coords\n        const y4 = y0 - 1.0 + 4.0 * G4;\n        const z4 = z0 - 1.0 + 4.0 * G4;\n        const w4 = w0 - 1.0 + 4.0 * G4;\n        // Work out the hashed gradient indices of the five simplex corners\n        const ii = i & 255;\n        const jj = j & 255;\n        const kk = k & 255;\n        const ll = l & 255;\n        // Calculate the contribution from the five corners\n        let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;\n        if (t0 < 0)\n            n0 = 0.0;\n        else {\n            const gi0 = (perm[ii + perm[jj + perm[kk + perm[ll]]]] % 32) * 4;\n            t0 *= t0;\n            n0 = t0 * t0 * (grad4[gi0] * x0 + grad4[gi0 + 1] * y0 + grad4[gi0 + 2] * z0 + grad4[gi0 + 3] * w0);\n        }\n        let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;\n        if (t1 < 0)\n            n1 = 0.0;\n        else {\n            const gi1 = (perm[ii + i1 + perm[jj + j1 + perm[kk + k1 + perm[ll + l1]]]] % 32) * 4;\n            t1 *= t1;\n            n1 = t1 * t1 * (grad4[gi1] * x1 + grad4[gi1 + 1] * y1 + grad4[gi1 + 2] * z1 + grad4[gi1 + 3] * w1);\n        }\n        let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;\n        if (t2 < 0)\n            n2 = 0.0;\n        else {\n            const gi2 = (perm[ii + i2 + perm[jj + j2 + perm[kk + k2 + perm[ll + l2]]]] % 32) * 4;\n            t2 *= t2;\n            n2 = t2 * t2 * (grad4[gi2] * x2 + grad4[gi2 + 1] * y2 + grad4[gi2 + 2] * z2 + grad4[gi2 + 3] * w2);\n        }\n        let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;\n        if (t3 < 0)\n            n3 = 0.0;\n        else {\n            const gi3 = (perm[ii + i3 + perm[jj + j3 + perm[kk + k3 + perm[ll + l3]]]] % 32) * 4;\n            t3 *= t3;\n            n3 = t3 * t3 * (grad4[gi3] * x3 + grad4[gi3 + 1] * y3 + grad4[gi3 + 2] * z3 + grad4[gi3 + 3] * w3);\n        }\n        let t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;\n        if (t4 < 0)\n            n4 = 0.0;\n        else {\n            const gi4 = (perm[ii + 1 + perm[jj + 1 + perm[kk + 1 + perm[ll + 1]]]] % 32) * 4;\n            t4 *= t4;\n            n4 = t4 * t4 * (grad4[gi4] * x4 + grad4[gi4 + 1] * y4 + grad4[gi4 + 2] * z4 + grad4[gi4 + 3] * w4);\n        }\n        // Sum up and scale the result to cover the range [-1,1]\n        return 27.0 * (n0 + n1 + n2 + n3 + n4);\n    };\n\n    /**\n     * Builds a random permutation table.\n     * This is exported only for (internal) testing purposes.\n     * Do not rely on this export.\n     * @param {() => number} random\n     * @private\n     */\n    function buildPermutationTable(random) {\n        const p = new Uint8Array(256);\n        for (let i = 0; i < 256; i++) {\n            p[i] = i;\n        }\n        for (let i = 0; i < 255; i++) {\n            const r = i + ~~(random() * (256 - i));\n            const aux = p[i];\n            p[i] = p[r];\n            p[r] = aux;\n        }\n        return p;\n    }\n\n    /*\n    The ALEA PRNG and masher code used by simplex-noise.js\n    is based on code by Johannes Baagøe, modified by Jonas Wagner.\n    See alea.md for the full license.\n    @param {string|number} seed\n    */\n    function alea(seed) {\n        let s0 = 0;\n        let s1 = 0;\n        let s2 = 0;\n        let c = 1;\n        const mash = masher();\n        s0 = mash(' ');\n        s1 = mash(' ');\n        s2 = mash(' ');\n        s0 -= mash(seed);\n        if (s0 < 0) {\n            s0 += 1;\n        }\n        s1 -= mash(seed);\n        if (s1 < 0) {\n            s1 += 1;\n        }\n        s2 -= mash(seed);\n        if (s2 < 0) {\n            s2 += 1;\n        }\n        return function () {\n            const t = 2091639 * s0 + c * 2.3283064365386963e-10; // 2^-32\n            s0 = s1;\n            s1 = s2;\n            return s2 = t - (c = t | 0);\n        };\n    }\n\n    function masher() {\n        let n = 0xefc8249d;\n        return function (data) {\n            data = data.toString();\n            for (let i = 0; i < data.length; i++) {\n                n += data.charCodeAt(i);\n                let h = 0.02519603282416938 * n;\n                n = h >>> 0;\n                h -= n;\n                h *= n;\n                n = h >>> 0;\n                h -= n;\n                n += h * 0x100000000; // 2^32\n            }\n            return (n >>> 0) * 2.3283064365386963e-10; // 2^-32\n        };\n    }\n    return SimplexNoise;\n}());\n\ngdjs._cameraShakeExtension.noiseManager = new gdjs._cameraShakeExtension.NoiseManager();",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Generate a number from 2 dimensional simplex noise.",
+      "fullName": "2D noise",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Noise2d",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y);",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "X coordinate",
+          "longDescription": "",
+          "name": "X",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Y coordinate",
+          "longDescription": "",
+          "name": "Y",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Generate a number from 3 dimensional simplex noise.",
+      "fullName": "3D noise",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Noise3d",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\nconst z = eventsFunctionContext.getArgument(\"Z\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y, z);",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "X coordinate",
+          "longDescription": "",
+          "name": "X",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Y coordinate",
+          "longDescription": "",
+          "name": "Y",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Z coordinate",
+          "longDescription": "",
+          "name": "Z",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Generate a number from 4 dimensional simplex noise.",
+      "fullName": "4D noise",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Noise4d",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\nconst x = eventsFunctionContext.getArgument(\"X\");\r\nconst y = eventsFunctionContext.getArgument(\"Y\");\r\nconst z = eventsFunctionContext.getArgument(\"Z\");\r\nconst w = eventsFunctionContext.getArgument(\"W\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).noise(x, y, z, w);",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "X coordinate",
+          "longDescription": "",
+          "name": "X",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Y coordinate",
+          "longDescription": "",
+          "name": "Y",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Z coordinate",
+          "longDescription": "",
+          "name": "Z",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "W coordinate",
+          "longDescription": "",
+          "name": "W",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Create a noise generator with default settings (frequency = 1,  octaves = 1, persistence = 0.5, lacunarity = 2).",
+      "fullName": "Create a noise generator",
+      "functionType": "Action",
+      "group": "",
+      "name": "Create",
+      "private": true,
+      "sentence": "Create a noise generator named _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name);",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Delete a noise generators and loose its settings.",
+      "fullName": "Delete a noise generator",
+      "functionType": "Action",
+      "group": "",
+      "name": "Delete",
+      "private": true,
+      "sentence": "Delete _PARAM1_ noise generator",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.deleteGenerator(name);",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Delete all noise generators and loose their settings.",
+      "fullName": "Delete all noise generators",
+      "functionType": "Action",
+      "group": "",
+      "name": "DeleteAll",
+      "private": true,
+      "sentence": "Delete all noise generators",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs._cameraShakeExtension.noiseManager.deleteAllGenerators();",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "The seed is a number used to generate the random noise. Setting the same seed will result in the same random noise generation. It's for example useful to generate the same world, by saving this seed value and reusing it later to generate again a world.",
+      "fullName": "Noise seed",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetSeed",
+      "private": true,
+      "sentence": "Change the noise seed to _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs._cameraShakeExtension.noiseManager.setSeed(eventsFunctionContext.getArgument(\"Seed\"));",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Seed",
+          "longDescription": "15 digits numbers maximum",
+          "name": "Seed",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the looping period on X used for noise generation. The noise will wrap-around on X.",
+      "fullName": "Noise looping period on X",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetLoopPeriodX",
+      "private": true,
+      "sentence": "Change the looping period on X of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).xLoopPeriod = eventsFunctionContext.getArgument(\"LoopPeriod\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Looping period on X",
+          "longDescription": "",
+          "name": "LoopPeriod",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the looping period on Y used for noise generation. The noise will wrap-around on Y.",
+      "fullName": "Noise looping period on Y",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetLoopPeriodY",
+      "private": true,
+      "sentence": "Change the looping period on Y of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).yLoopPeriod = eventsFunctionContext.getArgument(\"LoopPeriod\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Looping period on Y",
+          "longDescription": "",
+          "name": "LoopPeriod",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the base frequency used for noise generation. A lower frequency will zoom in the noise.",
+      "fullName": "Noise base frequency",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetFrequency",
+      "private": true,
+      "sentence": "Change the noise frequency of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).frequency = eventsFunctionContext.getArgument(\"Frequency\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Frequency",
+          "longDescription": "",
+          "name": "Frequency",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the number of octaves used for noise generation. It can be seen as layers of noise with different zoom.",
+      "fullName": "Noise octaves",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetOctaves",
+      "private": true,
+      "sentence": "Change the number of noise octaves of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).octaves = eventsFunctionContext.getArgument(\"Octaves\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Octaves",
+          "longDescription": "",
+          "name": "Octaves",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the persistence used for noise generation. At its default value \"0.5\", it halves the noise amplitude at each octave.",
+      "fullName": "Noise persistence",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetPersistence",
+      "private": true,
+      "sentence": "Change the noise persistence of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).persistence = eventsFunctionContext.getArgument(\"Persistence\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Persistence",
+          "longDescription": "",
+          "name": "Persistence",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the lacunarity used for noise generation. At its default value \"2\", it doubles the frequency at each octave.",
+      "fullName": "Noise lacunarity",
+      "functionType": "Action",
+      "group": "",
+      "name": "SetLacunarity",
+      "private": true,
+      "sentence": "Change the noise lacunarity of _PARAM2_: _PARAM1_",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\ngdjs._cameraShakeExtension.noiseManager.getGenerator(name).lacunarity = eventsFunctionContext.getArgument(\"Lacunarity\");",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Lacunarity",
+          "longDescription": "",
+          "name": "Lacunarity",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "The seed used for noise generation.",
+      "fullName": "Noise seed",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Seed",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.seed;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "The base frequency used for noise generation.",
+      "fullName": "Noise base frequency",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Frequency",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).frequency;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "The number of octaves used for noise generation.",
+      "fullName": "Noise octaves number",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Octaves",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).octaves;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "The persistence used for noise generation.",
+      "fullName": "Noise persistence",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Persistence",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).persistence;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "The lacunarity used for noise generation.",
+      "fullName": "Noise lacunarity",
+      "functionType": "Expression",
+      "group": "",
+      "name": "Lacunarity",
+      "private": true,
+      "sentence": "",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const name = eventsFunctionContext.getArgument(\"Name\");\r\n\r\neventsFunctionContext.returnValue = gdjs._cameraShakeExtension.noiseManager.getGenerator(name).lacunarity;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Generator name",
+          "longDescription": "",
+          "name": "Name",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
       "objectGroups": []
     }
   ],

--- a/extensions/reviewed/CameraShake.json
+++ b/extensions/reviewed/CameraShake.json
@@ -1,7 +1,7 @@
 {
   "author": "westboy31, Tristan Rhodes (https://victrisgames.itch.io/)",
   "category": "",
-  "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitely to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth\n\nRelease notes:\n- Version 3.0.0\n  - No adaptation of the game events is needed.\n  - It fixes an issue when used with scrolling, the amplitude will feel bigger in this case.\n  - The shaking relies on noise which could feel a bit different.",
+  "description": "Shake layer cameras with translation, rotation and zoom.\n- Short shaking can be used to give impact (explosion, hit)\n- Shaking can go indefinitely to set an ambiance (engine vibration, earthquake, pulsing)\n- Low frequency shaking allows to simulate slow moving objects (ship rocking back and forth)\n- Setting amplitudes per layer make it possible to respect the parallax and give more depth\n\nRelease notes:\n- Version 3.0.0\n  - No adaptation of the game events is needed.\n  - It fixes an issue when used with scrolling, the amplitude will feel bigger in this case.\n  - The shaking relies on noise which could feel a bit different.\n  - This extension can no longer do impulses. For this, another extension \"Camera impulse\" can be used.",
   "extensionNamespace": "",
   "fullName": "Camera shake",
   "helpPath": "",
@@ -896,127 +896,6 @@
       "sentence": "Shake camera for _PARAM1_ seconds with _PARAM2_ seconds of easing to start and _PARAM3_ seconds to stop",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "It \"imports\" the function. A bug doesn't include functions that are only called in life-cycle one.",
-          "comment2": ""
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": true,
-                "value": "BuiltinCommonInstructions::Always"
-              },
-              "parameters": [
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::IsShaking"
-              },
-              "parameters": [
-                "",
-                ""
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "test",
-                "=",
-                "CameraShake::Noise2d(\"\", 0, 0)"
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetLayerShakable"
-              },
-              "parameters": [
-                "",
-                "no",
-                "\"\"",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultShakingFrequency"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultTranslationAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultRotationAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultZoomAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetFrequency"
-              },
-              "parameters": [
-                "",
-                "0",
-                "\"\"",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "DebuggerTools::ConsoleLog"
-              },
-              "parameters": [
-                "\"\"",
-                "",
-                ""
-              ]
-            }
-          ]
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
@@ -1144,127 +1023,6 @@
       "sentence": "Shake camera on _PARAM3_ layer for _PARAM5_ seconds. Use an amplitude of _PARAM1_px on X axis and _PARAM2_px on Y axis, angle rotation amplitude _PARAM6_ degrees, and zoom amplitude _PARAM7_ percent.  Wait _PARAM8_ seconds between shakes. Keep shaking until stopped: _PARAM9_",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "It \"imports\" the noise function. A bug doesn't include functions that are only called in life-cycle one.",
-          "comment2": ""
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": true,
-                "value": "BuiltinCommonInstructions::Always"
-              },
-              "parameters": [
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::IsShaking"
-              },
-              "parameters": [
-                "",
-                ""
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "test",
-                "=",
-                "CameraShake::Noise2d(\"\", 0, 0)"
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetLayerShakable"
-              },
-              "parameters": [
-                "",
-                "no",
-                "\"\"",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultShakingFrequency"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultTranslationAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultRotationAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetDefaultZoomAmplitude"
-              },
-              "parameters": [
-                "",
-                "0",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "CameraShake::SetFrequency"
-              },
-              "parameters": [
-                "",
-                "0",
-                "\"\"",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "DebuggerTools::ConsoleLog"
-              },
-              "parameters": [
-                "\"\"",
-                "",
-                ""
-              ]
-            }
-          ]
-        },
-        {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
@@ -1285,16 +1043,6 @@
                     "__CameraShake.LayerName",
                     "=",
                     "GetArgumentAsString(\"Layer\")"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "DebuggerTools::ConsoleLog"
-                  },
-                  "parameters": [
-                    "\"Start\"",
-                    "",
-                    ""
                   ]
                 }
               ]

--- a/scripts/lib/ExtensionsValidatorExceptions.js
+++ b/scripts/lib/ExtensionsValidatorExceptions.js
@@ -148,6 +148,12 @@ const extensionsAllowedProperties = {
       runtimeSceneAllowedProperties: ['__boidsExtension'],
       javaScriptObjectAllowedProperties: [],
     },
+    CameraShake: {
+      gdjsAllowedProperties: ['_cameraShakeExtension'],
+      gdjsEvtToolsAllowedProperties: [],
+      runtimeSceneAllowedProperties: [],
+      javaScriptObjectAllowedProperties: [],
+    },
     DialogBox: {
       gdjsAllowedProperties: [],
       gdjsEvtToolsAllowedProperties: [],


### PR DESCRIPTION
## Changes
* Embed the Noise extension for a more realistic shake (especially at low frequency)
* Configuration per layer
* Linear easing
* Fix conflicts with camera movements.

## Example
### With parallax
Try it:
* Project: https://www.dropbox.com/s/nai88cdnjg76ynm/ScreenShakeExamples.zip?dl=1
* Build: https://liluo.io/instant-builds/e0257129-0d90-46f3-b029-42c12f8b9854

### With impulse and scrolling
It also uses:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/529

Press `I` to start an impulsion and `S` to shake.
I didn't find any conflict between the impulse and the scrolling or the screen shake.
 
- Project: https://www.dropbox.com/s/spvas50648blctc/platformer-with-tilemap-shake.zip?dl=1
- Build: https://games.gdevelop-app.com/game-881fc8e5-272e-460a-8d72-7d01baca255d/index.html

## JavaScript
It uses a JavaScript event but it's just a copy-paste of the Noise extension with a different name-space.