### PR TITLE
Add the CameraImpulse extension.

### DIFF
--- a/extensions/reviewed/CameraImpulse.json
+++ b/extensions/reviewed/CameraImpulse.json
@@ -1,0 +1,795 @@
+{
+  "author": "",
+  "category": "",
+  "description": "Move the camera following an impulse trajectory.\n\nIt can be used to simulate earthquakes or impacts.",
+  "extensionNamespace": "",
+  "fullName": "Camera impulse",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8Zz4NCgk8cGF0aCBkPSJNMjEsMzBjLTAuMywwLTAuNS0wLjEtMC43LTAuM2wtNC00Yy0wLjQtMC40LTAuNC0xLDAtMS40czEtMC40LDEuNCwwbDMuMywzLjNsMy4zLTMuM2MwLjQtMC40LDEtMC40LDEuNCwwczAuNCwxLDAsMS40DQoJCWwtNCw0QzIxLjUsMjkuOSwyMS4zLDMwLDIxLDMweiIvPg0KPC9nPg0KPGc+DQoJPHBhdGggZD0iTTIxLDMwYy0wLjYsMC0xLTAuNC0xLTFWN2MwLTAuNiwwLjQtMSwxLTFzMSwwLjQsMSwxdjIyQzIyLDI5LjYsMjEuNiwzMCwyMSwzMHoiLz4NCjwvZz4NCjxnPg0KCTxwYXRoIGQ9Ik0xNSw4Yy0wLjMsMC0wLjUtMC4xLTAuNy0wLjNMMTEsNC40TDcuNyw3LjdjLTAuNCwwLjQtMSwwLjQtMS40LDBzLTAuNC0xLDAtMS40bDQtNGMwLjQtMC40LDEtMC40LDEuNCwwbDQsNA0KCQljMC40LDAuNCwwLjQsMSwwLDEuNEMxNS41LDcuOSwxNS4zLDgsMTUsOHoiLz4NCjwvZz4NCjxnPg0KCTxwYXRoIGQ9Ik0xMSwyNmMtMC42LDAtMS0wLjQtMS0xVjNjMC0wLjYsMC40LTEsMS0xczEsMC40LDEsMXYyMkMxMiwyNS42LDExLjYsMjYsMTEsMjZ6Ii8+DQo8L2c+DQo8L3N2Zz4NCg==",
+  "name": "CameraImpulse",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Arrows/Arrows_thin_arrow_up_down_directions.svg",
+  "shortDescription": "Move the camera following an impulse trajectory.",
+  "version": "1.0.0",
+  "tags": [
+    "implusion",
+    "shaking",
+    "camera",
+    "effect",
+    "screen",
+    "shake",
+    "translate"
+  ],
+  "authorIds": [
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePostEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Step time counters.",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+          "iterableVariableName": "__CameraImpulse.Impulses",
+          "valueIteratorVariableName": "__CameraImpulse.Impulse",
+          "keyIteratorVariableName": "__CameraImpulse.Identifer",
+          "conditions": [],
+          "actions": [],
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__CameraImpulse.Impulses[VariableString(__CameraImpulse.Identifer)].Time",
+                    "+",
+                    "TimeDelta()"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Apply impulses on cameras.",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+          "iterableVariableName": "__CameraImpulse.Impulses",
+          "valueIteratorVariableName": "__CameraImpulse.Impulse",
+          "keyIteratorVariableName": "__CameraImpulse.Identifer",
+          "conditions": [],
+          "actions": [],
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarScene"
+                  },
+                  "parameters": [
+                    "__CameraImpulse.Impulse.Time",
+                    ">=",
+                    "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration) + Variable(__CameraImpulse.Impulse.BackDuration)"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "VariableClearChildren"
+                  },
+                  "parameters": [
+                    "__CameraImpulse.Impulses[VariableString(__CameraImpulse.Identifer)]"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarScene"
+                  },
+                  "parameters": [
+                    "__CameraImpulse.Impulse.Time",
+                    "<",
+                    "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration) + Variable(__CameraImpulse.Impulse.BackDuration)"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Going away",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Impulse.Time",
+                        "<",
+                        "Variable(__CameraImpulse.Impulse.AwayDuration)"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.DistanceFactor",
+                        "=",
+                        "Tween::Ease(VariableString(__CameraImpulse.Impulse.AwayEasing), 0, 1, Variable(__CameraImpulse.Impulse.Time) / Variable(__CameraImpulse.Impulse.AwayDuration))"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Staying",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Impulse.Time",
+                        ">=",
+                        "Variable(__CameraImpulse.Impulse.AwayDuration)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Impulse.Time",
+                        "<",
+                        "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration)"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.DistanceFactor",
+                        "=",
+                        "1"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Going back",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Impulse.Time",
+                        ">=",
+                        "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration)"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.DistanceFactor",
+                        "=",
+                        "Tween::Ease(VariableString(__CameraImpulse.Impulse.BackEasing), 0, 1, (1 - (Variable(__CameraImpulse.Impulse.Time) - Variable(__CameraImpulse.Impulse.AwayDuration) - Variable(__CameraImpulse.Impulse.StayDuration)) / Variable(__CameraImpulse.Impulse.BackDuration)))"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Keep the camera displacement to revert it in onScenePreEvents",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaX",
+                        "+",
+                        "Variable(__CameraImpulse.Impulse.DeltaX) * Variable(__CameraImpulse.DistanceFactor)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaY",
+                        "+",
+                        "Variable(__CameraImpulse.Impulse.DeltaY) * Variable(__CameraImpulse.DistanceFactor)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "Variable(__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaX)",
+                        "VariableString(__CameraImpulse.Impulse.Layer)",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "+",
+                        "Variable(__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaY)",
+                        "VariableString(__CameraImpulse.Impulse.Layer)",
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onScenePreEvents",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Revert the impulses.",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+          "iterableVariableName": "__CameraImpulse.Layers",
+          "valueIteratorVariableName": "__CameraImpulse.Layer",
+          "keyIteratorVariableName": "__CameraImpulse.LayerName",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetCameraX"
+              },
+              "parameters": [
+                "",
+                "-",
+                "Variable(__CameraImpulse.Layer.CameraDeltaX)",
+                "VariableString(__CameraImpulse.LayerName)",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "SetCameraY"
+              },
+              "parameters": [
+                "",
+                "-",
+                "Variable(__CameraImpulse.Layer.CameraDeltaY)",
+                "VariableString(__CameraImpulse.LayerName)",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Layers[VariableString(__CameraImpulse.LayerName)].CameraDeltaX",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Layers[VariableString(__CameraImpulse.LayerName)].CameraDeltaY",
+                "=",
+                "0"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Add an impulse to the camera position.",
+      "fullName": "Add a camera impulse",
+      "functionType": "Action",
+      "group": "",
+      "name": "AddImpulse",
+      "private": false,
+      "sentence": "Add an impulse _PARAM1_ to the camera from layer _PARAM2_ with an amplitude of _PARAM3_  and an angle of _PARAM4_,  going away in _PARAM5_ seconds with _PARAM6_ easing, staying _PARAM7_  seconds, going back in _PARAM8_ seconds with _PARAM9_ easing",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].Layer",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].DeltaX",
+                "=",
+                "GetArgumentAsNumber(\"DisplacementX\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].DeltaY",
+                "=",
+                "GetArgumentAsNumber(\"DisplacementY\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].AwayDuration",
+                "=",
+                "GetArgumentAsNumber(\"AwayDuration\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].StayDuration",
+                "=",
+                "GetArgumentAsNumber(\"StayDuration\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].BackDuration",
+                "=",
+                "GetArgumentAsNumber(\"BackDuration\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].AwayEasing",
+                "=",
+                "GetArgumentAsString(\"AwayEasing\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].BackEasing",
+                "=",
+                "GetArgumentAsString(\"BackEasing\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses[GetArgumentAsString(\"Identifier\")].Time",
+                "=",
+                "0"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Identifier",
+          "longDescription": "",
+          "name": "Identifier",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Displacement X",
+          "longDescription": "",
+          "name": "DisplacementX",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Displacement Y",
+          "longDescription": "",
+          "name": "DisplacementY",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get away duration (in seconds)",
+          "longDescription": "",
+          "name": "AwayDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get away easing",
+          "longDescription": "",
+          "name": "AwayEasing",
+          "optional": false,
+          "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Stay duration (in seconds)",
+          "longDescription": "",
+          "name": "StayDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get back duration (in seconds)",
+          "longDescription": "",
+          "name": "BackDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get back easing",
+          "longDescription": "",
+          "name": "BackEasing",
+          "optional": false,
+          "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Add an impulse to the camera position.",
+      "fullName": "Add a camera impulse (angle)",
+      "functionType": "Action",
+      "group": "",
+      "name": "AddImpulseAngle",
+      "private": false,
+      "sentence": "Add an impulse _PARAM1_ to the camera from layer _PARAM2_ with an amplitude of _PARAM3_  and an angle of _PARAM4_,  going away in _PARAM5_ seconds with _PARAM6_ easing, staying _PARAM7_  seconds, going back in _PARAM8_ seconds with _PARAM9_ easing",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "CameraImpulse::AddImpulse"
+              },
+              "parameters": [
+                "",
+                "GetArgumentAsString(\"Identifier\")",
+                "GetArgumentAsString(\"Layer\")",
+                "XFromAngleAndDistance(GetArgumentAsNumber(\"Angle\"), GetArgumentAsNumber(\"Amplitude\"))",
+                "YFromAngleAndDistance(GetArgumentAsNumber(\"Angle\"), GetArgumentAsNumber(\"Amplitude\"))",
+                "GetArgumentAsNumber(\"AwayDuration\")",
+                "GetArgumentAsString(\"AwayEasing\")",
+                "GetArgumentAsNumber(\"StayDuration\")",
+                "GetArgumentAsNumber(\"BackDuration\")",
+                "GetArgumentAsString(\"BackEasing\")",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Identifier",
+          "longDescription": "",
+          "name": "Identifier",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Layer",
+          "longDescription": "",
+          "name": "Layer",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Amplitude",
+          "longDescription": "",
+          "name": "Amplitude",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Angle (in degree)",
+          "longDescription": "",
+          "name": "Angle",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get away duration (in seconds)",
+          "longDescription": "",
+          "name": "AwayDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get away easing",
+          "longDescription": "",
+          "name": "AwayEasing",
+          "optional": false,
+          "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Stay duration (in seconds)",
+          "longDescription": "",
+          "name": "StayDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get back duration (in seconds)",
+          "longDescription": "",
+          "name": "BackDuration",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Get back easing",
+          "longDescription": "",
+          "name": "BackEasing",
+          "optional": false,
+          "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if a camera impulse is playing.",
+      "fullName": "Camera impulse is playing",
+      "functionType": "Condition",
+      "group": "",
+      "name": "IsPlaying",
+      "private": false,
+      "sentence": "Camera impulse _PARAM1_ is playing",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "VariableChildExists"
+              },
+              "parameters": [
+                "__CameraImpulse.Impulses",
+                "GetArgumentAsString(\"Identifier\")"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Identifier",
+          "longDescription": "",
+          "name": "Identifier",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}


### PR DESCRIPTION
* It can be used to simulate earthquakes or impacts.

## Example
It also uses:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/387

Press `I` to start an impulsion and `S` to shake.
I didn't find any conflict between the impulse and the scrolling or the screen shake.
 
- Project: https://www.dropbox.com/s/spvas50648blctc/platformer-with-tilemap-shake.zip?dl=1
- Build: https://games.gdevelop-app.com/game-881fc8e5-272e-460a-8d72-7d01baca255d/index.html