### PR TITLE
Added ZoomWithMouseWheel and ZoomWithKeypress actions

### DIFF
--- a/Extensions/CameraZoom.json
+++ b/Extensions/CameraZoom.json
@@ -1,14 +1,14 @@
 {
   "author": "",
   "category": "",
-  "description": "## Description\n\nThis extension allows to zoom a camera on a layer at a given speed. The zoom speed is configurable and allows a constant as well as a variable zoom speed. An anchor point can be defined, for instance, to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Change camera zoom with mouse wheel\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point\n",
+  "description": "Change camera zoom using actions or let users change zoom by scrolling the mouse wheel.\n\nZoom speed is configurable and can use constant or variable speed.  An anchor point can be defined to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Change camera zoom with mouse wheel\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point\n",
   "extensionNamespace": "",
   "fullName": "Camera Zoom",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjEzIiB5MT0iOSIgeDI9IjEzIiB5Mj0iMTciLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSI5IiB5MT0iMTMiIHgyPSIxNyIgeTI9IjEzIi8+DQo8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxMyIgY3k9IjEzIiByPSI5Ii8+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTcsMjFsNyw3YzEuMSwxLjEsMi45LDEuMSw0LDBsMCwwYzEuMS0xLjEsMS4xLTIuOSwwLTRsLTctNyIvPg0KPC9zdmc+DQo=",
   "name": "CameraZoom",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_zoom_in_plus.svg",
-  "shortDescription": "Allows to zoom camera on a layer with a speed (factor per second).",
+  "shortDescription": "Zoom camera on a layer at a given speed (factor per second).",
   "version": "0.3.0",
   "origin": {
     "identifier": "CameraZoom",
@@ -31,16 +31,14 @@
   "eventsFunctions": [
     {
       "description": "Change the camera zoom at a given speed (in factor per second).",
-      "fullName": "Zoom camera with speed",
+      "fullName": "Zoom camera over time",
       "functionType": "Action",
       "group": "",
       "name": "ZoomWithSpeed",
       "private": false,
-      "sentence": "Zoom camera with speed: _PARAM1_ (layer: _PARAM2_, camera: _PARAM3_)",
+      "sentence": "Change camera zoom at speed: _PARAM1_ (layer: _PARAM2_, camera: _PARAM3_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
@@ -96,17 +94,15 @@
       "objectGroups": []
     },
     {
-      "description": "Change the camera zoom and keep an anchor point fixed on screen (instead of the center).",
-      "fullName": "Zoom with anchor",
+      "description": "Change camera zoom (instantly) and keep an anchor point fixed on screen (instead of the center).",
+      "fullName": "Change camera zoom and use an anchor point",
       "functionType": "Action",
       "group": "",
       "name": "ZoomWithAnchor",
       "private": false,
-      "sentence": "Change camera zoom to: _PARAM1_ with an anchor at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
+      "sentence": "Set camera zoom to: _PARAM1_ with anchor at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -120,8 +116,6 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
@@ -226,16 +220,14 @@
     },
     {
       "description": "Change the camera zoom at a given speed (in factor per second) and keep an anchor point fixed on screen (instead of the center).",
-      "fullName": "Zoom camera with speed and anchor",
+      "fullName": "Zoom camera over time and use an anchor point",
       "functionType": "Action",
       "group": "",
       "name": "ZoomWithSpeedAndAnchor",
       "private": false,
-      "sentence": "Zoom camera with speed: _PARAM1_ and an anchor at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
+      "sentence": "Zoom camera at speed: _PARAM1_ and anchor at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
@@ -314,28 +306,24 @@
       "objectGroups": []
     },
     {
-      "description": "Change camera zoom with mouse wheel. ",
+      "description": "Change camera zoom with mouse wheel.",
       "fullName": "Change camera zoom with mouse wheel",
       "functionType": "Action",
       "group": "",
       "name": "ZoomWithMouseWheel",
       "private": false,
-      "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Min zoom: _PARAM5_, Max zoom: _PARAM6_, Zoom towards mouse: _PARAM4_)",
+      "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Min zoom: _PARAM5_, Max zoom: _PARAM6_, Zoom towards cursor: _PARAM4_)",
       "events": [
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
           "name": "Zoom without anchor",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -356,15 +344,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Zoom in",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -404,15 +388,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Zoom out",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -457,15 +437,11 @@
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
           "name": "Zoom with anchor at mouse",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -486,15 +462,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Zoom in",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -536,15 +508,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Zoom out",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -591,15 +559,11 @@
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
           "name": "Enforce max/min zoom values",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -609,12 +573,10 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Don't enforce zoom range when MaxZoom is left emtpy (MaxZoom=0)",
+              "comment": "Don't enforce zoom range when MaxZoom is left empty (MaxZoom=0)",
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -685,7 +647,7 @@
         {
           "codeOnly": false,
           "defaultValue": "True",
-          "description": "Zoom towards mouse",
+          "description": "Zoom towards cursor",
           "longDescription": "",
           "name": "ZoomTowardsMouse",
           "optional": true,

--- a/Extensions/CameraZoom.json
+++ b/Extensions/CameraZoom.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "",
-  "description": "## Description\n\nThis extension allows to zoom a camera on a layer at a given speed. The zoom speed is configurable and allows a constant as well as a variable zoom speed. An anchor point can be defined, for instance, to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point",
+  "description": "## Description\n\nThis extension allows to zoom a camera on a layer at a given speed. The zoom speed is configurable and allows a constant as well as a variable zoom speed. An anchor point can be defined, for instance, to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Change camera zoom with mouse wheel\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point\n",
   "extensionNamespace": "",
   "fullName": "Camera Zoom",
   "helpPath": "",
@@ -9,15 +9,23 @@
   "name": "CameraZoom",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_zoom_in_plus.svg",
   "shortDescription": "Allows to zoom camera on a layer with a speed (factor per second).",
-  "version": "0.2.0",
+  "version": "0.3.0",
+  "origin": {
+    "identifier": "CameraZoom",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
-    "Camera",
-    "Layer",
-    "Zoom"
+    "camera",
+    "layer",
+    "zoom",
+    "mouse",
+    "wheel",
+    "scroll"
   ],
   "authorIds": [
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2",
-    "30b1QQoYi1gQQHzIjMlNY8aLyYV2"
+    "30b1QQoYi1gQQHzIjMlNY8aLyYV2",
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -223,7 +231,7 @@
       "group": "",
       "name": "ZoomWithSpeedAndAnchor",
       "private": false,
-      "sentence": "Zoom camera with speed: _PARAM1_ and an anchror at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
+      "sentence": "Zoom camera with speed: _PARAM1_ and an anchor at: _PARAM4_; _PARAM5_ (layer: _PARAM2_, camera: _PARAM3_)",
       "events": [
         {
           "disabled": false,
@@ -301,6 +309,324 @@
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change camera zoom with mouse wheel. ",
+      "fullName": "Change camera zoom with mouse wheel",
+      "functionType": "Action",
+      "group": "",
+      "name": "ZoomWithMouseWheel",
+      "private": false,
+      "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Zoom towards mouse: _PARAM4_)",
+      "events": [
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Zoom without anchor",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"ZoomTowardsMouse\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Zoom in",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "IsMouseWheelScrollingUp"
+                          },
+                          "parameters": [
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraZoom::ZoomWithSpeed"
+                          },
+                          "parameters": [
+                            "",
+                            "max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "GetArgumentAsString(\"Layer\")",
+                            "GetArgumentAsNumber(\"Camera\")",
+                            "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Zoom out",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "IsMouseWheelScrollingDown"
+                          },
+                          "parameters": [
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraZoom::ZoomWithSpeed"
+                          },
+                          "parameters": [
+                            "",
+                            "1/max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "GetArgumentAsString(\"Layer\")",
+                            "GetArgumentAsNumber(\"Camera\")",
+                            "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Zoom with anchor at mouse",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"ZoomTowardsMouse\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Zoom in",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "IsMouseWheelScrollingUp"
+                          },
+                          "parameters": [
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraZoom::ZoomWithSpeedAndAnchor"
+                          },
+                          "parameters": [
+                            "",
+                            "max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "GetArgumentAsString(\"Layer\")",
+                            "GetArgumentAsNumber(\"Camera\")",
+                            "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            "MouseY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "disabled": false,
+                  "folded": false,
+                  "name": "Zoom out",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "IsMouseWheelScrollingDown"
+                          },
+                          "parameters": [
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "inverted": false,
+                            "value": "CameraZoom::ZoomWithSpeedAndAnchor"
+                          },
+                          "parameters": [
+                            "",
+                            "1/max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "GetArgumentAsString(\"Layer\")",
+                            "GetArgumentAsNumber(\"Camera\")",
+                            "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            "MouseY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            ""
+                          ],
+                          "subInstructions": []
+                        }
+                      ],
+                      "events": []
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Camera",
+          "longDescription": "",
+          "name": "Camera",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Zoom speed (Range: 1 to infinity)",
+          "longDescription": "",
+          "name": "ZoomSpeed",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "True",
+          "description": "Zoom towards mouse",
+          "longDescription": "",
+          "name": "ZoomTowardsMouse",
+          "optional": true,
+          "supplementaryInformation": "",
+          "type": "trueorfalse"
         }
       ],
       "objectGroups": []

--- a/Extensions/CameraZoom.json
+++ b/Extensions/CameraZoom.json
@@ -344,6 +344,16 @@
                           "parameters": [
                             ""
                           ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            "<",
+                            "ToNumber(GetArgumentAsString(\"MaxZoom\"))"
+                          ]
                         }
                       ],
                       "actions": [
@@ -382,6 +392,16 @@
                           },
                           "parameters": [
                             ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            ">",
+                            "ToNumber(GetArgumentAsString(\"MinZoom\"))"
                           ]
                         }
                       ],
@@ -450,6 +470,16 @@
                           "parameters": [
                             ""
                           ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            "<",
+                            "ToNumber(GetArgumentAsString(\"MaxZoom\"))"
+                          ]
                         }
                       ],
                       "actions": [
@@ -490,6 +520,16 @@
                           },
                           "parameters": [
                             ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                            ">",
+                            "ToNumber(GetArgumentAsString(\"MinZoom\"))"
                           ]
                         }
                       ],
@@ -665,6 +705,16 @@
                     "",
                     "GetArgumentAsString(\"ZoomInKey\")"
                   ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                    "<",
+                    "ToNumber(GetArgumentAsString(\"MaxZoom\"))"
+                  ]
                 }
               ],
               "actions": [
@@ -704,6 +754,16 @@
                   "parameters": [
                     "",
                     "GetArgumentAsString(\"ZoomOutKey\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
+                    ">",
+                    "ToNumber(GetArgumentAsString(\"MinZoom\"))"
                   ]
                 }
               ],

