### PR TITLE
[SmootCamera] Add an action to fix the 1-frame delay.

### DIFF
--- a/extensions/reviewed/SmoothCamera.json
+++ b/extensions/reviewed/SmoothCamera.json
@@ -9,7 +9,11 @@
   "name": "SmoothCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_camcoder_gopro_go_pro_camera.svg",
   "shortDescription": "Smoothly scroll to follow an object.",
-  "version": "0.1.1",
+  "version": "0.2.0",
+  "origin": {
+    "identifier": "SmoothCamera",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "camera",
     "scrolling",
@@ -38,8 +42,6 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -53,14 +55,11 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeed"
                   },
                   "parameters": [
@@ -68,12 +67,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyLeftwardSpeed()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetRightwardSpeed"
                   },
                   "parameters": [
@@ -81,12 +78,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyRightwardSpeed()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
                   },
                   "parameters": [
@@ -94,12 +89,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyUpwardSpeed()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
                   },
                   "parameters": [
@@ -107,12 +100,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyDownwardSpeed()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeedMax"
                   },
                   "parameters": [
@@ -120,12 +111,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyLeftwardSpeedMax()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetRightwardSpeedMax"
                   },
                   "parameters": [
@@ -133,12 +122,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyRightwardSpeedMax()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
                   },
                   "parameters": [
@@ -146,12 +133,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyUpwardSpeedMax()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
                   },
                   "parameters": [
@@ -159,12 +144,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyDownwardSpeedMax()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaLeft"
                   },
                   "parameters": [
@@ -172,12 +155,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyFollowFreeAreaLeft()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaRight"
                   },
                   "parameters": [
@@ -185,12 +166,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyFollowFreeAreaRight()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -198,12 +177,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyFollowFreeAreaTop()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
                   },
                   "parameters": [
@@ -211,12 +188,10 @@
                     "Behavior",
                     "Object.Behavior::PropertyFollowFreeAreaBottom()",
                     "log(1 - )"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
                   },
                   "parameters": [
@@ -224,11 +199,9 @@
                     "Behavior",
                     "=",
                     "Object.Behavior::PropertyCameraDelay()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -265,8 +238,140 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SmoothCamera::SmoothCamera::PropertyIsCalledManually"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SmoothCamera::SmoothCamera::DoMoveCameraCloser"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Move the camera closer to the object. This action must be called after the object has moved for the frame.",
+          "fullName": "Move the camera closer",
+          "functionType": "Action",
+          "group": "",
+          "name": "MoveCameraCloser",
+          "private": false,
+          "sentence": "Move the camera closer to _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "The camera following is called with an action, the call from doStepPreEvents must be disabled to avoid to do it twice.",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SmoothCamera::SmoothCamera::SetPropertyIsCalledManually"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SmoothCamera::SmoothCamera::DoMoveCameraCloser"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SmoothCamera::SmoothCamera",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Move the camera closer to the object.",
+          "fullName": "Do move the camera closer",
+          "functionType": "Action",
+          "group": "",
+          "name": "DoMoveCameraCloser",
+          "private": true,
+          "sentence": "Do move the camera closer _PARAM0_",
+          "events": [
+            {
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -280,41 +385,32 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::UpdateDelayedPosition"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::UpdateForecastedPosition"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -328,26 +424,21 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::PropertyFollowOnX"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyOldX"
                   },
                   "parameters": [
@@ -355,19 +446,15 @@
                     "Behavior",
                     "=",
                     "CameraX(Object.Layer(), 0)"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraX"
                       },
                       "parameters": [
@@ -376,14 +463,12 @@
                         "Object.Behavior::FreeAreaRight()",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraX"
                       },
                       "parameters": [
@@ -392,19 +477,15 @@
                         "Object.Behavior::FreeAreaRight()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraX"
                           },
                           "parameters": [
@@ -413,14 +494,12 @@
                             "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCameraX"
                           },
                           "parameters": [
@@ -429,22 +508,17 @@
                             "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraX"
                       },
                       "parameters": [
@@ -453,14 +527,12 @@
                         "Object.Behavior::FreeAreaLeft()",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraX"
                       },
                       "parameters": [
@@ -469,19 +541,15 @@
                         "Object.Behavior::FreeAreaLeft()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraX"
                           },
                           "parameters": [
@@ -490,14 +558,12 @@
                             "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCameraX"
                           },
                           "parameters": [
@@ -506,37 +572,30 @@
                             "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::PropertyFollowOnY"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyOldY"
                   },
                   "parameters": [
@@ -544,19 +603,15 @@
                     "Behavior",
                     "=",
                     "CameraY(Object.Layer(), 0)"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraY"
                       },
                       "parameters": [
@@ -565,14 +620,12 @@
                         "Object.Behavior::FreeAreaBottom()",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraY"
                       },
                       "parameters": [
@@ -581,19 +634,15 @@
                         "Object.Behavior::FreeAreaBottom()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraY"
                           },
                           "parameters": [
@@ -602,14 +651,12 @@
                             "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCameraY"
                           },
                           "parameters": [
@@ -618,22 +665,17 @@
                             "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "CameraY"
                       },
                       "parameters": [
@@ -642,14 +684,12 @@
                         "Object.Behavior::FreeAreaTop()",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraY"
                       },
                       "parameters": [
@@ -658,19 +698,15 @@
                         "Object.Behavior::FreeAreaTop()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
                         "Object.Layer()",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "CameraY"
                           },
                           "parameters": [
@@ -679,14 +715,12 @@
                             "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SetCameraY"
                           },
                           "parameters": [
@@ -695,11 +729,9 @@
                             "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
                             "Object.Layer()",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -740,8 +772,6 @@
           "sentence": "Delay the camera of _PARAM0_ during: _PARAM2_ seconds according to the maximum speed _PARAM3_;_PARAM4_ seconds and catch up in _PARAM5_ seconds",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -755,14 +785,11 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingEnd"
                   },
                   "parameters": [
@@ -770,12 +797,10 @@
                     "Behavior",
                     "=",
                     "TimeFromStart() + GetArgumentAsNumber(\"WaitingDuration\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedXMax"
                   },
                   "parameters": [
@@ -783,12 +808,10 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"WaitingSpeedXMax\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedYMax"
                   },
                   "parameters": [
@@ -796,12 +819,10 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"WaitingSpeedYMax\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpDuration"
                   },
                   "parameters": [
@@ -809,32 +830,26 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"CatchUpDuration\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "disabled": true,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "DebuggerTools::ConsoleLog"
                   },
                   "parameters": [
                     "\"Wait and catch up\"",
                     "\"info\"",
                     "\"SmoothCamera\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -911,59 +926,47 @@
           "sentence": "Draw targeted and actual camera position for _PARAM0_ on _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PrimitiveDrawing::FillOpacity"
                   },
                   "parameters": [
                     "ShapePainter",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
               "colorB": 228,
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Path used by the forecasting",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
                         ">",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                       },
                       "parameters": [
@@ -971,56 +974,46 @@
                         "Behavior",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::OutlineColor"
                       },
                       "parameters": [
                         "ShapePainter",
                         "\"245;166;35\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::BeginFillPath"
                       },
                       "parameters": [
                         "ShapePainter",
                         "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
                         "Object.Variable(__SmoothCamera_ForecastHistoryY[0])"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Repeat",
                       "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::PathLineTo"
                           },
                           "parameters": [
                             "ShapePainter",
                             "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])",
                             "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -1028,30 +1021,23 @@
                             "Behavior",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "PrimitiveDrawing::EndFillPath"
                           },
                           "parameters": [
                             "ShapePainter"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -1063,27 +1049,21 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Follow-free area.",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Or"
                       },
                       "parameters": [],
                       "subInstructions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaLeft"
                           },
                           "parameters": [
@@ -1091,12 +1071,10 @@
                             "Behavior",
                             "!=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaRight"
                           },
                           "parameters": [
@@ -1104,12 +1082,10 @@
                             "Behavior",
                             "!=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaTop"
                           },
                           "parameters": [
@@ -1117,12 +1093,10 @@
                             "Behavior",
                             "!=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaBottom"
                           },
                           "parameters": [
@@ -1130,8 +1104,7 @@
                             "Behavior",
                             "!=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ]
                     }
@@ -1139,18 +1112,15 @@
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::OutlineColor"
                       },
                       "parameters": [
                         "ShapePainter",
                         "\"126;211;33\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Rectangle"
                       },
                       "parameters": [
@@ -1159,11 +1129,9 @@
                         "Object.Behavior::FreeAreaTop() - 1",
                         "Object.Behavior::FreeAreaRight() + 1",
                         "Object.Behavior::FreeAreaBottom() + 1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -1173,32 +1141,25 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Linear regression vector used by the forcasting.",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::OutlineColor"
                       },
                       "parameters": [
                         "ShapePainter",
                         "\"208;2;27\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::LineV2"
                       },
                       "parameters": [
@@ -1208,11 +1169,9 @@
                         "Object.Behavior::PropertyProjectedNewestX()",
                         "Object.Behavior::PropertyProjectedNewestY()",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -1222,21 +1181,16 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Targeted and actual camera position",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Circle"
                       },
                       "parameters": [
@@ -1244,12 +1198,10 @@
                         "Object.Behavior::PropertyForecastedX()",
                         "Object.Behavior::PropertyForecastedY()",
                         "3"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::LineV2"
                       },
                       "parameters": [
@@ -1259,12 +1211,10 @@
                         "CameraX(Object.Layer(), 0)",
                         "CameraY(Object.Layer(), 0) + 4",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::LineV2"
                       },
                       "parameters": [
@@ -1274,11 +1224,9 @@
                         "CameraX(Object.Layer(), 0) + 4",
                         "CameraY(Object.Layer(), 0)",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -1328,57 +1276,45 @@
           "sentence": "The camera follows _PARAM0_ on X axis: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnX"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"FollowOnX\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnX"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1425,57 +1361,45 @@
           "sentence": "The camera follows _PARAM0_ on Y axis: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "GetArgumentAsBoolean"
                   },
                   "parameters": [
                     "\"FollowOnY\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1522,14 +1446,11 @@
           "sentence": "Change the camera follow free area right border of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -1537,11 +1458,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaRight\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1588,14 +1507,11 @@
           "sentence": "Change the camera follow free area left border of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -1603,11 +1519,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaLeft\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1654,14 +1568,11 @@
           "sentence": "Change the camera follow free area top border of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -1669,11 +1580,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"FollowFreeAreaTop\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1720,14 +1629,11 @@
           "sentence": "Change the camera follow free area bottom border of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaBottom"
                   },
                   "parameters": [
@@ -1735,11 +1641,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaBottom\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1786,14 +1690,11 @@
           "sentence": "Change the camera leftward maximum speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
                   },
                   "parameters": [
@@ -1801,11 +1702,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"Speed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1852,14 +1751,11 @@
           "sentence": "Change the camera rightward maximum speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
                   },
                   "parameters": [
@@ -1867,11 +1763,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"Speed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1918,14 +1812,11 @@
           "sentence": "Change the camera upward maximum speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeedMax"
                   },
                   "parameters": [
@@ -1933,11 +1824,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"Speed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1984,14 +1873,11 @@
           "sentence": "Change the camera downward maximum speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeedMax"
                   },
                   "parameters": [
@@ -1999,11 +1885,9 @@
                     "Behavior",
                     "=",
                     "max(0, GetArgumentAsNumber(\"Speed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2050,14 +1934,11 @@
           "sentence": "Change the camera leftward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeed"
                   },
                   "parameters": [
@@ -2065,12 +1946,10 @@
                     "Behavior",
                     "=",
                     "clamp(0, 1, GetArgumentAsNumber(\"LeftwardSpeed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLogLeftwardSpeed"
                   },
                   "parameters": [
@@ -2078,11 +1957,9 @@
                     "Behavior",
                     "=",
                     "log(1 - Object.Behavior::PropertyLeftwardSpeed())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2129,14 +2006,11 @@
           "sentence": "Change the camera rightward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyRightwardSpeed"
                   },
                   "parameters": [
@@ -2144,12 +2018,10 @@
                     "Behavior",
                     "=",
                     "clamp(0, 1, GetArgumentAsNumber(\"RightwardSpeed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLogRightwardSpeed"
                   },
                   "parameters": [
@@ -2157,11 +2029,9 @@
                     "Behavior",
                     "=",
                     "log(1 - Object.Behavior::PropertyRightwardSpeed())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2208,14 +2078,11 @@
           "sentence": "Change the camera downward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeed"
                   },
                   "parameters": [
@@ -2223,12 +2090,10 @@
                     "Behavior",
                     "=",
                     "clamp(0, 1, GetArgumentAsNumber(\"DownwardSpeed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLogDownwardSpeed"
                   },
                   "parameters": [
@@ -2236,11 +2101,9 @@
                     "Behavior",
                     "=",
                     "log(1 - Object.Behavior::PropertyDownwardSpeed())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2287,14 +2150,11 @@
           "sentence": "Change the camera upward catch-up speed of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeed"
                   },
                   "parameters": [
@@ -2302,12 +2162,10 @@
                     "Behavior",
                     "=",
                     "clamp(0, 1, GetArgumentAsNumber(\"UpwardSpeed\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyLogUpwardSpeed"
                   },
                   "parameters": [
@@ -2315,11 +2173,9 @@
                     "Behavior",
                     "=",
                     "log(1 - Object.Behavior::PropertyUpwardSpeed())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2366,14 +2222,11 @@
           "sentence": "Change the camera offset on X axis of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetX"
                   },
                   "parameters": [
@@ -2381,11 +2234,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"CameraOffsetX\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2432,14 +2283,11 @@
           "sentence": "Change the camera offset on Y axis of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetY"
                   },
                   "parameters": [
@@ -2447,11 +2295,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"CameraOffsetY\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2498,14 +2344,11 @@
           "sentence": "Change the camera forecast time of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastTime"
                   },
                   "parameters": [
@@ -2513,11 +2356,9 @@
                     "Behavior",
                     "=",
                     "min(0, GetArgumentAsNumber(\"ForecastTime\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2564,14 +2405,11 @@
           "sentence": "Change the camera delay of _PARAM0_: _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
                   },
                   "parameters": [
@@ -2579,11 +2417,9 @@
                     "Behavior",
                     "=",
                     "min(0, GetArgumentAsNumber(\"CameraDelay\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2630,23 +2466,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() - Object.Behavior::PropertyFollowFreeAreaLeft()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2683,23 +2514,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() + Object.Behavior::PropertyFollowFreeAreaRight()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2736,23 +2562,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() + Object.Behavior::PropertyFollowFreeAreaBottom()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2789,23 +2610,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() - Object.Behavior::PropertyFollowFreeAreaTop()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -2842,8 +2658,6 @@
           "sentence": "Update delayed position and delayed history of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -2857,78 +2671,63 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::IsWaiting"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Egal"
                   },
                   "parameters": [
                     "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectTime",
                     "TimeFromStart()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectX",
                     "Object.Behavior::PropertyDelayedCenterX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectY",
                     "Object.Behavior::PropertyDelayedCenterY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -2942,14 +2741,11 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
                   },
                   "parameters": [
@@ -2957,12 +2753,10 @@
                     "Behavior",
                     "=",
                     "Object.CenterX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
                   },
                   "parameters": [
@@ -2970,15 +2764,11 @@
                     "Behavior",
                     "=",
                     "Object.CenterY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -2990,14 +2780,12 @@
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
                   },
                   "parameters": [
@@ -3007,47 +2795,38 @@
                     "Object.CenterX()",
                     "Object.CenterY()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::IsDelayed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::IsWaiting"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -3055,45 +2834,37 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectTime",
                     "TimeFromStart()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectX",
                     "Object.CenterX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectY",
                     "Object.CenterY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -3107,26 +2878,21 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "infiniteLoopWarning": true,
                   "type": "BuiltinCommonInstructions::While",
                   "whileConditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
                         ">=",
                         "2"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarObjet"
                       },
                       "parameters": [
@@ -3134,15 +2900,13 @@
                         "__SmoothCamera_ObjectTime[1]",
                         "<",
                         "TimeFromStart() - Object.Behavior::CurrentDelay()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
                       },
                       "parameters": [
@@ -3152,51 +2916,41 @@
                         "Object.Variable(__SmoothCamera_ObjectX[0])",
                         "Object.Variable(__SmoothCamera_ObjectY[0])",
                         ""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ObjectTime",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ObjectX",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ObjectY",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -3210,14 +2964,11 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
                       },
                       "parameters": [
@@ -3225,12 +2976,10 @@
                         "Behavior",
                         "=",
                         "Object.Variable(__SmoothCamera_ObjectX[0])"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
                       },
                       "parameters": [
@@ -3238,32 +2987,25 @@
                         "Behavior",
                         "=",
                         "Object.Variable(__SmoothCamera_ObjectY[0])"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
                         ">=",
                         "2"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarObjet"
                       },
                       "parameters": [
@@ -3271,15 +3013,12 @@
                         "__SmoothCamera_ObjectTime[0]",
                         "<",
                         "TimeFromStart() - Object.Behavior::CurrentDelay()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -3293,27 +3032,22 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::IsWaiting"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
                           },
                           "parameters": [
@@ -3321,37 +3055,30 @@
                             "Behavior",
                             "+",
                             "max(0, TimeDelta() * (1 - min(Object.Behavior::PropertyWaitingSpeedXMax() * abs(Object.Variable(__SmoothCamera_ObjectX[1]) - Object.Variable(__SmoothCamera_ObjectX[0])), Object.Behavior::PropertyWaitingSpeedYMax() * abs(Object.Variable(__SmoothCamera_ObjectY[1]) - Object.Variable(__SmoothCamera_ObjectY[0]))) / (Object.Variable(__SmoothCamera_ObjectTime[1]) - Object.Variable(__SmoothCamera_ObjectTime[0]))))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "DebuggerTools::ConsoleLog"
                               },
                               "parameters": [
                                 "\"Extra delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
                                 "\"info\"",
                                 "\"SmoothCamera\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -3365,14 +3092,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
                           },
                           "parameters": [
@@ -3380,12 +3104,10 @@
                             "Behavior",
                             "=",
                             "lerp(Object.Variable(__SmoothCamera_ObjectX[1]), Object.Variable(__SmoothCamera_ObjectX[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
                           },
                           "parameters": [
@@ -3393,19 +3115,15 @@
                             "Behavior",
                             "=",
                             "lerp(Object.Variable(__SmoothCamera_ObjectY[1]), Object.Variable(__SmoothCamera_ObjectY[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -3417,8 +3135,7 @@
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
@@ -3429,50 +3146,40 @@
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariableClearChildren"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectTime"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariableClearChildren"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectX"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariableClearChildren"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ObjectY"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -3484,22 +3191,18 @@
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpSpeed"
                   },
                   "parameters": [
@@ -3507,37 +3210,30 @@
                     "Behavior",
                     "=",
                     "Object.Behavior::PropertyCameraExtraDelay() / Object.Behavior::PropertyCameraDelayCatchUpDuration()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
                   "disabled": true,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "DebuggerTools::ConsoleLog"
                       },
                       "parameters": [
                         "\"Start to catch up\"",
                         "\"info\"",
                         "\"SmoothCamera\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -3549,12 +3245,10 @@
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::PropertyCameraExtraDelay"
                   },
                   "parameters": [
@@ -3562,14 +3256,12 @@
                     "Behavior",
                     ">",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
                   },
                   "parameters": [
@@ -3577,31 +3269,26 @@
                     "Behavior",
                     "=",
                     "max(0, Object.Behavior::PropertyCameraExtraDelay() -Object.Behavior::PropertyCameraDelayCatchUpSpeed() * TimeDelta())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
                   "disabled": true,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "DebuggerTools::ConsoleLog"
                       },
                       "parameters": [
                         "\"Catching up delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
                         "\"info\"",
                         "\"SmoothCamera\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -3640,36 +3327,29 @@
           "sentence": "The camera of _PARAM0_ is delayed",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Egal"
                   },
                   "parameters": [
                     "Object.Behavior::CurrentDelay()",
                     ">",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -3706,23 +3386,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyCameraDelay() + Object.Behavior::PropertyCameraExtraDelay()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -3759,13 +3434,10 @@
           "sentence": "The camera of _PARAM0_ is waiting",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::PropertyWaitingEnd"
                   },
                   "parameters": [
@@ -3773,23 +3445,19 @@
                     "Behavior",
                     ">",
                     "TimeFromStart()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -3826,20 +3494,16 @@
           "sentence": "Add the time:_PARAM2_ and position: _PARAM3_; _PARAM4_ to the forecast history of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
                       },
                       "parameters": [
@@ -3847,12 +3511,10 @@
                         "Behavior",
                         ">",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
                       },
                       "parameters": [
@@ -3860,8 +3522,7 @@
                         "Behavior",
                         ">",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -3869,45 +3530,37 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ForecastHistoryTime",
                     "GetArgumentAsNumber(\"Time\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ForecastHistoryX",
                     "GetArgumentAsNumber(\"ObjectX\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectVariablePushNumber"
                   },
                   "parameters": [
                     "Object",
                     "__SmoothCamera_ForecastHistoryY",
                     "GetArgumentAsNumber(\"ObjectY\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -3921,26 +3574,21 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "infiniteLoopWarning": true,
                   "type": "BuiltinCommonInstructions::While",
                   "whileConditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
                         ">=",
                         "3"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "VarObjet"
                       },
                       "parameters": [
@@ -3948,50 +3596,42 @@
                         "__SmoothCamera_ForecastHistoryTime[0]",
                         "<",
                         "TimeFromStart() - Object.Behavior::PropertyCameraDelay() - Object.Behavior::PropertyCameraExtraDelay() - Object.Behavior::PropertyForecastHistoryDuration()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ForecastHistoryTime",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ForecastHistoryX",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectVariableRemoveAt"
                       },
                       "parameters": [
                         "Object",
                         "__SmoothCamera_ForecastHistoryY",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -4060,14 +3700,11 @@
           "sentence": "Update forecasted position of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
                   },
                   "parameters": [
@@ -4075,12 +3712,10 @@
                     "Behavior",
                     "=",
                     "Object.Behavior::PropertyDelayedCenterX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
                   },
                   "parameters": [
@@ -4088,15 +3723,11 @@
                     "Behavior",
                     "=",
                     "Object.Behavior::PropertyDelayedCenterY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -4110,32 +3741,26 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Egal"
                   },
                   "parameters": [
                     "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
                     ">=",
                     "2"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
                       },
                       "parameters": [
@@ -4143,12 +3768,10 @@
                         "Behavior",
                         ">",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
                       },
                       "parameters": [
@@ -4156,8 +3779,7 @@
                         "Behavior",
                         ">",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -4169,21 +3791,16 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Mean X",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
                           },
                           "parameters": [
@@ -4191,12 +3808,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4204,22 +3819,17 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Repeat",
                       "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
                           },
                           "parameters": [
@@ -4227,12 +3837,10 @@
                             "Behavior",
                             "+",
                             "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4240,21 +3848,16 @@
                             "Behavior",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
                           },
                           "parameters": [
@@ -4262,11 +3865,9 @@
                             "Behavior",
                             "/",
                             "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -4276,21 +3877,16 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Mean Y",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
                           },
                           "parameters": [
@@ -4298,12 +3894,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4311,22 +3905,17 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Repeat",
                       "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
                           },
                           "parameters": [
@@ -4334,12 +3923,10 @@
                             "Behavior",
                             "+",
                             "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4347,21 +3934,16 @@
                             "Behavior",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
                           },
                           "parameters": [
@@ -4369,32 +3951,26 @@
                             "Behavior",
                             "/",
                             "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "disabled": true,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DebuggerTools::ConsoleLog"
                           },
                           "parameters": [
                             "\"Mean: \" + ToString(Object.Behavior::PropertyForecastHistoryMeanX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryMeanY())",
                             "",
                             ""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -4404,15 +3980,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Variance and Covariance",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -4426,14 +3998,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
                           },
                           "parameters": [
@@ -4441,12 +4010,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
                           },
                           "parameters": [
@@ -4454,12 +4021,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
                           },
                           "parameters": [
@@ -4467,12 +4032,10 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4480,22 +4043,17 @@
                             "Behavior",
                             "=",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Repeat",
                       "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
                           },
                           "parameters": [
@@ -4503,12 +4061,10 @@
                             "Behavior",
                             "+",
                             "pow(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX(), 2)"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
                           },
                           "parameters": [
@@ -4516,12 +4072,10 @@
                             "Behavior",
                             "+",
                             "pow(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY(), 2)"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
                           },
                           "parameters": [
@@ -4529,12 +4083,10 @@
                             "Behavior",
                             "+",
                             "(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX())\n*\n(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY())"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                           },
                           "parameters": [
@@ -4542,67 +4094,54 @@
                             "Behavior",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
                       "disabled": true,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "DebuggerTools::ConsoleLog"
                           },
                           "parameters": [
                             "\"Variances: \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceY()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryCovariance())",
                             "\"info\"",
                             "\"SmoothCamera\""
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Egal"
                           },
                           "parameters": [
                             "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
                             "<",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Egal"
                           },
                           "parameters": [
                             "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
                             "<",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
                           },
                           "parameters": [
@@ -4610,12 +4149,10 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyDelayedCenterX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
                           },
                           "parameters": [
@@ -4623,47 +4160,38 @@
                             "Behavior",
                             "=",
                             "Object.Behavior::PropertyDelayedCenterY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
                                 ">=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
                                 ">=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ]
                         }
