### PR TITLE
[SmoothCamera] Use a parent variable for the extension.

### DIFF
--- a/extensions/reviewed/SmoothCamera.json
+++ b/extensions/reviewed/SmoothCamera.json
@@ -9,7 +9,7 @@
   "name": "SmoothCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_camcoder_gopro_go_pro_camera.svg",
   "shortDescription": "Smoothly scroll to follow an object.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "origin": {
     "identifier": "SmoothCamera",
     "name": "gdevelop-extension-store"
@@ -958,7 +958,7 @@
                         "value": "Egal"
                       },
                       "parameters": [
-                        "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                        "Object.VariableChildCount(__SmoothCamera.ForecastHistoryTime)",
                         ">",
                         "0"
                       ]
@@ -991,15 +991,15 @@
                       },
                       "parameters": [
                         "ShapePainter",
-                        "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
-                        "Object.Variable(__SmoothCamera_ForecastHistoryY[0])"
+                        "Object.Variable(__SmoothCamera.ForecastHistoryX[0])",
+                        "Object.Variable(__SmoothCamera.ForecastHistoryY[0])"
                       ]
                     }
                   ],
                   "events": [
                     {
                       "type": "BuiltinCommonInstructions::Repeat",
-                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera.ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
@@ -1008,8 +1008,8 @@
                           },
                           "parameters": [
                             "ShapePainter",
-                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])",
-                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                            "Object.Variable(__SmoothCamera.ForecastHistoryX[Object.Behavior::PropertyIndex()])",
+                            "Object.Variable(__SmoothCamera.ForecastHistoryY[Object.Behavior::PropertyIndex()])"
                           ]
                         },
                         {
@@ -2688,7 +2688,7 @@
                     "value": "Egal"
                   },
                   "parameters": [
-                    "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                    "Object.VariableChildCount(__SmoothCamera.ObjectTime)",
                     "=",
                     "0"
                   ]
@@ -2701,7 +2701,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectTime",
+                    "__SmoothCamera.ObjectTime",
                     "TimeFromStart()"
                   ]
                 },
@@ -2711,7 +2711,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectX",
+                    "__SmoothCamera.ObjectX",
                     "Object.Behavior::PropertyDelayedCenterX()"
                   ]
                 },
@@ -2721,7 +2721,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectY",
+                    "__SmoothCamera.ObjectY",
                     "Object.Behavior::PropertyDelayedCenterY()"
                   ]
                 }
@@ -2838,7 +2838,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectTime",
+                    "__SmoothCamera.ObjectTime",
                     "TimeFromStart()"
                   ]
                 },
@@ -2848,7 +2848,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectX",
+                    "__SmoothCamera.ObjectX",
                     "Object.CenterX()"
                   ]
                 },
@@ -2858,7 +2858,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectY",
+                    "__SmoothCamera.ObjectY",
                     "Object.CenterY()"
                   ]
                 }
@@ -2886,7 +2886,7 @@
                         "value": "Egal"
                       },
                       "parameters": [
-                        "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                        "Object.VariableChildCount(__SmoothCamera.ObjectTime)",
                         ">=",
                         "2"
                       ]
@@ -2897,7 +2897,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ObjectTime[1]",
+                        "__SmoothCamera.ObjectTime[1]",
                         "<",
                         "TimeFromStart() - Object.Behavior::CurrentDelay()"
                       ]
@@ -2912,9 +2912,9 @@
                       "parameters": [
                         "Object",
                         "Behavior",
-                        "Object.Variable(__SmoothCamera_ObjectTime[0])",
-                        "Object.Variable(__SmoothCamera_ObjectX[0])",
-                        "Object.Variable(__SmoothCamera_ObjectY[0])",
+                        "Object.Variable(__SmoothCamera.ObjectTime[0])",
+                        "Object.Variable(__SmoothCamera.ObjectX[0])",
+                        "Object.Variable(__SmoothCamera.ObjectY[0])",
                         ""
                       ]
                     },
@@ -2924,7 +2924,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ObjectTime",
+                        "__SmoothCamera.ObjectTime",
                         "0"
                       ]
                     },
@@ -2934,7 +2934,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ObjectX",
+                        "__SmoothCamera.ObjectX",
                         "0"
                       ]
                     },
@@ -2944,7 +2944,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ObjectY",
+                        "__SmoothCamera.ObjectY",
                         "0"
                       ]
                     }
@@ -2975,7 +2975,7 @@
                         "Object",
                         "Behavior",
                         "=",