--- a/Extensions/CameraZoom.json
+++ b/Extensions/CameraZoom.json
@@ -1,14 +1,14 @@
 {
   "author": "",
   "category": "",
-  "description": "Change camera zoom using actions or let users change zoom by scrolling the mouse wheel.\n\nZoom speed is configurable and can use constant or variable speed.  An anchor point can be defined to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Change camera zoom with mouse wheel\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point\n",
+  "description": "Change camera zoom using actions or allow users to change zoom by scrolling the mouse wheel or pressing keys.\nAn anchor point can be defined to keep what is under the cursor at the same place on screen.\n\n### Actions\n\n- Change camera zoom with mouse wheel\n- Change camera zoom by pressing keys\n- Zoom at a given speed\n- Change the zoom with an anchor point\n- Zoom at a given speed and with an anchor point\n",
   "extensionNamespace": "",
   "fullName": "Camera Zoom",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjEzIiB5MT0iOSIgeDI9IjEzIiB5Mj0iMTciLz4NCjxsaW5lIGNsYXNzPSJzdDAiIHgxPSI5IiB5MT0iMTMiIHgyPSIxNyIgeTI9IjEzIi8+DQo8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxMyIgY3k9IjEzIiByPSI5Ii8+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTcsMjFsNyw3YzEuMSwxLjEsMi45LDEuMSw0LDBsMCwwYzEuMS0xLjEsMS4xLTIuOSwwLTRsLTctNyIvPg0KPC9zdmc+DQo=",
   "name": "CameraZoom",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/UI Essentials/UI Essentials_zoom_in_plus.svg",
-  "shortDescription": "Zoom camera on a layer at a given speed (factor per second).",
+  "shortDescription": "Change camera zoom using several methods including user input.",
   "version": "0.3.0",
   "origin": {
     "identifier": "CameraZoom",
@@ -44,7 +44,6 @@
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ZoomCamera"
               },
               "parameters": [
@@ -52,11 +51,9 @@
                 "CameraZoom(GetArgumentAsString(\"Layer\"), GetArgumentAsNumber(\"Camera\")) * pow(GetArgumentAsNumber(\"ZoomSpeed\"), TimeDelta())",
                 "GetArgumentAsString(\"Layer\")",
                 "GetArgumentAsNumber(\"Camera\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -121,7 +118,6 @@
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetCameraX"
               },
               "parameters": [
@@ -130,12 +126,10 @@
                 "GetArgumentAsNumber(\"AnchorX\")\n+ (\n   CameraX(GetArgumentAsString(\"Layer\"), GetArgumentAsNumber(\"Camera\"))\n   - GetArgumentAsNumber(\"AnchorX\")\n)\n* CameraZoom(GetArgumentAsString(\"Layer\"), GetArgumentAsNumber(\"Camera\"))\n/ GetArgumentAsNumber(\"Zoom\")",
                 "\"\"",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "SetCameraY"
               },
               "parameters": [
@@ -144,12 +138,10 @@
                 "GetArgumentAsNumber(\"AnchorY\")\n+ (\n   CameraY(GetArgumentAsString(\"Layer\"), GetArgumentAsNumber(\"Camera\"))\n   - GetArgumentAsNumber(\"AnchorY\")\n)\n* CameraZoom(GetArgumentAsString(\"Layer\"), GetArgumentAsNumber(\"Camera\"))\n/ GetArgumentAsNumber(\"Zoom\")",
                 "\"\"",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ZoomCamera"
               },
               "parameters": [
@@ -157,11 +149,9 @@
                 "GetArgumentAsNumber(\"Zoom\")",
                 "GetArgumentAsString(\"Layer\")",
                 "GetArgumentAsNumber(\"Camera\")"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -233,7 +223,6 @@
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "CameraZoom::ZoomWithAnchor"
               },
               "parameters": [
@@ -244,11 +233,9 @@
                 "GetArgumentAsNumber(\"AnchorX\")",
                 "GetArgumentAsNumber(\"AnchorY\")",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -315,9 +302,9 @@
       "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Min zoom: _PARAM5_, Max zoom: _PARAM6_, Zoom towards cursor: _PARAM4_)",
       "events": [
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
+          "colorB": 224,
+          "colorG": 16,
+          "colorR": 189,
           "creationTime": 0,
           "name": "Zoom without anchor",
           "source": "",
@@ -333,8 +320,7 @@
                   },
                   "parameters": [
                     "\"ZoomTowardsMouse\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
@@ -353,32 +339,27 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "IsMouseWheelScrollingUp"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraZoom::ZoomWithSpeed"
                           },
                           "parameters": [
                             "",
-                            "max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
                             "GetArgumentAsString(\"Layer\")",
                             "GetArgumentAsNumber(\"Camera\")",
                             "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -397,32 +378,27 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "IsMouseWheelScrollingDown"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraZoom::ZoomWithSpeed"
                           },
                           "parameters": [
                             "",
-                            "1/max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "1/max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
                             "GetArgumentAsString(\"Layer\")",
                             "GetArgumentAsNumber(\"Camera\")",
                             "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -433,9 +409,9 @@
           "parameters": []
         },
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
+          "colorB": 224,
+          "colorG": 16,
+          "colorR": 189,
           "creationTime": 0,
           "name": "Zoom with anchor at mouse",
           "source": "",
@@ -446,13 +422,11 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"ZoomTowardsMouse\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
@@ -471,34 +445,29 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "IsMouseWheelScrollingUp"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraZoom::ZoomWithSpeedAndAnchor"
                           },
                           "parameters": [
                             "",
-                            "max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
                             "GetArgumentAsString(\"Layer\")",
                             "GetArgumentAsNumber(\"Camera\")",
                             "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
                             "MouseY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -517,34 +486,29 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "IsMouseWheelScrollingDown"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraZoom::ZoomWithSpeedAndAnchor"
                           },
                           "parameters": [
                             "",
-                            "1/max(1,GetArgumentAsNumber(\"ZoomSpeed\"))",
+                            "1/max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
                             "GetArgumentAsString(\"Layer\")",
                             "GetArgumentAsNumber(\"Camera\")",
                             "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
                             "MouseY(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -581,21 +545,18 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
                     "GetArgumentAsNumber(\"MaxZoom\")",
                     "!=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ZoomCamera"
                   },
                   "parameters": [
@@ -603,11 +564,9 @@
                     "clamp(CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")),GetArgumentAsNumber(\"MinZoom\"),GetArgumentAsNumber(\"MaxZoom\"))",
                     "GetArgumentAsString(\"Layer\")",
                     "GetArgumentAsNumber(\"Camera\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": []
@@ -673,6 +632,223 @@
           "optional": false,
           "supplementaryInformation": "",
           "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change camera zoom by pressing keys.",
+      "fullName": "Change camera zoom by pressing keys",
+      "functionType": "Action",
+      "group": "",
+      "name": "ZoomWithKeypress",
+      "private": false,
+      "sentence": "Press _PARAM6_ to zoom in and _PARAM7_ to zoom out (Layer: _PARAM1_, Zoom speed: _PARAM3_, Min zoom: _PARAM4_, Max zoom: _PARAM5_)",
+      "events": [
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Zoom in",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "KeyFromTextPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "GetArgumentAsString(\"ZoomInKey\")"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "CameraZoom::ZoomWithSpeed"
+                  },
+                  "parameters": [
+                    "",
+                    "max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
+                    "GetArgumentAsString(\"Layer\")",
+                    "GetArgumentAsNumber(\"Camera\")",
+                    "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Zoom out",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "KeyFromTextPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "GetArgumentAsString(\"ZoomOutKey\")"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "CameraZoom::ZoomWithSpeed"
+                  },
+                  "parameters": [
+                    "",
+                    "1/max(1,pow(GetArgumentAsNumber(\"ZoomSpeed\"),2))",
+                    "GetArgumentAsString(\"Layer\")",
+                    "GetArgumentAsNumber(\"Camera\")",
+                    "MouseX(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\"))"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Enforce max/min zoom values",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Don't enforce zoom range when MaxZoom is left empty (MaxZoom=0)",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"MaxZoom\")",
+                    "!=",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ZoomCamera"
+                  },
+                  "parameters": [
+                    "",
+                    "clamp(CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")),GetArgumentAsNumber(\"MinZoom\"),GetArgumentAsNumber(\"MaxZoom\"))",
+                    "GetArgumentAsString(\"Layer\")",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "layer"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Camera",
+          "longDescription": "",
+          "name": "Camera",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Zoom speed (Range: 1 to infinity)",
+          "longDescription": "",
+          "name": "ZoomSpeed",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Minimum zoom",
+          "longDescription": "",
+          "name": "MinZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Maximum zoom",
+          "longDescription": "",
+          "name": "MaxZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Key to zoom in",
+          "longDescription": "",
+          "name": "ZoomInKey",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Key to zoom out",
+          "longDescription": "",
+          "name": "ZoomOutKey",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "key"
         }
       ],
       "objectGroups": []

