### PR TITLE
[PixelPerfectMovement] Fix: top-down characters collision

### DIFF
--- a/Extensions/PixelPerfectMovement.json
+++ b/Extensions/PixelPerfectMovement.json
@@ -9,7 +9,11 @@
   "name": "PixelPerfectMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Graphic Design/Graphic Design_grid.svg",
   "shortDescription": "Pixel perfect platformer and top-down movements.",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "origin": {
+    "identifier": "PixelPerfectMovement",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "pixel perfect",
     "platform",
@@ -32,68 +36,54 @@
       "sentence": "Braking distance from an initial speed: _PARAM2_ and a deceleration: _PARAM3_ is less than _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareNumbers"
               },
               "parameters": [
                 "GetArgumentAsNumber(\"Distance\")",
                 ">=",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnNumber"
               },
               "parameters": [
                 "sqrt(2 * GetArgumentAsNumber(\"Distance\") * GetArgumentAsNumber(\"Deceleration\"))"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::CompareNumbers"
               },
               "parameters": [
                 "GetArgumentAsNumber(\"Distance\")",
                 "<",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnNumber"
               },
               "parameters": [
                 "-sqrt(-2 * GetArgumentAsNumber(\"Distance\") * GetArgumentAsNumber(\"Deceleration\"))"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -130,23 +120,18 @@
       "sentence": "Braking distance from an initial speed: _PARAM2_ and a deceleration: _PARAM3_ is less than _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "SetReturnNumber"
               },
               "parameters": [
                 "GetArgumentAsNumber(\"Speed\") * GetArgumentAsNumber(\"Speed\") / (2 * GetArgumentAsNumber(\"Deceleration\"))"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
@@ -195,15 +180,11 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "X axis",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -217,8 +198,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -230,23 +209,18 @@
                         "Object",
                         "TopDownMovement",
                         "\"Right\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -258,14 +232,12 @@
                             "Object",
                             "TopDownMovement",
                             "\"Left\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetX"
                           },
                           "parameters": [
@@ -273,12 +245,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * ceil((Object.X() + PixelPerfectMovement::BrakingDistance(Object.TopDownMovement::XVelocity(), Object.TopDownMovement::Deceleration()) - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -286,39 +256,32 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"TargetX: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetX())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -330,23 +293,18 @@
                         "Object",
                         "TopDownMovement",
                         "\"Left\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -358,14 +316,12 @@
                             "Object",
                             "TopDownMovement",
                             "\"Right\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetX"
                           },
                           "parameters": [
@@ -373,12 +329,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * floor((Object.X() - PixelPerfectMovement::BrakingDistance(Object.TopDownMovement::XVelocity(), Object.TopDownMovement::Deceleration()) - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -386,39 +340,32 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"TargetX: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetX())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -432,8 +379,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -445,8 +390,7 @@
                         "Object",
                         "TopDownMovement",
                         "\"Left\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -457,32 +401,26 @@
                         "Object",
                         "TopDownMovement",
                         "\"Right\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosX"
                           },
                           "parameters": [
                             "Object",
                             "<",
                             "Object.Behavior::PropertyTargetX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -490,14 +428,12 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityX"
                           },
                           "parameters": [
@@ -505,32 +441,25 @@
                             "TopDownMovement",
                             "=",
                             "min(Object.TopDownMovement::XVelocity() + Object.TopDownMovement::Acceleration(), min(Object.TopDownMovement::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetX() - Object.X(), Object.TopDownMovement::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosX"
                           },
                           "parameters": [
                             "Object",
                             ">",
                             "Object.Behavior::PropertyTargetX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -538,14 +467,12 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityX"
                           },
                           "parameters": [
@@ -553,46 +480,37 @@
                             "TopDownMovement",
                             "=",
                             "max(Object.TopDownMovement::XVelocity() - Object.TopDownMovement::Acceleration(), max(-Object.TopDownMovement::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetX() - Object.X(), Object.TopDownMovement::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosX"
                                   },
                                   "parameters": [
                                     "Object",
                                     ">=",
                                     "Object.Behavior::PropertyTargetX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionX"
                                   },
                                   "parameters": [
@@ -600,33 +518,28 @@
                                     "Behavior",
                                     "=",
                                     "1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosX"
                                   },
                                   "parameters": [
                                     "Object",
                                     "<=",
                                     "Object.Behavior::PropertyTargetX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionX"
                                   },
                                   "parameters": [
@@ -634,8 +547,7 @@
                                     "Behavior",
                                     "=",
                                     "-1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             }
@@ -645,19 +557,16 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MettreX"
                           },
                           "parameters": [
                             "Object",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * round((Object.X() - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -665,12 +574,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityX"
                           },
                           "parameters": [
@@ -678,32 +585,26 @@
                             "TopDownMovement",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "disabled": true,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DebuggerTools::ConsoleLog"
                           },
                           "parameters": [
                             "\"X: \" + ToString(Object.X()) + \" Speed: \" + ToString(Object.Behavior::SpeedX())",
                             "",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -715,15 +616,11 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Y axis",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -737,8 +634,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -750,23 +645,18 @@
                         "Object",
                         "TopDownMovement",
                         "\"Down\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -778,14 +668,12 @@
                             "Object",
                             "TopDownMovement",
                             "\"Up\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetY"
                           },
                           "parameters": [
@@ -793,12 +681,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * ceil((Object.Y() + PixelPerfectMovement::BrakingDistance(Object.TopDownMovement::YVelocity(), Object.TopDownMovement::Deceleration()) - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionY"
                           },
                           "parameters": [
@@ -806,39 +692,32 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"TargetY: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetY())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -850,23 +729,18 @@
                         "Object",
                         "TopDownMovement",
                         "\"Up\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -878,14 +752,12 @@
                             "Object",
                             "TopDownMovement",
                             "\"Down\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetY"
                           },
                           "parameters": [
@@ -893,12 +765,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * floor((Object.Y() - PixelPerfectMovement::BrakingDistance(Object.TopDownMovement::YVelocity(), Object.TopDownMovement::Deceleration()) - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionY"
                           },
                           "parameters": [
@@ -906,39 +776,32 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"TargetY: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetY())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -952,8 +815,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -965,8 +826,7 @@
                         "Object",
                         "TopDownMovement",
                         "\"Up\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -977,32 +837,26 @@
                         "Object",
                         "TopDownMovement",
                         "\"Down\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosY"
                           },
                           "parameters": [
                             "Object",
                             "<",
                             "Object.Behavior::PropertyTargetY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionY"
                           },
                           "parameters": [
@@ -1010,14 +864,12 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityY"
                           },
                           "parameters": [
@@ -1025,32 +877,25 @@
                             "TopDownMovement",
                             "=",
                             "min(Object.TopDownMovement::YVelocity() + Object.TopDownMovement::Acceleration(), min(Object.TopDownMovement::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetY() - Object.Y(), Object.TopDownMovement::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosY"
                           },
                           "parameters": [
                             "Object",
                             ">",
                             "Object.Behavior::PropertyTargetY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionY"
                           },
                           "parameters": [
@@ -1058,14 +903,12 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityY"
                           },
                           "parameters": [
@@ -1073,46 +916,37 @@
                             "TopDownMovement",
                             "=",
                             "max(Object.TopDownMovement::YVelocity() - Object.TopDownMovement::Acceleration(), max(-Object.TopDownMovement::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetY() - Object.Y(), Object.TopDownMovement::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosY"
                                   },
                                   "parameters": [
                                     "Object",
                                     ">=",
                                     "Object.Behavior::PropertyTargetY()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionY"
                                   },
                                   "parameters": [
@@ -1120,33 +954,28 @@
                                     "Behavior",
                                     "=",
                                     "1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosY"
                                   },
                                   "parameters": [
                                     "Object",
                                     "<=",
                                     "Object.Behavior::PropertyTargetY()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::PropertyTargetDirectionY"
                                   },
                                   "parameters": [
@@ -1154,8 +983,7 @@
                                     "Behavior",
                                     "=",
                                     "-1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             }
@@ -1165,19 +993,16 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MettreY"
                           },
                           "parameters": [
                             "Object",
                             "=",
                             "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * round((Object.Y() - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionY"
                           },
                           "parameters": [
@@ -1185,12 +1010,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityY"
                           },
                           "parameters": [
@@ -1198,37 +1021,393 @@
                             "TopDownMovement",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "disabled": true,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DebuggerTools::ConsoleLog"
                           },
                           "parameters": [
                             "\"Y: \" + ToString(Object.Y()) + \" Speed: \" + ToString(Object.TopDownMovement::YVelocity())",
                             "",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
               ],
               "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "PixelPerfectMovement::PixelPerfectTopDownMovement",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "The \"separate\" action can leave the object position with rounding errors.\nThe snaping is applied doStepPostEvent rather than at the beginning of doPreEvent because it must be done before the top-down movement is applied.",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "TopDownMovementBehavior::TopDownMovementBehavior::IsUsingControl"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownMovement",
+                    "\"Left\""
+                  ]
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "TopDownMovementBehavior::TopDownMovementBehavior::IsUsingControl"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownMovement",
+                    "\"Right\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SnapRoundingErrorX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "TopDownMovement",
+                        "=",
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "TopDownMovementBehavior::TopDownMovementBehavior::IsUsingControl"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownMovement",
+                    "\"Up\""
+                  ]
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "TopDownMovementBehavior::TopDownMovementBehavior::IsUsingControl"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TopDownMovement",
+                    "\"Down\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SnapRoundingErrorY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyTargetDirectionY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "TopDownMovementBehavior::TopDownMovementBehavior::SetVelocityY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "TopDownMovement",
+                        "=",
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "PixelPerfectMovement::PixelPerfectTopDownMovement",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Snap on the grid horizontally to remove rounding errors that could happen with the separate action.",
+          "fullName": "Snap rounding errors on X",
+          "functionType": "Condition",
+          "group": "",
+          "name": "SnapRoundingErrorX",
+          "private": true,
+          "sentence": "Snap _PARAM0_ on the grid horizontally if there is any rounding error",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyRoundedX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyPixelSize() * ceil((Object.X() - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "abs(Object.X() - Object.Behavior::PropertyRoundedX())",
+                    "<",
+                    "0.000001"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MettreX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "=",
+                    "Object.Behavior::PropertyRoundedX()"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "PixelPerfectMovement::PixelPerfectTopDownMovement",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Snap on the grid vertically to remove rounding errors that could happen with the separate action.",
+          "fullName": "Snap rounding errors on Y",
+          "functionType": "Condition",
+          "group": "",
+          "name": "SnapRoundingErrorY",
+          "private": true,
+          "sentence": "Snap _PARAM0_ on the grid vertically if there is any rounding error",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PixelPerfectMovement::PixelPerfectTopDownMovement::SetPropertyRoundedY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Behavior::PropertyPixelSize() * ceil((Object.Y() - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "abs(Object.Y() - Object.Behavior::PropertyRoundedY())",
+                    "<",
+                    "0.000001"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MettreY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "=",
+                    "Object.Behavior::PropertyRoundedY()"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": []
             }
           ],
           "parameters": [
@@ -1338,6 +1517,26 @@
           "extraInformation": [],
           "hidden": true,
           "name": "TargetDirectionY"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "RoundedX"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "RoundedY"
         }
       ]
     },
@@ -1361,15 +1560,11 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "X axis",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -1383,8 +1578,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -1396,23 +1589,18 @@
                         "Object",
                         "PlatformerCharacter",
                         "\"Right\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -1424,14 +1612,12 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Left\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetX"
                           },
                           "parameters": [
@@ -1439,12 +1625,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * ceil((Object.X() + PixelPerfectMovement::BrakingDistance(Object.PlatformerCharacter::CurrentSpeed(), Object.PlatformerCharacter::Deceleration()) - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -1452,39 +1636,32 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"Target: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetX())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -1496,23 +1673,18 @@
                         "Object",
                         "PlatformerCharacter",
                         "\"Left\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -1524,14 +1696,12 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Right\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetX"
                           },
                           "parameters": [
@@ -1539,12 +1709,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * floor((Object.X() - PixelPerfectMovement::BrakingDistance(Object.PlatformerCharacter::CurrentSpeed(), Object.PlatformerCharacter::Deceleration()) - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -1552,39 +1720,32 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"Target: \" + ToString(Object.X()) + \"-->\" + ToString(Object.Behavior::PropertyTargetX())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -1598,8 +1759,6 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -1611,8 +1770,7 @@
                         "Object",
                         "PlatformerCharacter",
                         "\"Left\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -1623,32 +1781,26 @@
                         "Object",
                         "PlatformerCharacter",
                         "\"Right\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosX"
                           },
                           "parameters": [
                             "Object",
                             "<",
                             "Object.Behavior::PropertyTargetX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -1656,14 +1808,12 @@
                             "Behavior",
                             "=",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PlatformBehavior::PlatformerObjectBehavior::SetCurrentSpeed"
                           },
                           "parameters": [
@@ -1671,32 +1821,25 @@
                             "PlatformerCharacter",
                             "=",
                             "min(Object.PlatformerCharacter:: CurrentSpeed() + Object.PlatformerCharacter::Acceleration(), min(Object.PlatformerCharacter::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetX() - Object.X(), Object.PlatformerCharacter::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PosX"
                           },
                           "parameters": [
                             "Object",
                             ">",
                             "Object.Behavior::PropertyTargetX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -1704,14 +1847,12 @@
                             "Behavior",
                             "=",
                             "-1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PlatformBehavior::PlatformerObjectBehavior::SetCurrentSpeed"
                           },
                           "parameters": [
@@ -1719,46 +1860,37 @@
                             "PlatformerCharacter",
                             "=",
                             "max(Object.PlatformerCharacter:: CurrentSpeed() - Object.PlatformerCharacter::Acceleration(), max(-Object.PlatformerCharacter::MaxSpeed(), PixelPerfectMovement::SpeedToReach(Object.Behavior::PropertyTargetX() - Object.X(), Object.PlatformerCharacter::Deceleration())))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosX"
                                   },
                                   "parameters": [
                                     "Object",
                                     ">=",
                                     "Object.Behavior::PropertyTargetX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionX"
                                   },
                                   "parameters": [
@@ -1766,33 +1898,28 @@
                                     "Behavior",
                                     "=",
                                     "1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::And"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PosX"
                                   },
                                   "parameters": [
                                     "Object",
                                     "<=",
                                     "Object.Behavior::PropertyTargetX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionX"
                                   },
                                   "parameters": [
@@ -1800,8 +1927,7 @@
                                     "Behavior",
                                     "=",
                                     "-1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             }
@@ -1811,19 +1937,16 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MettreX"
                           },
                           "parameters": [
                             "Object",
                             "=",
                             "Object.Behavior::PropertyOffsetX() + Object.Behavior::PropertyPixelSize() * round((Object.X() - Object.Behavior::PropertyOffsetX()) / Object.Behavior::PropertyPixelSize())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionX"
                           },
                           "parameters": [
@@ -1831,12 +1954,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PlatformBehavior::PlatformerObjectBehavior::SetCurrentSpeed"
                           },
                           "parameters": [
@@ -1844,32 +1965,26 @@
                             "PlatformerCharacter",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "disabled": true,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DebuggerTools::ConsoleLog"
                           },
                           "parameters": [
                             "\"X: \" + ToString(Object.X()) + \" Speed: \" + ToString(Object.PlatformerCharacter::CurrentSpeed())",
                             "",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -1881,34 +1996,26 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Ladder",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PlatformBehavior::IsOnLadder"
                       },
                       "parameters": [
                         "Object",
                         "PlatformerCharacter"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1922,8 +2029,6 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -1935,23 +2040,18 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Down\""
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Once"
                           },
-                          "parameters": [],
-                          "subInstructions": []
+                          "parameters": []
                         }
                       ],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
@@ -1963,14 +2063,12 @@
                                 "Object",
                                 "PlatformerCharacter",
                                 "\"Up\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetY"
                               },
                               "parameters": [
@@ -1978,12 +2076,10 @@
                                 "Behavior",
                                 "=",
                                 "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * ceil((Object.Y() - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionY"
                               },
                               "parameters": [
@@ -1991,39 +2087,32 @@
                                 "Behavior",
                                 "=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "events": [
                             {
                               "disabled": true,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "DebuggerTools::ConsoleLog"
                                   },
                                   "parameters": [
                                     "\"Target: \" + ToString(Object.Y()) + \"-->\" + ToString(Object.Behavior::PropertyTargetY())",
                                     "",
                                     ""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -2035,23 +2124,18 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Up\""
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Once"
                           },
-                          "parameters": [],
-                          "subInstructions": []
+                          "parameters": []
                         }
                       ],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
@@ -2063,14 +2147,12 @@
                                 "Object",
                                 "PlatformerCharacter",
                                 "\"Down\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetY"
                               },
                               "parameters": [
@@ -2078,12 +2160,10 @@
                                 "Behavior",
                                 "=",
                                 "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * floor((Object.Y() - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionY"
                               },
                               "parameters": [
@@ -2091,39 +2171,32 @@
                                 "Behavior",
                                 "=",
                                 "-1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "events": [
                             {
                               "disabled": true,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "DebuggerTools::ConsoleLog"
                                   },
                                   "parameters": [
                                     "\"Target: \" + ToString(Object.Y()) + \"-->\" + ToString(Object.Behavior::PropertyTargetY())",
                                     "",
                                     ""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -2137,8 +2210,6 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -2150,8 +2221,7 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Up\""
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
@@ -2162,32 +2232,26 @@
                             "Object",
                             "PlatformerCharacter",
                             "\"Down\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PosY"
                               },
                               "parameters": [
                                 "Object",
                                 "<",
                                 "Object.Behavior::PropertyTargetY()"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionY"
                               },
                               "parameters": [
@@ -2195,46 +2259,37 @@
                                 "Behavior",
                                 "=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MettreY"
                               },
                               "parameters": [
                                 "Object",
                                 "+",
                                 "Object.PlatformerCharacter::MaxSpeed() * TimeDelta()"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PosY"
                               },
                               "parameters": [
                                 "Object",
                                 ">",
                                 "Object.Behavior::PropertyTargetY()"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionY"
                               },
                               "parameters": [
@@ -2242,60 +2297,49 @@
                                 "Behavior",
                                 "=",
                                 "-1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MettreY"
                               },
                               "parameters": [
                                 "Object",
                                 "-",
                                 "Object.PlatformerCharacter::MaxSpeed() * TimeDelta()"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::Or"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "PosY"
                                       },
                                       "parameters": [
                                         "Object",
                                         ">=",
                                         "Object.Behavior::PropertyTargetY()"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionY"
                                       },
                                       "parameters": [
@@ -2303,33 +2347,28 @@
                                         "Behavior",
                                         "=",
                                         "1"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "PosY"
                                       },
                                       "parameters": [
                                         "Object",
                                         "<=",
                                         "Object.Behavior::PropertyTargetY()"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::PropertyTargetDirectionY"
                                       },
                                       "parameters": [
@@ -2337,8 +2376,7 @@
                                         "Behavior",
                                         "=",
                                         "-1"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 }
@@ -2348,19 +2386,16 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MettreY"
                               },
                               "parameters": [
                                 "Object",
                                 "=",
                                 "Object.Behavior::PropertyOffsetY() + Object.Behavior::PropertyPixelSize() * round((Object.Y() - Object.Behavior::PropertyOffsetY()) / Object.Behavior::PropertyPixelSize())"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "PixelPerfectMovement::PixelPerfectPlatformerCharacter::SetPropertyTargetDirectionY"
                               },
                               "parameters": [
@@ -2368,32 +2403,26 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"X: \" + ToString(Object.X()) + \" Speed: \" + ToString(Object.PlatformerCharacter::CurrentSpeed())",
                                 "",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }


### PR DESCRIPTION
### Changes
Fix: top-down characters moving on a grid no longer go side way after colliding with an obstacle.

### Example
* PR: https://github.com/GDevelopApp/GDevelop-examples/pull/312
* Project: https://www.dropbox.com/s/57hf3rnozd5em5a/top-down-grid-movement.zip?dl=0
* Try it: https://liluo.io/instant-builds/52f4e501-aa73-4d9c-a5e8-6e701a200abc

![bhyGhAKTXp](https://user-images.githubusercontent.com/2611977/173238547-874db576-403d-446a-9990-8be31500e021.png)