@@ -4675,15 +4203,11 @@
                           "colorG": 176,
                           "colorR": 74,
                           "creationTime": 0,
-                          "disabled": false,
-                          "folded": false,
                           "name": "Linear function parameters",
                           "source": "",
                           "type": "BuiltinCommonInstructions::Group",
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -4697,27 +4221,22 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
                                     ">=",
                                     "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
                                   },
                                   "parameters": [
@@ -4725,12 +4244,10 @@
                                     "Behavior",
                                     "=",
                                     "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
                                   },
                                   "parameters": [
@@ -4738,52 +4255,42 @@
                                     "Behavior",
                                     "=",
                                     "Object.Behavior::PropertyForecastHistoryMeanY() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "events": [
                                 {
                                   "disabled": true,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "DebuggerTools::ConsoleLog"
                                       },
                                       "parameters": [
                                         "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
                                         "\"info\"",
                                         "\"SmoothCamera\""
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 },
                                 {
                                   "colorB": 228,
                                   "colorG": 176,
                                   "colorR": 74,
                                   "creationTime": 0,
-                                  "disabled": false,
-                                  "folded": false,
                                   "name": "Projection",
                                   "source": "",
                                   "type": "BuiltinCommonInstructions::Group",
                                   "events": [
                                     {
-                                      "disabled": false,
-                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [],
                                       "actions": [
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
                                           },
                                           "parameters": [
@@ -4794,11 +4301,9 @@
                                             "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
                                             "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
                                             ""
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         }
-                                      ],
-                                      "events": []
+                                      ]
                                     }
                                   ],
                                   "parameters": []
