### PR TITLE
[CursorMovement] Fix conditions were always returning true when called a 2nd time.

### DIFF
--- a/Extensions/CursorMovement.json
+++ b/Extensions/CursorMovement.json
@@ -1,14 +1,19 @@
 {
   "author": "D8H",
+  "category": "",
   "description": "Provides two conditions:\n* The cursor is moving\n* The cursor has stayed still for a given duration",
   "extensionNamespace": "",
-  "fullName": "Cursor Movement Conditions",
+  "fullName": "Cursor movement conditions",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQoJLnN0MXtmaWxsOm5vbmU7c3Ryb2tlOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjI7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30NCjwvc3R5bGU+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTEsMjhMMTEsMjhjLTMuMywwLTYtMi43LTYtNnYtNGMwLTMuMywyLjctNiw2LTZoMGMzLjMsMCw2LDIuNyw2LDZ2NEMxNywyNS4zLDE0LjMsMjgsMTEsMjh6Ii8+DQo8bGluZSBjbGFzcz0ic3QwIiB4MT0iMTEiIHkxPSIxNSIgeDI9IjExIiB5Mj0iMTkiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yOSw5YzAsMi41LTIsNC41LTQuNSw0LjVTMjAsMTEuNSwyMCw5VjguNUMyMCw2LDE4LDQsMTUuNSw0UzExLDYsMTEsOC41Ii8+DQo8L3N2Zz4NCg==",
   "name": "CursorMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_mouse_pc.svg",
-  "shortDescription": "Conditions checking the cursor movement (is it moving, is it still since a specified duration...).",
-  "version": "1.0.0",
+  "shortDescription": "Conditions to check the cursor movement (still or moving).",
+  "version": "1.0.1",
+  "origin": {
+    "identifier": "CursorMovement",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "mouse",
     "pointer",
@@ -20,126 +25,79 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Check if the cursor has stayed still for the specified time.",
+      "description": "Check if the cursor has stayed still for the specified time on the default layer.",
       "fullName": "Cursor stays still",
       "functionType": "Condition",
+      "group": "",
       "name": "CursorStayStill",
       "private": false,
       "sentence": "Cursor has stayed still for _PARAM1_ seconds ",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "False"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Or"
+                "inverted": true,
+                "value": "CompareTimer"
               },
-              "parameters": [],
-              "subInstructions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "SceneVariableAsBoolean"
-                  },
-                  "parameters": [
-                    "__mousemovement_HasMovedOnce",
-                    "True"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GetArgumentAsNumber(\"Duration\")",
-                    "\"__mousemovement_MouseStayStill\""
-                  ],
-                  "subInstructions": []
-                }
+              "parameters": [
+                "",
+                "\"__mousemovement_MouseStayStill\"",
+                "<",
+                "GetArgumentAsNumber(\"Duration\")"
               ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "CursorMovement::CursorIsMoving"
               },
               "parameters": [
                 "",
                 ""
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ResetTimer"
               },
               "parameters": [
                 "",
                 "\"__mousemovement_MouseStayStill\""
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "SetSceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__mousemovement_HasMovedOnce",
-                "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -157,131 +115,101 @@
       "objectGroups": []
     },
     {
-      "description": "Check if the cursor is moving.",
+      "description": "Check if the cursor is moving on the default layer.",
       "fullName": "Cursor is moving",
       "functionType": "Condition",
+      "group": "",
       "name": "CursorIsMoving",
       "private": false,
       "sentence": "Cursor is moving",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__mousemovement_previousPositionIsKnown",
-                "True"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "SetReturnBoolean"
-              },
-              "parameters": [
-                "True"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__mousemovement_MousePreX",
-                "=",
-                "MouseX(\"\", 0)"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__mousemovement_MousePreY",
-                "=",
-                "MouseY(\"\", 0)"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "SetReturnBoolean"
-              },
-              "parameters": [
-                ""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "ModVarScene"
+                "value": "SetReturnBoolean"
               },
               "parameters": [
-                "__mousemovement_MousePreX",
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "VarScene"
+              },
+              "parameters": [
+                "__mousemovement.MousePreX",
                 "=",
                 "MouseX(\"\", 0)"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
+                "value": "VarScene"
+              },
+              "parameters": [
+                "__mousemovement.MousePreY",
+                "=",
+                "MouseY(\"\", 0)"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePostEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__mousemovement_MousePreY",
+                "__mousemovement.MousePreX",
                 "=",
-                "MouseY(\"\", 0)"
-              ],
-              "subInstructions": []
+                "MouseX(\"\", 0)"
+              ]
             },
             {
               "type": {
-                "inverted": false,
-                "value": "SetSceneVariableAsBoolean"
+                "value": "ModVarScene"
               },
               "parameters": [
-                "__mousemovement_previousPositionIsKnown",
-                "True"
-              ],
-              "subInstructions": []
+                "__mousemovement.MousePreY",
+                "=",
+                "MouseY(\"\", 0)"
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],


### PR DESCRIPTION
## Change
* The cursor position is saved in `onScenePostEvents` instead of the condition itself.

## Known issues
* The condition won't work if the default layer is moving.
  This might need some JavaScript to get the cursor position in the window referential so I prefer to do it in another PR to merge this quickly.

## Demo
* https://www.dropbox.com/s/wgwkzboyinbu3vi/StillCursorTest.zip?dl=1

Thank you Ash for reporting the issue.