### PR TITLE
Added shape painter option to Multitouch Joystick extension

### DIFF
--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -1,10 +1,10 @@
 {
   "author": "",
   "category": "Input",
-  "description": "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.\n\nMulitouch buttons can be used whenever a game allows the user to press multiple locations at once.\n\nHow to use:\n\n- Add the joystick behavior to a sprite that will be the joystick \n- Place the joystick object on the scene\n- Run the \"Animate joystick\" action on every frame and specify the thumb object\n- The joystick thumb object will automatically be created and moved\n\nTips:\n\n- Use \"Simulate a touch\" functions to provide mouse and gamepad controls\n- More than one joystick or button can be used at the same time\n- Joystick and thumb objects should have all sides the same length\n- Thumb object must be smaller than the joystick object",
+  "description": "Users can interact with the multitouch joystick to specify an angle and force value.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.\n\nThe mulitouch button behavior can be used in games that allow the user to press multiple locations at once.\n\nHow to use (sprites):\n\n- Add the joystick behavior to a sprite object\n- Place the joystick sprite on the scene\n- Run the \"Animate joystick\" action on every frame and select a sprite to be used as the joystick thumb\n- Joystick and thumb objects should have height equal to width\n- Thumb object must be smaller than the joystick object\n\nHow to use (shape painter):\n\n- Add the joystick behavior to a shape painter object \n- Place the joystick shape painter on the scene\n- Run the \"Animate joystick\" action on every frame and select a shape painter to draw the joystick thumb\n- Edit the shape painter objects to change the joystick appearance. \n\nTips:\n\n- More than one joystick or button can be used at the same time\n- The joystick thumb object will automatically be created and moved\n- Use \"Simulate a touch\" functions to allow mouse and gamepad controls to control virtual joystick\n",
   "extensionNamespace": "",
   "fullName": "Multitouch joystick and buttons",
-  "helpPath": "",
+  "helpPath": "https://wiki.gdevelop.io/gdevelop5/extensions/multitouch-joystick/start",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTYiIGN5PSIxNiIgcj0iMTMiLz4NCjxwb2x5bGluZSBjbGFzcz0ic3QwIiBwb2ludHM9IjI4LjQsMTIgMjAsMTIgMjAsMy42ICIvPg0KPHBvbHlsaW5lIGNsYXNzPSJzdDAiIHBvaW50cz0iMjAsMjguNCAyMCwyMCAyOC40LDIwICIvPg0KPHBvbHlsaW5lIGNsYXNzPSJzdDAiIHBvaW50cz0iMy42LDIwIDEyLDIwIDEyLDI4LjQgIi8+DQo8cG9seWxpbmUgY2xhc3M9InN0MCIgcG9pbnRzPSIxMiwzLjYgMTIsMTIgMy42LDEyICIvPg0KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxNiw2IDE2LjcsNyAxNS4zLDcgIi8+DQo8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE2LDI2IDE1LjMsMjUgMTYuNywyNSAiLz4NCjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iNiwxNiA3LDE1LjMgNywxNi43ICIvPg0KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIyNiwxNiAyNSwxNi43IDI1LDE1LjMgIi8+DQo8L3N2Zz4NCg==",
   "name": "MultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
@@ -22,7 +22,8 @@
     "touchscreen",
     "twin stick",
     "shooter",
-    "virtual"
+    "virtual",
+    "shape painter"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
@@ -32,7 +33,7 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Activate a joystick that can be controlled by interacting with a touchscreen.\nJoystick and thumb are drawn with shape painter objects.",
+      "description": "Animate a virtual joystick that can be controlled by interacting with a touchscreen.\nJoystick and thumb are drawn with shape painter objects.\nEdit the shape painter objects to change the joystick appearance. ",
       "fullName": "Multitouch Joystick (using shape painter)",
       "name": "MultitouchJoystick_ShapePainter",
       "objectType": "PrimitiveDrawing::Drawer",
@@ -140,7 +141,7 @@
           "objectGroups": []
         },
         {
-          "description": "Animate multitouch joystick that is drawn with shape painters.",
+          "description": "Animate a multitouch joystick by moving the thumb object to follow a touch.",
           "fullName": "Animate multitouch joystick (shape painter)",
           "functionType": "Action",
           "group": "",
@@ -2983,7 +2984,7 @@
       ]
     },
     {
-      "description": "Activate a joystick that can be controlled by interacting with a touchscreen.",
+      "description": "Animate a virtual joystick that can be controlled by interacting with a touchscreen.",
       "fullName": "Multitouch Joystick",
       "name": "MultitouchJoystick",
       "objectType": "",
@@ -3091,7 +3092,7 @@
           "objectGroups": []
         },
         {
-          "description": "Animate multitouch joystick.",
+          "description": "Animate a multitouch joystick by moving the thumb object to follow a touch.",
           "fullName": "Animate multitouch joystick",
           "functionType": "Action",
           "group": "",
@@ -5709,7 +5710,7 @@
       ]
     },
     {
-      "description": "Detect button presses made from a touchscreen.",
+      "description": "Detect button presses made from a touchscreen.  \nMultiple buttons can be pressed at the same time.",
       "fullName": "Multitouch button",
       "name": "MultitouchButton",
       "objectType": "",

--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -1,15 +1,19 @@
 {
   "author": "",
   "category": "Input",
-  "description": "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.\n\nMulitouch buttons can be used whenever a game allows the user to press multiple locations at once.\n\nHow to use:\n\n- Add the joystick behavior to a sprite that will be the joystick \n- Place the joystick object on the scene\n- Run the \"Activate joystick\" action on every frame and specify the thumb object\n- The joystick thumb object will automatically be created and moved\n\nTips:\n\n- Use \"Simulate a touch\" functions to provide mouse and gamepad controls\n- More than one joystick or button can be used at the same time\n- Joystick and thumb objects should have all sides the same length\n- Thumb object must be smaller than the joystick object",
+  "description": "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.\n\nMulitouch buttons can be used whenever a game allows the user to press multiple locations at once.\n\nHow to use:\n\n- Add the joystick behavior to a sprite that will be the joystick \n- Place the joystick object on the scene\n- Run the \"Animate joystick\" action on every frame and specify the thumb object\n- The joystick thumb object will automatically be created and moved\n\nTips:\n\n- Use \"Simulate a touch\" functions to provide mouse and gamepad controls\n- More than one joystick or button can be used at the same time\n- Joystick and thumb objects should have all sides the same length\n- Thumb object must be smaller than the joystick object",
   "extensionNamespace": "",
   "fullName": "Multitouch joystick and buttons",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTYiIGN5PSIxNiIgcj0iMTMiLz4NCjxwb2x5bGluZSBjbGFzcz0ic3QwIiBwb2ludHM9IjI4LjQsMTIgMjAsMTIgMjAsMy42ICIvPg0KPHBvbHlsaW5lIGNsYXNzPSJzdDAiIHBvaW50cz0iMjAsMjguNCAyMCwyMCAyOC40LDIwICIvPg0KPHBvbHlsaW5lIGNsYXNzPSJzdDAiIHBvaW50cz0iMy42LDIwIDEyLDIwIDEyLDI4LjQgIi8+DQo8cG9seWxpbmUgY2xhc3M9InN0MCIgcG9pbnRzPSIxMiwzLjYgMTIsMTIgMy42LDEyICIvPg0KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxNiw2IDE2LjcsNyAxNS4zLDcgIi8+DQo8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE2LDI2IDE1LjMsMjUgMTYuNywyNSAiLz4NCjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iNiwxNiA3LDE1LjMgNywxNi43ICIvPg0KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIyNiwxNiAyNSwxNi43IDI1LDE1LjMgIi8+DQo8L3N2Zz4NCg==",
   "name": "MultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
-  "shortDescription": "Activate a joystick or buttons that can be controlled by interacting with a touchscreen.",
-  "version": "1.0.1",
+  "shortDescription": "Animate a virtual joystick or buttons that can be controlled by interacting with a touchscreen.",
+  "version": "1.1.0",
+  "origin": {
+    "identifier": "MultitouchJoystick",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "multitouch",
     "joystick",
@@ -17,7 +21,8 @@
     "controller",
     "touchscreen",
     "twin stick",
-    "shooter"
+    "shooter",
+    "virtual"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
@@ -26,6 +31,2957 @@
   "dependencies": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
+    {
+      "description": "Activate a joystick that can be controlled by interacting with a touchscreen.\nJoystick and thumb are drawn with shape painter objects.",
+      "fullName": "Multitouch Joystick (using shape painter)",
+      "name": "MultitouchJoystick_ShapePainter",
+      "objectType": "PrimitiveDrawing::Drawer",
+      "eventsFunctions": [
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "onCreated",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "0"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "onActivate",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "0"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Animate multitouch joystick that is drawn with shape painters.",
+          "fullName": "Animate multitouch joystick (shape painter)",
+          "functionType": "Action",
+          "group": "",
+          "name": "ActivateJoystick",
+          "private": false,
+          "sentence": "Animate joystick _PARAM0_ (radius: _PARAM3_) using _PARAM2_ (radius: _PARAM4_) as the thumbstick",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Initialize",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Create joystick thumb and link it to the joystick",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Not"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "LinkedObjects::PickObjectsLinkedTo"
+                          },
+                          "parameters": [
+                            "",
+                            "JoystickThumb",
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "PickedInstancesCount"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "<",
+                        "1"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Create"
+                      },
+                      "parameters": [
+                        "",
+                        "JoystickThumb",
+                        "Object.CenterX()",
+                        "Object.CenterY()",
+                        "Object.Layer()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ChangePlan"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "=",
+                        "Object.ZOrder()+1"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "LinkedObjects::LinkObjects"
+                      },
+                      "parameters": [
+                        "",
+                        "Object",
+                        "JoystickThumb"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Initialize",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Enforce proper properties",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "PrimitiveDrawing::AreCoordinatesRelative"
+                          },
+                          "parameters": [
+                            "Object"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::UseRelativeCoordinates"
+                          },
+                          "parameters": [
+                            "Object",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "PrimitiveDrawing::AreCoordinatesRelative"
+                          },
+                          "parameters": [
+                            "JoystickThumb"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::UseRelativeCoordinates"
+                          },
+                          "parameters": [
+                            "JoystickThumb",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "PrimitiveDrawing::ClearBetweenFrames"
+                          },
+                          "parameters": [
+                            "Object"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::ClearBetweenFrames"
+                          },
+                          "parameters": [
+                            "Object",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "PrimitiveDrawing::ClearBetweenFrames"
+                          },
+                          "parameters": [
+                            "JoystickThumb"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::ClearBetweenFrames"
+                          },
+                          "parameters": [
+                            "JoystickThumb",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Draw joystick and thumb",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "PrimitiveDrawing::Circle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "0",
+                        "0",
+                        "GetArgumentAsNumber(\"JoystickRadius\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "PrimitiveDrawing::Circle"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "0",
+                        "0",
+                        "GetArgumentAsNumber(\"ThumbRadius\")"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Save radius so other actions can use it",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickRadius"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"JoystickRadius\")"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Manage touches",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Touch started",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "HasAnyTouchStarted"
+                          },
+                          "parameters": [
+                            ""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchCounter"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "StartedTouchCount()",
+                          "conditions": [],
+                          "actions": [],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Comment",
+                              "color": {
+                                "b": 109,
+                                "g": 230,
+                                "r": 255,
+                                "textB": 0,
+                                "textG": 0,
+                                "textR": 0
+                              },
+                              "comment": "Detect new touch on joystick",
+                              "comment2": ""
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "inverted": true,
+                                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyIsPressed"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                                  },
+                                  "parameters": [
+                                    "Object.DistanceToPosition(TouchX(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0), TouchY(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0))",
+                                    "<=",
+                                    "GetArgumentAsNumber(\"JoystickRadius\")"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchID"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "=",
+                                    "StartedTouchId(Object.Behavior::PropertyTouchCounter())"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "yes"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchCounter"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "+",
+                                    "1"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Touch ended",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Reset \"released\" every frame",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyButtonReleased"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "HasTouchEnded"
+                          },
+                          "parameters": [
+                            "",
+                            "Object.Behavior::PropertyTouchID()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyIsPressed"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyButtonReleased"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Move thumb back to center",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "LinkedObjects::PickObjectsLinkedTo"
+                              },
+                              "parameters": [
+                                "",
+                                "JoystickThumb",
+                                "Object",
+                                ""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCenter"
+                              },
+                              "parameters": [
+                                "JoystickThumb",
+                                "=",
+                                "Object.CenterX()",
+                                "=",
+                                "Object.CenterY()"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Reset values (except for angle, which stays the same)",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "False"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickForce"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchID"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update joystick values",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Detect if joystick has a valid TouchID",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyTouchID"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "!=",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Record joystick angle ",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickAngle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "AngleBetweenPositions(Object.CenterX(),Object.CenterY(),TouchX(Object.Behavior::PropertyTouchID(),Object.Layer(),0),TouchY(Object.Behavior::PropertyTouchID(),Object.Layer(),0))"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Record distance to touch",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchDistance"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "DistanceBetweenPositions(Object.CenterX(),Object.CenterY(),TouchX(Object.Behavior::PropertyTouchID(),Object.Layer(),0),TouchY(Object.Behavior::PropertyTouchID(),Object.Layer(),0))"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Calculate the percent of distance the thumb has moved from the center of joystick.",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickForce"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "clamp(Object. Behavior::PropertyTouchDistance() / Object.Width()*2,0,1)"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Move thumb based on joystick values",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Move thumb back to center when not being pressed (acts like a spring on a real controller)",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::IsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "LinkedObjects::PickObjectsLinkedTo"
+                      },
+                      "parameters": [
+                        "",
+                        "JoystickThumb",
+                        "Object",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCenter"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "=",
+                        "Object.CenterX()",
+                        "=",
+                        "Object.CenterY()"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Move joystick thumb when a touch is active",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::IsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyTouchID"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "!=",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "If floating is enabled, move joystick to keep touch inside",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyFloatingEnabled"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Touch is outside joystick",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Object.Behavior::PropertyTouchDistance()",
+                                ">",
+                                "Object.Behavior::PropertyJoystickRadius()"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCenter"
+                              },
+                              "parameters": [
+                                "Object",
+                                "+",
+                                "XFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Behavior::PropertyJoystickRadius())",
+                                "+",
+                                "YFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Behavior::PropertyJoystickRadius())"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Move joystick thumb to the location of the touch (but stay inside joystick)",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "LinkedObjects::PickObjectsLinkedTo"
+                          },
+                          "parameters": [
+                            "",
+                            "JoystickThumb",
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MettreAutour"
+                          },
+                          "parameters": [
+                            "JoystickThumb",
+                            "Object",
+                            "min(Object.Behavior::PropertyTouchDistance(),Object.Behavior::PropertyJoystickRadius())",
+                            "Object.Behavior::JoystickAngle()"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Joystick thumb",
+              "longDescription": "",
+              "name": "JoystickThumb",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "objectList"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Radius of joystick",
+              "longDescription": "",
+              "name": "JoystickRadius",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Radius of thumbstick",
+              "longDescription": "",
+              "name": "ThumbRadius",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Percentage the thumb has been pulled away from the joystick center (Range: 0 to 1).",
+          "fullName": "Joystick force",
+          "functionType": "Expression",
+          "group": "",
+          "name": "JoystickForce",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyJoystickForce()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Touch ID the joystick is following.",
+          "fullName": "Touch ID the joystick is following",
+          "functionType": "Expression",
+          "group": "",
+          "name": "TouchID",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyTouchID()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Angle the joystick is pointing towards (Range: -180 to 180).",
+          "fullName": "Joystick angle",
+          "functionType": "Expression",
+          "group": "",
+          "name": "JoystickAngle",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyJoystickAngle()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if joystick force is greater or equal to a value.",
+          "fullName": "Joystick force",
+          "functionType": "Condition",
+          "group": "",
+          "name": "CheckJoystickForce",
+          "private": false,
+          "sentence": "Force of _PARAM0_ is  greater or equal to _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "Object.Behavior::JoystickForce()",
+                    ">=",
+                    "GetArgumentAsNumber(\"Force\")"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Joystick force (Range: 0 to 1)",
+              "longDescription": "",
+              "name": "Force",
+              "optional": false,
+              "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if joystick is pushed in a given direction.",
+          "fullName": "Joystick pushed in a direction",
+          "functionType": "Condition",
+          "group": "",
+          "name": "DirectionPushed",
+          "private": false,
+          "sentence": "_PARAM0_ is pushed in direction _PARAM2_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Range (-180 to 180)",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Up",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareStrings"
+                          },
+                          "parameters": [
+                            "GetArgumentAsString(\"Direction\")",
+                            "=",
+                            "\"Up\""
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-180"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetReturnBoolean"
+                              },
+                              "parameters": [
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Down",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareStrings"
+                          },
+                          "parameters": [
+                            "GetArgumentAsString(\"Direction\")",
+                            "=",
+                            "\"Down\""
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "180"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetReturnBoolean"
+                              },
+                              "parameters": [
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Left",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareStrings"
+                          },
+                          "parameters": [
+                            "GetArgumentAsString(\"Direction\")",
+                            "=",
+                            "\"Left\""
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::And"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        ">=",
+                                        "-180"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "<",
+                                        "-90"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::And"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        ">=",
+                                        "90"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "<",
+                                        "180"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetReturnBoolean"
+                              },
+                              "parameters": [
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Right",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareStrings"
+                          },
+                          "parameters": [
+                            "GetArgumentAsString(\"Direction\")",
+                            "=",
+                            "\"Right\""
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::And"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        ">=",
+                                        "-90"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "<",
+                                        "0"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::And"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        ">=",
+                                        "0"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyJoystickAngle"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "<",
+                                        "90"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetReturnBoolean"
+                              },
+                              "parameters": [
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Direction",
+              "longDescription": "",
+              "name": "Direction",
+              "optional": false,
+              "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
+              "type": "stringWithSelector"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if joystick is floating.",
+          "fullName": "Check if joystick is floating",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsFloating",
+          "private": false,
+          "sentence": "Joystick _PARAM0_ is floating",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::IsFloating"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Joystick will follow the position of this touch.",
+          "fullName": "Set TouchID of joystick",
+          "functionType": "Action",
+          "group": "",
+          "name": "SetTouchID",
+          "private": false,
+          "sentence": "Set TouchID of joystick _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Enable (or disable) floating on a joystick.",
+          "fullName": "Enable (or disable) floating on a joystick",
+          "functionType": "Action",
+          "group": "",
+          "name": "SetFloating",
+          "private": false,
+          "sentence": "Enable floating on joystick _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyFloatingEnabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyFloatingEnabled"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if a joystick is pressed.",
+          "fullName": "Joystick pressed",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsPressed",
+          "private": false,
+          "sentence": "Joystick _PARAM0_ is pressed",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyIsPressed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change joystick to pressed.",
+          "fullName": "Change joystick to pressed",
+          "functionType": "Action",
+          "group": "",
+          "name": "SetPressed",
+          "private": false,
+          "sentence": "Change joystick _PARAM0_ to pressed: _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Press joystick",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Release joystick",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyButtonReleased"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls.",
+          "fullName": "Simulate a touch on joystick (based on position)",
+          "functionType": "Action",
+          "group": "",
+          "name": "SimulateTouch_Position",
+          "private": false,
+          "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ at position: _PARAM3_,_PARAM4_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update joystick values",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Mark joystick as pressed",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Record angle to touch",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickAngle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "AngleBetweenPositions(Object.CenterX(),Object.CenterY(),GetArgumentAsNumber(\"SimulatedTouchX\"),GetArgumentAsNumber(\"SimulatedTouchY\"))"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Record distance to touch",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyTouchDistance"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "DistanceBetweenPositions(Object.CenterX(),Object.CenterY(),GetArgumentAsNumber(\"SimulatedTouchX\"),GetArgumentAsNumber(\"SimulatedTouchY\"))"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Calculate the percent of distance the thumb has moved from the center of joystick.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickForce"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(Object. Behavior::PropertyTouchDistance() / Object.Behavior::PropertyJoystickRadius(),0,1)"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Move joystick thumb",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "If floating is enabled, move joystick to keep touch inside",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyFloatingEnabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "Object.Behavior::PropertyTouchDistance()",
+                            ">",
+                            "Object.Behavior::PropertyJoystickRadius()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCenter"
+                          },
+                          "parameters": [
+                            "Object",
+                            "+",
+                            "XFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Behavior::PropertyJoystickRadius())",
+                            "+",
+                            "YFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Behavior::PropertyJoystickRadius())"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Move joystick thumb to the location of the touch (but stay inside joystick)",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "LinkedObjects::PickObjectsLinkedTo"
+                      },
+                      "parameters": [
+                        "",
+                        "JoystickThumb",
+                        "Object",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MettreAutour"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "Object",
+                        "min(Object.Behavior::PropertyTouchDistance(),Object.Behavior::PropertyJoystickRadius())",
+                        "Object.Behavior::JoystickAngle()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "JoystickThumb",
+              "longDescription": "",
+              "name": "JoystickThumb",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "objectList"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "X position of simulated touch",
+              "longDescription": "",
+              "name": "SimulatedTouchX",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Y position of simulated touch",
+              "longDescription": "",
+              "name": "SimulatedTouchY",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls.",
+          "fullName": "Simulate a touch on joystick (based on angle and force)",
+          "functionType": "Action",
+          "group": "",
+          "name": "SimulateTouch_AngleForce",
+          "private": false,
+          "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ to angle _PARAM3_ and force _PARAM4_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update joystick values",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Mark joystick as pressed",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Update values",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickAngle"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(GetArgumentAsNumber(\"Angle\"),-180,180)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickForce"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(GetArgumentAsNumber(\"Force\"),0,1)"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Move joystick thumb",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Move joystick thumb to the location of the touch (but stay inside joystick)",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "LinkedObjects::PickObjectsLinkedTo"
+                      },
+                      "parameters": [
+                        "",
+                        "JoystickThumb",
+                        "Object",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCenter"
+                      },
+                      "parameters": [
+                        "JoystickThumb",
+                        "=",
+                        "Object.CenterX() + XFromAngleAndDistance(Object.Behavior::JoystickAngle(), Object.Behavior::JoystickForce() * Object.Behavior::PropertyJoystickRadius())",
+                        "=",
+                        "Object.CenterY() + YFromAngleAndDistance(Object.Behavior::JoystickAngle(), Object.Behavior::JoystickForce() * Object.Behavior::PropertyJoystickRadius())"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "JoystickThumb",
+              "longDescription": "",
+              "name": "JoystickThumb",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "objectList"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Angle (Range: -180 to 180)",
+              "longDescription": "",
+              "name": "Angle",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Force (Range: 0 to 1)",
+              "longDescription": "",
+              "name": "Force",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Simulate a touch ended.",
+          "fullName": "Simulate a touch ended",
+          "functionType": "Action",
+          "group": "",
+          "name": "SimulateTouchEnded",
+          "private": false,
+          "sentence": "Simulate a touch ended on joystick _PARAM0_ with thumb _PARAM2_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Touch ended",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::PropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyButtonReleased"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyIsPressed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Move thumb back to center",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "LinkedObjects::PickObjectsLinkedTo"
+                          },
+                          "parameters": [
+                            "",
+                            "JoystickThumb",
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCenter"
+                          },
+                          "parameters": [
+                            "JoystickThumb",
+                            "=",
+                            "Object.CenterX()",
+                            "=",
+                            "Object.CenterY()"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Reset values",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchJoystick_ShapePainter::SetPropertyJoystickForce"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick_ShapePainter",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "JoystickThumb",
+              "longDescription": "",
+              "name": "JoystickThumb",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "objectList"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Joystick angle (range: -180 to 180)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "JoystickAngle"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Joystick force (range: 0 to 1)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "JoystickForce"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Is currently pressed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsPressed"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "TouchID the joystick is following",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TouchID"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "Distance from joystick to touch",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TouchDistance"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Floating (allow joystick to be moved by dragging)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloatingEnabled"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Button was just released",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "ButtonReleased"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TouchCounter"
+        },
+        {
+          "value": "64",
+          "type": "Number",
+          "label": "Joystick radius",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "JoystickRadius"
+        }
+      ]
+    },
     {
       "description": "Activate a joystick that can be controlled by interacting with a touchscreen.",
       "fullName": "Multitouch Joystick",
@@ -47,7 +3003,6 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchID"
                   },
                   "parameters": [
@@ -55,11 +3010,9 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -101,7 +3054,6 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchID"
                   },
                   "parameters": [
@@ -109,11 +3061,9 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -141,13 +3091,13 @@
           "objectGroups": []
         },
         {
-          "description": "Activate multitouch joystick.",
-          "fullName": "Activate multitouch joystick",
+          "description": "Animate multitouch joystick.",
+          "fullName": "Animate multitouch joystick",
           "functionType": "Action",
           "group": "",
           "name": "ActivateJoystick",
           "private": false,
-          "sentence": "Activate joystick _PARAM0_ using _PARAM2_ as the thumbstick",
+          "sentence": "Animate joystick _PARAM0_ using _PARAM2_ as the thumbstick",
           "events": [
             {
               "colorB": 228,
@@ -176,14 +3126,12 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Not"
                       },
                       "parameters": [],
                       "subInstructions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "LinkedObjects::PickObjectsLinkedTo"
                           },
                           "parameters": [
@@ -191,28 +3139,24 @@
                             "JoystickThumb",
                             "Object",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PickedInstancesCount"
                       },
                       "parameters": [
                         "JoystickThumb",
                         "<",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Create"
                       },
                       "parameters": [
@@ -221,35 +3165,29 @@
                         "Object.CenterX()",
                         "Object.CenterY()",
                         "Object.Layer()"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ChangePlan"
                       },
                       "parameters": [
                         "JoystickThumb",
                         "=",
                         "Object.ZOrder()+1"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "LinkedObjects::LinkObjects"
                       },
                       "parameters": [
                         "",
                         "Object",
                         "JoystickThumb"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -277,19 +3215,16 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "HasAnyTouchStarted"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchCounter"
                           },
                           "parameters": [
@@ -297,8 +3232,7 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
@@ -332,26 +3266,22 @@
                                   "parameters": [
                                     "Object",
                                     "Behavior"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "CollisionPoint"
                                   },
                                   "parameters": [
                                     "Object",
                                     "TouchX(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0)",
                                     "TouchY(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchID"
                                   },
                                   "parameters": [
@@ -359,23 +3289,19 @@
                                     "Behavior",
                                     "=",
                                     "StartedTouchId(Object.Behavior::PropertyTouchCounter())"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                                   },
                                   "parameters": [
                                     "Object",
                                     "Behavior",
                                     "yes"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
@@ -383,7 +3309,6 @@
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchCounter"
                                   },
                                   "parameters": [
@@ -391,11 +3316,9 @@
                                     "Behavior",
                                     "+",
                                     "1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         }
@@ -432,57 +3355,48 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyButtonReleased"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "HasTouchEnded"
                           },
                           "parameters": [
                             "",
                             "Object.Behavior::PropertyTouchID()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::PropertyIsPressed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyButtonReleased"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "yes"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
@@ -504,7 +3418,6 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "LinkedObjects::PickObjectsLinkedTo"
                               },
                               "parameters": [
@@ -512,14 +3425,12 @@
                                 "JoystickThumb",
                                 "Object",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetCenter"
                               },
                               "parameters": [
@@ -528,11 +3439,9 @@
                                 "Object.CenterX()",
                                 "=",
                                 "Object.CenterY()"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
                           "type": "BuiltinCommonInstructions::Comment",
@@ -553,19 +3462,16 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior",
                                 "False"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickForce"
                               },
                               "parameters": [
@@ -573,12 +3479,10 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchID"
                               },
                               "parameters": [
@@ -586,11 +3490,9 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -627,7 +3529,6 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyTouchID"
                       },
                       "parameters": [
@@ -635,8 +3536,7 @@
                         "Behavior",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
@@ -660,7 +3560,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickAngle"
                           },
                           "parameters": [
@@ -668,11 +3567,9 @@
                             "Behavior",
                             "=",
                             "AngleBetweenPositions(Object.CenterX(),Object.CenterY(),TouchX(Object.Behavior::PropertyTouchID(),Object.Layer(),0),TouchY(Object.Behavior::PropertyTouchID(),Object.Layer(),0))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Comment",
@@ -693,7 +3590,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchDistance"
                           },
                           "parameters": [
@@ -701,11 +3597,9 @@
                             "Behavior",
                             "=",
                             "DistanceBetweenPositions(Object.CenterX(),Object.CenterY(),TouchX(Object.Behavior::PropertyTouchID(),Object.Layer(),0),TouchY(Object.Behavior::PropertyTouchID(),Object.Layer(),0))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Comment",
@@ -726,7 +3620,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickForce"
                           },
                           "parameters": [
@@ -734,11 +3627,9 @@
                             "Behavior",
                             "=",
                             "clamp(Object. Behavior::PropertyTouchDistance() / Object.Width()*2,0,1)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -779,12 +3670,10 @@
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "LinkedObjects::PickObjectsLinkedTo"
                       },
                       "parameters": [
@@ -792,14 +3681,12 @@
                         "JoystickThumb",
                         "Object",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCenter"
                       },
                       "parameters": [
@@ -808,11 +3695,9 @@
                         "Object.CenterX()",
                         "=",
                         "Object.CenterY()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Comment",
@@ -832,19 +3717,16 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::IsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyTouchID"
                       },
                       "parameters": [
@@ -852,8 +3734,7 @@
                         "Behavior",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
@@ -876,14 +3757,12 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::PropertyFloatingEnabled"
                           },
                           "parameters": [
                             "Object",
                             "Behavior"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -906,21 +3785,18 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::CompareNumbers"
                               },
                               "parameters": [
                                 "Object.Behavior::PropertyTouchDistance()",
                                 ">",
                                 "Object.Width()/2"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetCenter"
                               },
                               "parameters": [
@@ -929,11 +3805,9 @@
                                 "XFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Width()/2)",
                                 "+",
                                 "YFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Width()/2)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
@@ -955,7 +3829,6 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "LinkedObjects::PickObjectsLinkedTo"
                           },
                           "parameters": [
@@ -963,14 +3836,12 @@
                             "JoystickThumb",
                             "Object",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MettreAutour"
                           },
                           "parameters": [
@@ -978,11 +3849,9 @@
                             "Object",
                             "min(Object.Behavior::PropertyTouchDistance(),Object.Width()/2)",
                             "Object.Behavior::JoystickAngle()"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -1039,16 +3908,61 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyJoystickForce()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Touch ID the joystick is following.",
+          "fullName": "Touch ID the joystick is following",
+          "functionType": "Expression",
+          "group": "",
+          "name": "TouchID",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyTouchID()"
+                  ]
+                }
+              ]
             }
           ],
           "parameters": [
@@ -1090,16 +4004,13 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyJoystickAngle()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1140,30 +4051,25 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
                     "Object.Behavior::JoystickForce()",
                     ">=",
                     "GetArgumentAsNumber(\"Force\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1232,15 +4138,13 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::CompareStrings"
                           },
                           "parameters": [
                             "GetArgumentAsString(\"Direction\")",
                             "=",
                             "\"Up\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -1250,7 +4154,6 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
                               "parameters": [
@@ -1258,12 +4161,10 @@
                                 "Behavior",
                                 ">=",
                                 "-180"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
                               "parameters": [
@@ -1271,23 +4172,19 @@
                                 "Behavior",
                                 "<",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetReturnBoolean"
                               },
                               "parameters": [
                                 "True"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -1308,15 +4205,13 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::CompareStrings"
                           },
                           "parameters": [
                             "GetArgumentAsString(\"Direction\")",
                             "=",
                             "\"Down\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -1326,7 +4221,6 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
                               "parameters": [
@@ -1334,12 +4228,10 @@
                                 "Behavior",
                                 ">=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
                               "parameters": [
@@ -1347,23 +4239,19 @@
                                 "Behavior",
                                 "<",
                                 "180"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetReturnBoolean"
                               },
                               "parameters": [
                                 "True"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -1384,15 +4272,13 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::CompareStrings"
                           },
                           "parameters": [
                             "GetArgumentAsString(\"Direction\")",
                             "=",
                             "\"Left\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -1402,21 +4288,18 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::Or"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1424,12 +4307,10 @@
                                         "Behavior",
                                         ">=",
                                         "-180"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1437,21 +4318,18 @@
                                         "Behavior",
                                         "<",
                                         "-90"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1459,12 +4337,10 @@
                                         "Behavior",
                                         ">=",
                                         "90"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1472,8 +4348,7 @@
                                         "Behavior",
                                         "<",
                                         "180"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 }
@@ -1483,16 +4358,13 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetReturnBoolean"
                               },
                               "parameters": [
                                 "True"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -1513,15 +4385,13 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::CompareStrings"
                           },
                           "parameters": [
                             "GetArgumentAsString(\"Direction\")",
                             "=",
                             "\"Right\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -1531,21 +4401,18 @@
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::Or"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1553,12 +4420,10 @@
                                         "Behavior",
                                         ">=",
                                         "-90"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1566,21 +4431,18 @@
                                         "Behavior",
                                         "<",
                                         "0"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "BuiltinCommonInstructions::And"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1588,12 +4450,10 @@
                                         "Behavior",
                                         ">=",
                                         "0"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                       },
                                       "parameters": [
@@ -1601,8 +4461,7 @@
                                         "Behavior",
                                         "<",
                                         "90"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
                                   ]
                                 }
@@ -1612,16 +4471,13 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetReturnBoolean"
                               },
                               "parameters": [
                                 "True"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -1680,29 +4536,24 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::PropertyFloatingEnabled"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1730,6 +4581,67 @@
           "objectGroups": []
         },
         {
+          "description": "Joystick will follow the position of this touch.",
+          "fullName": "Set TouchID of joystick",
+          "functionType": "Action",
+          "group": "",
+          "name": "SetTouchID",
+          "private": false,
+          "sentence": "Set TouchID of joystick _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Value",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Enable (or disable) floating on a joystick.",
           "fullName": "Enable (or disable) floating on a joystick",
           "functionType": "Action",
@@ -1743,30 +4655,25 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyFloatingEnabled"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1778,25 +4685,21 @@
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyFloatingEnabled"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "no"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1847,29 +4750,24 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::PropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1923,30 +4821,25 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "type": "BuiltinCommonInstructions::Comment",
@@ -1971,8 +4864,7 @@
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
@@ -1982,31 +4874,26 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchButton::PropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsReleased"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -2014,18 +4901,15 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "no"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -2101,18 +4985,15 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Comment",
@@ -2133,7 +5014,6 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickAngle"
                       },
                       "parameters": [
@@ -2141,11 +5021,9 @@
                         "Behavior",
                         "=",
                         "AngleBetweenPositions(Object.CenterX(),Object.CenterY(),GetArgumentAsNumber(\"SimulatedTouchX\"),GetArgumentAsNumber(\"SimulatedTouchY\"))"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Comment",
@@ -2166,7 +5044,6 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyTouchDistance"
                       },
                       "parameters": [
@@ -2174,11 +5051,9 @@
                         "Behavior",
                         "=",
                         "DistanceBetweenPositions(Object.CenterX(),Object.CenterY(),GetArgumentAsNumber(\"SimulatedTouchX\"),GetArgumentAsNumber(\"SimulatedTouchY\"))"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Comment",
@@ -2199,7 +5074,6 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickForce"
                       },
                       "parameters": [
@@ -2207,11 +5081,9 @@
                         "Behavior",
                         "=",
                         "clamp(Object. Behavior::PropertyTouchDistance() / Object.Width()*2,0,1)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -2243,14 +5115,12 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyFloatingEnabled"
                       },
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
@@ -2260,21 +5130,18 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::CompareNumbers"
                           },
                           "parameters": [
                             "Object.Behavior::PropertyTouchDistance()",
                             ">",
                             "Object.Width()/2"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCenter"
                           },
                           "parameters": [
@@ -2283,11 +5150,9 @@
                             "XFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Width()/2)",
                             "+",
                             "YFromAngleAndDistance(Object.Behavior::JoystickAngle(),Object.Behavior::PropertyTouchDistance() - Object.Width()/2)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
@@ -2309,7 +5174,6 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "LinkedObjects::PickObjectsLinkedTo"
                       },
                       "parameters": [
@@ -2317,14 +5181,12 @@
                         "JoystickThumb",
                         "Object",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MettreAutour"
                       },
                       "parameters": [
@@ -2332,11 +5194,9 @@
                         "Object",
                         "min(Object.Behavior::PropertyTouchDistance(),Object.Width()/2)",
                         "Object.Behavior::JoystickAngle()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -2433,18 +5293,15 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Comment",
@@ -2465,7 +5322,6 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickAngle"
                       },
                       "parameters": [
@@ -2473,12 +5329,10 @@
                         "Behavior",
                         "=",
                         "clamp(GetArgumentAsNumber(\"Angle\"),-180,180)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickForce"
                       },
                       "parameters": [
@@ -2486,11 +5340,9 @@
                         "Behavior",
                         "=",
                         "clamp(GetArgumentAsNumber(\"Force\"),0,1)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -2522,7 +5374,6 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "LinkedObjects::PickObjectsLinkedTo"
                       },
                       "parameters": [
@@ -2530,14 +5381,12 @@
                         "JoystickThumb",
                         "Object",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCenter"
                       },
                       "parameters": [
@@ -2546,11 +5395,9 @@
                         "Object.CenterX() + XFromAngleAndDistance(Object.Behavior::JoystickAngle(), Object.Behavior::JoystickForce() * Object.Width()/2)",
                         "=",
                         "Object.CenterY() + YFromAngleAndDistance(Object.Behavior::JoystickAngle(), Object.Behavior::JoystickForce() * Object.Width()/2)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -2633,40 +5480,34 @@
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::PropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyButtonReleased"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "False"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
@@ -2688,7 +5529,6 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "LinkedObjects::PickObjectsLinkedTo"
                           },
                           "parameters": [
@@ -2696,14 +5536,12 @@
                             "JoystickThumb",
                             "Object",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCenter"
                           },
                           "parameters": [
@@ -2712,11 +5550,9 @@
                             "Object.CenterX()",
                             "=",
                             "Object.CenterY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Comment",
@@ -2737,7 +5573,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyJoystickForce"
                           },
                           "parameters": [
@@ -2745,11 +5580,9 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -2826,7 +5659,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "TouchID",
+          "label": "TouchID the joystick is following",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -2913,19 +5746,16 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "HasAnyTouchStarted"
                           },
                           "parameters": [
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchButton::SetPropertyTouchCounter"
                           },
                           "parameters": [
@@ -2933,8 +5763,7 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
@@ -2968,26 +5797,22 @@
                                   "parameters": [
                                     "Object",
                                     "Behavior"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "CollisionPoint"
                                   },
                                   "parameters": [
                                     "Object",
                                     "TouchX(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0)",
                                     "TouchY(StartedTouchId(Object.Behavior::PropertyTouchCounter()), Object.Layer(),0)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchButton::SetPropertyTouchID"
                                   },
                                   "parameters": [
@@ -2995,23 +5820,19 @@
                                     "Behavior",
                                     "=",
                                     "StartedTouchId(Object.Behavior::PropertyTouchCounter())"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchJoystick::SetPropertyIsPressed"
                                   },
                                   "parameters": [
                                     "Object",
                                     "Behavior",
                                     "yes"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
@@ -3019,7 +5840,6 @@
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "MultitouchJoystick::MultitouchButton::SetPropertyTouchCounter"
                                   },
                                   "parameters": [
@@ -3027,11 +5847,9 @@
                                     "Behavior",
                                     "+",
                                     "1"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         }
@@ -3068,43 +5886,36 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsReleased"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "no"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "HasTouchEnded"
                           },
                           "parameters": [
                             "",
                             "Object.Behavior::PropertyTouchID()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "MultitouchJoystick::MultitouchButton::PropertyIsPressed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
@@ -3128,31 +5939,26 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsPressed"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior",
                                 "False"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsReleased"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior",
                                 "yes"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MultitouchJoystick::MultitouchButton::SetPropertyTouchID"
                               },
                               "parameters": [
@@ -3160,11 +5966,9 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -3213,29 +6017,24 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::PropertyIsReleased"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -3276,29 +6075,24 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::PropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -3352,30 +6146,25 @@
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "type": "BuiltinCommonInstructions::Comment",
@@ -3400,48 +6189,40 @@
                   },
                   "parameters": [
                     "\"Value\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::PropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsPressed"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "no"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsReleased"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [


### PR DESCRIPTION
## Updates

- Added behavior for shape painter (Thanks Melon!)
- Changed wording from "Activate joystick" to "Animate joystick"
- No change to function names to prevent impacting existing games

## Playable game
https://liluo.io/games/968717d9-209e-4a9d-a5e5-f6ec995161cb
Works with touch, mouse (sprite=left-click, painter=right-click) and gamepad inputs (sprite=controller 1, painter=controller 2)

## Project files
[MultitouchJoystick Shape Painter.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/8945118/MultitouchJoystick.Shape.Painter.zip)