-                        "Object.Variable(__SmoothCamera_ObjectX[0])"
+                        "Object.Variable(__SmoothCamera.ObjectX[0])"
                       ]
                     },
                     {
@@ -2986,7 +2986,7 @@
                         "Object",
                         "Behavior",
                         "=",
-                        "Object.Variable(__SmoothCamera_ObjectY[0])"
+                        "Object.Variable(__SmoothCamera.ObjectY[0])"
                       ]
                     }
                   ]
@@ -2999,7 +2999,7 @@
                         "value": "Egal"
                       },
                       "parameters": [
-                        "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                        "Object.VariableChildCount(__SmoothCamera.ObjectTime)",
                         ">=",
                         "2"
                       ]
@@ -3010,7 +3010,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ObjectTime[0]",
+                        "__SmoothCamera.ObjectTime[0]",
                         "<",
                         "TimeFromStart() - Object.Behavior::CurrentDelay()"
                       ]
@@ -3054,7 +3054,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "max(0, TimeDelta() * (1 - min(Object.Behavior::PropertyWaitingSpeedXMax() * abs(Object.Variable(__SmoothCamera_ObjectX[1]) - Object.Variable(__SmoothCamera_ObjectX[0])), Object.Behavior::PropertyWaitingSpeedYMax() * abs(Object.Variable(__SmoothCamera_ObjectY[1]) - Object.Variable(__SmoothCamera_ObjectY[0]))) / (Object.Variable(__SmoothCamera_ObjectTime[1]) - Object.Variable(__SmoothCamera_ObjectTime[0]))))"
+                            "max(0, TimeDelta() * (1 - min(Object.Behavior::PropertyWaitingSpeedXMax() * abs(Object.Variable(__SmoothCamera.ObjectX[1]) - Object.Variable(__SmoothCamera.ObjectX[0])), Object.Behavior::PropertyWaitingSpeedYMax() * abs(Object.Variable(__SmoothCamera.ObjectY[1]) - Object.Variable(__SmoothCamera.ObjectY[0]))) / (Object.Variable(__SmoothCamera.ObjectTime[1]) - Object.Variable(__SmoothCamera.ObjectTime[0]))))"
                           ]
                         }
                       ],
@@ -3103,7 +3103,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Variable(__SmoothCamera_ObjectX[1]), Object.Variable(__SmoothCamera_ObjectX[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                            "lerp(Object.Variable(__SmoothCamera.ObjectX[1]), Object.Variable(__SmoothCamera.ObjectX[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera.ObjectTime[1])) / (Object.Variable(__SmoothCamera.ObjectTime[0]) - Object.Variable(__SmoothCamera.ObjectTime[1])))"
                           ]
                         },
                         {
@@ -3114,7 +3114,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "lerp(Object.Variable(__SmoothCamera_ObjectY[1]), Object.Variable(__SmoothCamera_ObjectY[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                            "lerp(Object.Variable(__SmoothCamera.ObjectY[1]), Object.Variable(__SmoothCamera.ObjectY[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera.ObjectTime[1])) / (Object.Variable(__SmoothCamera.ObjectTime[0]) - Object.Variable(__SmoothCamera.ObjectTime[1])))"
                           ]
                         }
                       ]
@@ -3156,7 +3156,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectTime"
+                    "__SmoothCamera.ObjectTime"
                   ]
                 },
                 {
@@ -3165,7 +3165,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectX"
+                    "__SmoothCamera.ObjectX"
                   ]
                 },
                 {
@@ -3174,7 +3174,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ObjectY"
+                    "__SmoothCamera.ObjectY"
                   ]
                 }
               ]
@@ -3534,7 +3534,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ForecastHistoryTime",
+                    "__SmoothCamera.ForecastHistoryTime",
                     "GetArgumentAsNumber(\"Time\")"
                   ]
                 },
@@ -3544,7 +3544,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ForecastHistoryX",
+                    "__SmoothCamera.ForecastHistoryX",
                     "GetArgumentAsNumber(\"ObjectX\")"
                   ]
                 },
@@ -3554,7 +3554,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "__SmoothCamera_ForecastHistoryY",
+                    "__SmoothCamera.ForecastHistoryY",
                     "GetArgumentAsNumber(\"ObjectY\")"
                   ]
                 }
@@ -3582,7 +3582,7 @@
                         "value": "Egal"
                       },
                       "parameters": [
-                        "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                        "Object.VariableChildCount(__SmoothCamera.ForecastHistoryTime)",
                         ">=",
                         "3"
                       ]
@@ -3593,7 +3593,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ForecastHistoryTime[0]",
+                        "__SmoothCamera.ForecastHistoryTime[0]",
                         "<",
                         "TimeFromStart() - Object.Behavior::PropertyCameraDelay() - Object.Behavior::PropertyCameraExtraDelay() - Object.Behavior::PropertyForecastHistoryDuration()"
                       ]