--- a/Extensions/CameraZoom.json
+++ b/Extensions/CameraZoom.json
@@ -320,7 +320,7 @@
       "group": "",
       "name": "ZoomWithMouseWheel",
       "private": false,
-      "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Zoom towards mouse: _PARAM4_)",
+      "sentence": "Change camera zoom with mouse wheel (Layer: _PARAM1_, Zoom speed: _PARAM3_, Min zoom: _PARAM5_, Max zoom: _PARAM6_, Zoom towards mouse: _PARAM4_)",
       "events": [
         {
           "colorB": 228,
@@ -585,6 +585,70 @@
             }
           ],
           "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Enforce max/min zoom values",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Don't enforce zoom range when MaxZoom is left emtpy (MaxZoom=0)",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "GetArgumentAsNumber(\"MaxZoom\")",
+                    "!=",
+                    "0"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ZoomCamera"
+                  },
+                  "parameters": [
+                    "",
+                    "clamp(CameraZoom(GetArgumentAsString(\"Layer\"),GetArgumentAsNumber(\"Camera\")),GetArgumentAsNumber(\"MinZoom\"),GetArgumentAsNumber(\"MaxZoom\"))",
+                    "GetArgumentAsString(\"Layer\")",
+                    "GetArgumentAsNumber(\"Camera\")"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": []
         }
       ],
       "parameters": [
@@ -627,6 +691,26 @@
           "optional": true,
           "supplementaryInformation": "",
           "type": "trueorfalse"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Minimum zoom",
+          "longDescription": "",
+          "name": "MinZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Maximum zoom",
+          "longDescription": "",
+          "name": "MaxZoom",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
         }
       ],
       "objectGroups": []


### PR DESCRIPTION
This will make it super simple to add user-controlled zoom to games with a single action.

@D8H this should work but I'm getting these errors.  Is there some small mistake?

## Project file
[ZoomWithMouseWheel.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/8547684/ZoomWithMouseWheel.zip)


![image](https://user-images.githubusercontent.com/8879811/164916203-918a31db-dea7-4607-876a-420cf5af5feb.png)

