### PR TITLE
Add resource loading tools extension

### DIFF
--- a/Extensions/ResourceLoadingTools.json
+++ b/Extensions/ResourceLoadingTools.json
@@ -1,0 +1,209 @@
+{
+  "author": "",
+  "category": "General",
+  "description": "Adds a set of actions to work with the loading of resources: Downloading a texture at runtime, loading a JSON into a scene variable, and more!",
+  "extensionNamespace": "",
+  "fullName": "Resources loading tools",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZpbGUtZG93bmxvYWQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTQsMkg2QzQuODksMiA0LDIuODkgNCw0VjIwQzQsMjEuMTEgNC44OSwyMiA2LDIySDE4QzE5LjExLDIyIDIwLDIxLjExIDIwLDIwVjhMMTQsMk0xMiwxOUw4LDE1SDEwLjVWMTJIMTMuNVYxNUgxNkwxMiwxOU0xMyw5VjMuNUwxOC41LDlIMTNaIiAvPjwvc3ZnPg==",
+  "name": "ResourceLoadingTools",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/file-download.svg",
+  "shortDescription": "Adds multiple actions to work with the loading of resources.",
+  "version": "1.0.0",
+  "tags": [
+    "resource",
+    "art",
+    "image",
+    "url",
+    "base64",
+    "data",
+    "url",
+    "load",
+    "json",
+    "file",
+    "download",
+    "get",
+    "request"
+  ],
+  "authorIds": [
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Loads a JSON resource into a scene structure variable.",
+      "fullName": "Load a JSON resource in a scene variable",
+      "functionType": "Action",
+      "group": "",
+      "name": "GetJSONResource",
+      "private": false,
+      "sentence": "Load _PARAM1_ into scene variable _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext\n    .getArgument(\"Variable\")\n    .fromJSObject(\n        runtimeScene\n            .getGame()\n            .getJsonManager()\n            .getLoadedJson(eventsFunctionContext.getArgument(\"Resource\"))\n    );\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The resource to load the JSON from",
+          "longDescription": "",
+          "name": "Resource",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "jsonResource"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The scene variable to load the JSON to",
+          "longDescription": "",
+          "name": "Variable",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Replaces the image contained by a sprite by a new one, from a URL. This will only affect the sprite in question and only until the image in it is changed through its animation or another action, unless you also modify the resource.",
+      "fullName": "Load URL into a sprite",
+      "functionType": "Action",
+      "group": "",
+      "name": "LoadURLIntoSprite",
+      "private": false,
+      "sentence": "Load URL _PARAM1_ into sprite _PARAM2_ (and into the corresponding resource: _PARAM3_)",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "if (eventsFunctionContext.getArgument(\"ChangeResource\")) {\n    const texture = PIXI.BaseTexture.from(eventsFunctionContext.getArgument(\"URL\"));\n    for (const obj of objects) obj.getRendererObject().texture.baseTexture = texture;\n} else {\n    const texture = PIXI.Texture.from(eventsFunctionContext.getArgument(\"URL\"));\n    for (const obj of objects) obj.getRendererObject().texture = texture;\n}\n",
+          "parameterObjects": "Object",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The URL to load the new image for the sprite from",
+          "longDescription": "",
+          "name": "URL",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to modify",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "Sprite",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Modify the resource?",
+          "longDescription": "If yes, modifies the image contained in the resource of the sprite's current frame instead of just the sprite's displayed image. This makes the changes affect all other sprites that also display this resource, and allows the change to persist after changing animations or the current frame.",
+          "name": "ChangeResource",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "yesorno"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Replaces the image contained by a resource by a new one, from a URL. This will update all sprites displaying the resource.",
+      "fullName": "Load URL into an image resource",
+      "functionType": "Action",
+      "group": "",
+      "name": "LoadURLIntoImageResource",
+      "private": false,
+      "sentence": "Load URL _PARAM1_ into resource _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "runtimeScene\n    .getGame()\n    .getImageManager()\n    .getPIXITexture(eventsFunctionContext.getArgument(\"Resource\"))\n    .baseTexture = PIXI.BaseTexture.from(eventsFunctionContext.getArgument(\"URL\"));\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The URL to load the new image for the resource from",
+          "longDescription": "",
+          "name": "URL",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The resource to modify",
+          "longDescription": "",
+          "name": "Resource",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "imageResource"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Replaces the audio contained by a resource by a new one, from a URL. This will stop all sounds currently using this resource.",
+      "fullName": "Load URL into an audio resource",
+      "functionType": "Action",
+      "group": "",
+      "name": "LoadURLIntoAudioResource",
+      "private": false,
+      "sentence": "Load URL _PARAM1_ into resource _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const resourceName = eventsFunctionContext.getArgument(\"Resource\");\nconst soundManager = runtimeScene\n    .getGame()\n    .getSoundManager();\nconst resource = soundManager\n    ._availableResources[resourceName];\n\nresource.file = eventsFunctionContext.getArgument(\"URL\");\n\n// Unload the previous howler sound\nsoundManager.unloadAudio(resourceName, true);\nsoundManager.unloadAudio(resourceName, false);\n\nif (resource.preloadAsMusic) soundManager.loadAudio(resourceName, true);\nif (resource.preloadAsSound) soundManager.loadAudio(resourceName, false);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The URL to load the new audio for the resource from",
+          "longDescription": "",
+          "name": "URL",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The resource to modify",
+          "longDescription": "",
+          "name": "Resource",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "soundfile"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}


### PR DESCRIPTION
Example file: [load-from-url.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/8836589/load-from-url.zip)
 
Adds a few actions that have something to do with loading resources.

Points of importance for the review:
 - A private JS variable is being used in the action for audio resources, which is not acceptable. My implementation of the audio one is generally meh in my opinion, I think we probably would remove it unless you think it is essential to keep. Other actions are good.
 - The name is kind of bad.
 - The extension is maybe not focused enough.
 - It uses parameter types not officially supported by events-based extensions. They work just fine without hacks in JavaScript though, only real downside is that if you select another type for those fields while editing the extension you will be stuck unable to go back unless you modify the JSON directly or redownload the extension. I think that this is fine but you may think otherwise.