@@ -3607,7 +3607,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ForecastHistoryTime",
+                        "__SmoothCamera.ForecastHistoryTime",
                         "0"
                       ]
                     },
@@ -3617,7 +3617,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ForecastHistoryX",
+                        "__SmoothCamera.ForecastHistoryX",
                         "0"
                       ]
                     },
@@ -3627,7 +3627,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "__SmoothCamera_ForecastHistoryY",
+                        "__SmoothCamera.ForecastHistoryY",
                         "0"
                       ]
                     }
@@ -3748,7 +3748,7 @@
                     "value": "Egal"
                   },
                   "parameters": [
-                    "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                    "Object.VariableChildCount(__SmoothCamera.ForecastHistoryTime)",
                     ">=",
                     "2"
                   ]
@@ -3825,7 +3825,7 @@
                     },
                     {
                       "type": "BuiltinCommonInstructions::Repeat",
-                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera.ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
@@ -3836,7 +3836,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])"
+                            "Object.Variable(__SmoothCamera.ForecastHistoryX[Object.Behavior::PropertyIndex()])"
                           ]
                         },
                         {
@@ -3864,7 +3864,7 @@
                             "Object",
                             "Behavior",
                             "/",
-                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)"
+                            "Object.VariableChildCount(__SmoothCamera.ForecastHistoryX)"
                           ]
                         }
                       ]
@@ -3911,7 +3911,7 @@
                     },
                     {
                       "type": "BuiltinCommonInstructions::Repeat",
-                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera.ForecastHistoryY)",
                       "conditions": [],
                       "actions": [
                         {
@@ -3922,7 +3922,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                            "Object.Variable(__SmoothCamera.ForecastHistoryY[Object.Behavior::PropertyIndex()])"
                           ]
                         },
                         {
@@ -3950,7 +3950,7 @@
                             "Object",
                             "Behavior",
                             "/",
-                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)"
+                            "Object.VariableChildCount(__SmoothCamera.ForecastHistoryY)"
                           ]
                         }
                       ]
@@ -4049,7 +4049,7 @@
                     },
                     {
                       "type": "BuiltinCommonInstructions::Repeat",
-                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                      "repeatExpression": "Object.VariableChildCount(__SmoothCamera.ForecastHistoryX)",
                       "conditions": [],
                       "actions": [
                         {
@@ -4060,7 +4060,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "pow(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX(), 2)"
+                            "pow(Object.Variable(__SmoothCamera.ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX(), 2)"
                           ]
                         },
                         {
@@ -4071,7 +4071,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "pow(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY(), 2)"
+                            "pow(Object.Variable(__SmoothCamera.ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY(), 2)"
                           ]
                         },
                         {
@@ -4082,7 +4082,7 @@
                             "Object",
                             "Behavior",
                             "+",
-                            "(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX())\n*\n(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY())"
+                            "(Object.Variable(__SmoothCamera.ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX())\n*\n(Object.Variable(__SmoothCamera.ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY())"
                           ]
                         },
                         {
@@ -4296,10 +4296,10 @@
                                           "parameters": [
                                             "Object",
                                             "Behavior",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryX[0])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryY[0])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryX[Object.VariableChildCount(__SmoothCamera.ForecastHistoryX) - 1])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryY[Object.VariableChildCount(__SmoothCamera.ForecastHistoryY) - 1])",
                                             ""
                                           ]
                                         }
@@ -4399,10 +4399,10 @@
                                           "parameters": [
                                             "Object",
                                             "Behavior",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
-                                            "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryY[0])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryX[0])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryY[Object.VariableChildCount(__SmoothCamera.ForecastHistoryY) - 1])",
+                                            "Object.Variable(__SmoothCamera.ForecastHistoryX[Object.VariableChildCount(__SmoothCamera.ForecastHistoryX) - 1])",
                                             ""
                                           ]
                                         }
@@ -4791,7 +4791,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "- Object.Behavior::PropertyForecastTime() / (Object.Variable(__SmoothCamera_ForecastHistoryTime[0]) - Object.Variable(__SmoothCamera_ForecastHistoryTime[Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime) - 1]))"
+                    "- Object.Behavior::PropertyForecastTime() / (Object.Variable(__SmoothCamera.ForecastHistoryTime[0]) - Object.Variable(__SmoothCamera.ForecastHistoryTime[Object.VariableChildCount(__SmoothCamera.ForecastHistoryTime) - 1]))"
                   ]
                 }
               ]


### PR DESCRIPTION
This is just an automatic refactor to have a root variable for the extension and avoid to pollute the debugger.

## Example
- Project: https://www.dropbox.com/s/08d29yjf5kf3817/AdvancedJumpAirAndWallJumpExample_D8H-1.zip?dl=1