@@ -4806,8 +4311,6 @@
                               ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -4821,27 +4324,22 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
                                     "<",
                                     "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
                                   },
                                   "parameters": [
@@ -4849,12 +4347,10 @@
                                     "Behavior",
                                     "=",
                                     "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceY()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
                                   },
                                   "parameters": [
@@ -4862,52 +4358,42 @@
                                     "Behavior",
                                     "=",
                                     "Object.Behavior::PropertyForecastHistoryMeanX() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanY()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "events": [
                                 {
                                   "disabled": true,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "DebuggerTools::ConsoleLog"
                                       },
                                       "parameters": [
                                         "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
                                         "\"info\"",
                                         "\"SmoothCamera\""
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 },
                                 {
                                   "colorB": 228,
                                   "colorG": 176,
                                   "colorR": 74,
                                   "creationTime": 0,
-                                  "disabled": false,
-                                  "folded": false,
                                   "name": "Projection",
                                   "source": "",
                                   "type": "BuiltinCommonInstructions::Group",
                                   "events": [
                                     {
-                                      "disabled": false,
-                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [],
                                       "actions": [
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
                                           },
                                           "parameters": [
@@ -4918,15 +4404,11 @@
                                             "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
                                             "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
                                             ""
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         }
-                                      ],
-                                      "events": []
+                                      ]
                                     },
                                     {
-                                      "disabled": false,
-                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Comment",
                                       "color": {
                                         "b": 109,
@@ -4940,14 +4422,11 @@
                                       "comment2": ""
                                     },
                                     {
-                                      "disabled": false,
-                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [],
                                       "actions": [
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                                           },
                                           "parameters": [
@@ -4955,12 +4434,10 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyProjectedOldestX()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         },
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
                                           },
                                           "parameters": [
@@ -4968,12 +4445,10 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyProjectedOldestY()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         },
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
                                           },
                                           "parameters": [
@@ -4981,21 +4456,16 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyIndex()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         }
-                                      ],
-                                      "events": []
+                                      ]
                                     },
                                     {
-                                      "disabled": false,
-                                      "folded": false,
                                       "type": "BuiltinCommonInstructions::Standard",
                                       "conditions": [],
                                       "actions": [
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
                                           },
                                           "parameters": [
@@ -5003,12 +4473,10 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyProjectedNewestX()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         },
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
                                           },
                                           "parameters": [
@@ -5016,12 +4484,10 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyProjectedNewestY()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         },
                                         {
                                           "type": {
-                                            "inverted": false,
                                             "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
                                           },
                                           "parameters": [
@@ -5029,56 +4495,46 @@
                                             "Behavior",
                                             "=",
                                             "Object.Behavior::PropertyIndex()"
-                                          ],
-                                          "subInstructions": []
+                                          ]
                                         }
