### PR TITLE
Update DraggablePhysics.json to force Kinematic to Dynamic

### DIFF
--- a/extensions/reviewed/DraggablePhysics.json
+++ b/extensions/reviewed/DraggablePhysics.json
@@ -1,7 +1,7 @@
 {
   "author": "",
   "category": "",
-  "description": "Enables users to click and drag on objects to move them.  The object will retain velocity when the click is released, which can allow users to fling objects across the screen.\n\nNote:\n- The standard \"draggable\" behavior will not work on objects that have the physics behavior. This extension should be used instead.\n- This extension will only work on objects that have the physics behavior.",
+  "description": "Enables users to click and drag on objects to move them.  The object will retain velocity when the click is released, which can allow users to fling objects across the screen.\n\nNote:\n- The standard \"draggable\" behavior will not work on objects that have the physics behavior. This extension should be used instead.\n- This extension will only work on objects that have the physics behavior.\n- Kinematic physics mode is incompatible with this extension. The object will be changed to dynamic mode.",
   "extensionNamespace": "",
   "fullName": "Draggable (for physics objects)",
   "helpPath": "",
@@ -9,7 +9,11 @@
   "name": "DraggablePhysics",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Virtual Reality/Virtual Reality_hand_vr_ar_360.svg",
   "shortDescription": "Drag a physics object with the mouse (or touch).",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "origin": {
+    "identifier": "DraggablePhysics",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "draggable",
     "mouse",
@@ -45,15 +49,48 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
+              "name": "Change \"kinematic\" to \"dyanmic\" to prevent crash",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Physics2::IsKinematic"
+                      },
+                      "parameters": [
+                        "Object",
+                        "PhysicsBehavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Physics2::SetDynamic"
+                      },
+                      "parameters": [
+                        "Object",
+                        "PhysicsBehavior"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
               "name": "Mouse",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -67,35 +104,27 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MouseButtonFromTextPressed"
                       },
                       "parameters": [
                         "",
                         "Object.Behavior::PropertyMouseButton()"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Once"
                       },
-                      "parameters": [],
-                      "subInstructions": []
+                      "parameters": []
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -107,12 +136,10 @@
                             "Object",
                             "Behavior",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SourisSurObjet"
                           },
                           "parameters": [
@@ -120,14 +147,12 @@
                             "",
                             "",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Physics2::AddMouseJoint"
                           },
                           "parameters": [
@@ -139,12 +164,10 @@
                             "Object.Behavior::PropertyFrequency()",
                             "Object.Behavior::PropertyDamping()",
                             "__DraggablePhysics.MouseJointID"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
                           },
                           "parameters": [
@@ -152,17 +175,13 @@
                             "Behavior",
                             "=",
                             "Variable(__DraggablePhysics.MouseJointID)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -176,41 +195,32 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MouseButtonFromTextReleased"
                       },
                       "parameters": [
                         "",
                         "Object.Behavior::PropertyMouseButton()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "DraggablePhysics::DraggablePhysics::ReleaseDrag"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -224,27 +234,22 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "DraggablePhysics::DraggablePhysics::IsBeingDragged"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Physics2::MouseJointTarget"
                       },
                       "parameters": [
@@ -253,11 +258,9 @@
                         "Object.Behavior::PropertyMouseJointID()",
                         "MouseX(Object.Layer(),0)",
                         "MouseY(Object.Layer(),0)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -297,39 +300,32 @@
           "sentence": "Release _PARAM0_ from being dragged (physics)",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DraggablePhysics::DraggablePhysics::IsBeingDragged"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Physics2::Remove joint"
                   },
                   "parameters": [
                     "Object",
                     "PhysicsBehavior",
                     "Object.Behavior::PropertyMouseJointID()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
                   },
                   "parameters": [
@@ -337,11 +333,9 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -378,13 +372,10 @@
           "sentence": "_PARAM0_ is being dragged (physics)",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DraggablePhysics::DraggablePhysics::PropertyMouseJointID"
                   },
                   "parameters": [
@@ -392,23 +383,19 @@
                     "Behavior",
                     "!=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -445,25 +432,20 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DraggablePhysics::DraggablePhysics::ReleaseDrag"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -505,7 +487,7 @@
           "name": "PhysicsBehavior"
         },
         {
-          "value": "",
+          "value": "Left",
           "type": "Choice",
           "label": "Mouse button",
           "description": "",

--- a/extensions/reviewed/DraggablePhysics.json
+++ b/extensions/reviewed/DraggablePhysics.json
@@ -49,7 +49,7 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "name": "Change \"kinematic\" to \"dyanmic\" to prevent crash",
+              "name": "Change \"kinematic\" to \"dynamic\" to prevent crash",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [


### PR DESCRIPTION
- Change Kinematic mode to Dynamic mode to prevent crash
- Set "left" mouse button as default

## Playable game

https://liluo.io/games/02910630-65f7-4dc4-aa26-3f262bc888ec
This object is assigned kinematic, but the extension forces it to be dynamic.

## Project files
[DraggableNonDynamic_BugFix.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/9128505/DraggableNonDynamic_BugFix.zip)