-                                      ],
-                                      "events": []
+                                      ]
                                     }
                                   ],
                                   "parameters": []
                                 },
                                 {
                                   "disabled": true,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "DebuggerTools::ConsoleLog"
                                       },
                                       "parameters": [
                                         "\"Oldest: \" + ToString(Object.Behavior::PropertyProjectedOldestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedOldestY())",
                                         "\"info\"",
                                         "\"SmoothCamera\""
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 },
                                 {
                                   "disabled": true,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "DebuggerTools::ConsoleLog"
                                       },
                                       "parameters": [
                                         "\"Newest: \" + ToString(Object.Behavior::PropertyProjectedNewestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedNewestY())",
                                         "\"info\"",
                                         "\"SmoothCamera\""
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 }
                               ]
                             },
@@ -5087,21 +4543,16 @@
                               "colorG": 176,
                               "colorR": 74,
                               "creationTime": 0,
-                              "disabled": false,
-                              "folded": false,
                               "name": "Forcasted position",
                               "source": "",
                               "type": "BuiltinCommonInstructions::Group",
                               "events": [
                                 {
-                                  "disabled": false,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
                                       },
                                       "parameters": [
@@ -5109,12 +4560,10 @@
                                         "Behavior",
                                         "=",
                                         "Object.Behavior::PropertyProjectedNewestX() + ( Object.Behavior::PropertyProjectedNewestX() - Object.Behavior::PropertyProjectedOldestX()) * Object.Behavior::ForecastTimeRatio()"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     },
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
                                       },
                                       "parameters": [
@@ -5122,32 +4571,26 @@
                                         "Behavior",
                                         "=",
                                         "Object.Behavior::PropertyProjectedNewestY() + ( Object.Behavior::PropertyProjectedNewestY() - Object.Behavior::PropertyProjectedOldestY()) * Object.Behavior::ForecastTimeRatio()"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 },
                                 {
                                   "disabled": true,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "DebuggerTools::ConsoleLog"
                                       },
                                       "parameters": [
                                         "\"Forecasted: \" + ToString(Object.Behavior::PropertyForecastedX()) + \" \" + ToString(Object.Behavior::PropertyForecastedY())",
                                         "\"info\"",
                                         "\"SmoothCamera\""
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 }
                               ],
                               "parameters": []
@@ -5197,8 +4640,6 @@
           "sentence": "Project history oldest: _PARAM2_;_PARAM3_ and newest position: _PARAM4_;_PARAM5_ of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -5212,14 +4653,11 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
                   },
                   "parameters": [
@@ -5227,12 +4665,10 @@
                     "Behavior",
                     "=",
                     "(GetArgumentAsNumber(\"NewestX\") + (GetArgumentAsNumber(\"NewestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
                   },
                   "parameters": [
@@ -5240,21 +4676,16 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"NewestY\") + (GetArgumentAsNumber(\"NewestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"NewestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
                   },
                   "parameters": [
@@ -5262,12 +4693,10 @@
                     "Behavior",
                     "=",
                     "(GetArgumentAsNumber(\"OldestX\") + (GetArgumentAsNumber(\"OldestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
                   },
                   "parameters": [
@@ -5275,11 +4704,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"OldestY\") + (GetArgumentAsNumber(\"OldestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"OldestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -5356,23 +4783,18 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "- Object.Behavior::PropertyForecastTime() / (Object.Variable(__SmoothCamera_ForecastHistoryTime[0]) - Object.Variable(__SmoothCamera_ForecastHistoryTime[Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime) - 1]))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -5870,6 +5292,16 @@
           "extraInformation": [],
           "hidden": true,
           "name": "OldY"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsCalledManually"
         }
       ]
     },
@@ -5889,8 +5321,6 @@
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -5901,8 +5331,7 @@
                   "parameters": [
                     "Object",
                     "PlatformerCharacter"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
@@ -5912,14 +5341,12 @@
                   "parameters": [
                     "Object",
                     "PlatformerCharacter"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
                   },
                   "parameters": [
@@ -5927,12 +5354,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorFollowFreeAreaTop()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -5940,12 +5365,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorFollowFreeAreaBottom()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
                   },
                   "parameters": [
@@ -5953,12 +5376,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorUpwardSpeed()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
                   },
                   "parameters": [
@@ -5966,12 +5387,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorDownwardSpeed()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
                   },
                   "parameters": [
@@ -5979,12 +5398,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorUpwardSpeedMax()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
                   },
                   "parameters": [
@@ -5992,45 +5409,36 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyFloorDownwardSpeedMax()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PlatformBehavior::IsJumping"
                       },
                       "parameters": [
                         "Object",
                         "PlatformerCharacter"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PlatformBehavior::IsFalling"
                       },
                       "parameters": [
                         "Object",
                         "PlatformerCharacter"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -6038,7 +5446,6 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
                   },
                   "parameters": [
@@ -6046,12 +5453,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirFollowFreeAreaTop()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
                   },
                   "parameters": [
@@ -6059,12 +5464,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirFollowFreeAreaBottom()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
                   },
                   "parameters": [
@@ -6072,12 +5475,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirUpwardSpeed()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
                   },
                   "parameters": [
@@ -6085,12 +5486,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirDownwardSpeed()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
                   },
                   "parameters": [
@@ -6098,12 +5497,10 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirUpwardSpeedMax()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
                   },
                   "parameters": [
@@ -6111,11 +5508,9 @@
                     "SmoothCamera",
                     "Object.Behavior::PropertyAirDownwardSpeedMax()",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [


### PR DESCRIPTION
This add an action to choose when the camera following must be applied to avoid a delay.

Note for reviewers: the change is only in the function:
- onPreEvents: its call DoMoveCameraCloser
- MoveCameraCloser: it calls DoMoveCameraCloser
- DoMoveCameraCloser: contains what was in onPreEvents

The delay does some kind of glitch.

* Camera following in the life-cycle function: 1 frame delay
https://games.gdevelop-app.com/game-c29f6b40-81cd-422f-b683-372675135e66/index.html

* Camera following after the player movement though an action: no delay
https://games.gdevelop-app.com/game-5d60504f-534f-4194-b9d0-b0b3649c3fbc/index.html  

Example:
* https://github.com/GDevelopApp/GDevelop-examples/pull/364