### PR TITLE
[New community extensions] Geolocation, References and ObjectPickingTools

### DIFF
--- a/extensions/community/Geolocation.json
+++ b/extensions/community/Geolocation.json
@@ -1,0 +1,138 @@
+{
+  "author": "Arthur Pacaud (arthuro555)",
+  "category": "Device",
+  "description": "Adds an action to locate the player using the built-in GPS, or other techniques if unavailable. \nYou can also track whether or not you've gotten the permission to use the GPS sensor, and track realtime player movement.",
+  "extensionNamespace": "",
+  "fullName": "GPS",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNyb3NzaGFpcnMtZ3BzIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTEyLDhBNCw0IDAgMCwxIDE2LDEyQTQsNCAwIDAsMSAxMiwxNkE0LDQgMCAwLDEgOCwxMkE0LDQgMCAwLDEgMTIsOE0zLjA1LDEzSDFWMTFIMy4wNUMzLjUsNi44MyA2LjgzLDMuNSAxMSwzLjA1VjFIMTNWMy4wNUMxNy4xNywzLjUgMjAuNSw2LjgzIDIwLjk1LDExSDIzVjEzSDIwLjk1QzIwLjUsMTcuMTcgMTcuMTcsMjAuNSAxMywyMC45NVYyM0gxMVYyMC45NUM2LjgzLDIwLjUgMy41LDE3LjE3IDMuMDUsMTNNMTIsNUE3LDcgMCAwLDAgNSwxMkE3LDcgMCAwLDAgMTIsMTlBNyw3IDAgMCwwIDE5LDEyQTcsNyAwIDAsMCAxMiw1WiIgLz48L3N2Zz4=",
+  "name": "Geolocation",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/crosshairs-gps.svg",
+  "shortDescription": "Adds a way to locate the player.",
+  "version": "1.0.0",
+  "tags": [
+    "geolocation",
+    "gps",
+    "position",
+    "location",
+    "locate",
+    "where",
+    "place"
+  ],
+  "authorIds": [
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
+  ],
+  "dependencies": [
+    {
+      "exportName": "cordova-plugin-geolocation",
+      "name": "Geolocation cordova support",
+      "type": "cordova",
+      "version": "https://github.com/apache/cordova-plugin-geolocation.git"
+    }
+  ],
+  "eventsFunctions": [
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "group": "",
+      "name": "onFirstSceneLoaded",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs.evtTools.geolocation = {\n    permission: { state: navigator.permissions ? \"loading\" : \"unknown\" }\n};\n\n// Prefetch the permission and set up an event handler to keep it up to date\nif (navigator.permissions) navigator.permissions.query({ name: 'geolocation' })\n    .then((permission) => {\n        gdjs.evtTools.geolocation.permission = permission;\n    });\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Returns the status of the geolocation permission.",
+      "fullName": "Permission status",
+      "functionType": "StringExpression",
+      "group": "",
+      "name": "PermissionStatus",
+      "private": false,
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = gdjs.evtTools.geolocation.permission.state;\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Detects when the player's device is moved and get its new location. If the permission status is pending, it will ask for user permission. Every time the location is updated, stores it in the callback variable.",
+      "fullName": "Watch the player",
+      "functionType": "Action",
+      "group": "",
+      "name": "WatchPlayer",
+      "private": false,
+      "sentence": "Watch player movements and store their position in scene variable _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "this.logger = (this.logger || new gdjs.Logger(\"Geolocation extension\"))\n\nif (navigator && navigator.geolocation) navigator\n    .geolocation\n    .watchPosition(\n        location => {\n            const variable = eventsFunctionContext.getArgument(\"callback\");\n            for (const child of Object.keys(location.coords.__proto__)) {\n                variable.getChild(child).setNumber(location.coords[child]);\n            }\n        },\n        (error) => this.logger.error(`Couldn't locate player: ` + error.message),\n        { enableHighAccuracy: true }\n    );\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Callback variable",
+          "longDescription": "",
+          "name": "callback",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Locates the player. If the permission status is pending, it will ask for user permission. Once the location is fetched, stores it in the callback variable.",
+      "fullName": "Locate the player",
+      "functionType": "Action",
+      "group": "",
+      "name": "LocatePlayer",
+      "private": false,
+      "sentence": "Locate the player and store the result in scene variable _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "this.logger = (this.logger || new gdjs.Logger(\"Geolocation extension\"))\n\nif (navigator && navigator.geolocation) navigator\n    .geolocation\n    .getCurrentPosition(\n        location => {\n            const variable = eventsFunctionContext.getArgument(\"callback\");\n            for (const child in location.coords) {\n                variable.getChild(child).setNumber(location.coords[child]);\n            }\n        },\n        (error) => this.logger.error(`Couldn't locate player: ` + error.message),\n        { enableHighAccuracy: true }\n    );\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Callback variable",
+          "longDescription": "",
+          "name": "callback",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/extensions/community/ObjectPickingTools.json
+++ b/extensions/community/ObjectPickingTools.json
@@ -1,0 +1,505 @@
+{
+  "author": "",
+  "category": "Advanced",
+  "description": "Adds various actions/conditions for advanced object selection, such as picking the object with the highest/lowest zOrder, picking only a specific object out of the objects lists, unpicking all objects of a certain type...",
+  "extensionNamespace": "",
+  "fullName": "Object picking tools",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXNlbGVjdGlvbi1lbGxpcHNlLWFycm93LWluc2lkZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xMS4yIDRDOS45NCA0LjEyIDguNzIgNC41MyA3LjY0IDUuMkw2LjY0IDMuNDdDNy45NSAyLjY0IDkuNDUgMi4xMyAxMSAyTTE3LjUzIDYuMjVDMTYuNjIgNS4zOSAxNS41MyA0LjczIDE0LjM0IDQuMzNMMTUgMi4zOUMxNi41IDIuODQgMTcuODkgMy42NiAxOSA0Ljc4TTUuMzQgNy40MUM0LjY0IDguNDQgNC4xOSA5LjYgNCAxMC44M0wyIDEwLjU1QzIuMiA5IDIuNzkgNy41IDMuNyA2LjIzTTIyIDEyVjEyLjY2TDIwIDEyLjVWMTJDMjAgMTAuOTIgMTkuODEgOS44NiAxOS4zOSA4Ljg2TDIxLjIyIDguMDZDMjEuNzUgOS4zMSAyMiAxMC42NSAyMiAxMk02IDE3LjNMNC41IDE4LjYxQzMuNDcgMTcuNDMgMi43MiAxNi4wNCAyLjMgMTQuNTNMNC4xNyAxNEM0LjUzIDE1LjIyIDUuMTYgMTYuMzUgNiAxNy4zTTEyLjE0IDIySDEyQzEwLjUgMjIgOSAyMS42OCA3LjY0IDIxLjA3TDguNTMgMTkuMjRDOS42MiAxOS43NSAxMC44IDIwIDEyIDIwSDEyLjE5TTE3IDIxSDE1VjE1SDIxVjE3SDE4LjQyTDIxLjE0IDE5Ljc2TDE5LjczIDIxLjE3TDE3IDE4LjUiIC8+PC9zdmc+",
+  "name": "ObjectPickingTools",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/selection-ellipse-arrow-inside.svg",
+  "shortDescription": "Adds various object picking related tools.",
+  "version": "1.0.0",
+  "tags": [
+    "object",
+    "picking",
+    "instance",
+    "pick",
+    "unpick",
+    "select",
+    "deselect"
+  ],
+  "authorIds": [
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Unpicks all instances of an object.",
+      "fullName": "Unpick all instances",
+      "functionType": "Action",
+      "group": "",
+      "name": "UnpickAction",
+      "private": false,
+      "sentence": "Unpick all instances of _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\nfor (const listName in lists)\n    lists[listName].length = 0;\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to unpick all instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Unpicks all instances of an object.",
+      "fullName": "Unpick all instances",
+      "functionType": "Condition",
+      "group": "",
+      "name": "UnpickCondition",
+      "private": false,
+      "sentence": "Unpick all instances of _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\nfor (const listName in lists)\n    lists[listName].length = 0;\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to unpick all instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the instance out of a list of objects that has the highest zOrder.",
+      "fullName": "Pick the object with highest zOrder",
+      "functionType": "Action",
+      "group": "",
+      "name": "PickHighestZAction",
+      "private": false,
+      "sentence": "Pick the _PARAM1_ with the highest zOrder",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nlet highestObject = null;\r\nlet highestZOrder = -Infinity;\r\n\r\nfor (const listName in lists) {\r\n    for (const object of lists[listName]) {\r\n        const zOrder = object.getZOrder();\r\n        if (zOrder > highestZOrder) {\r\n            highestObject = object;\r\n            highestZOrder = zOrder;\r\n        };\r\n    }\r\n    lists[listName].length = 0;\r\n}\r\n\r\nif (highestObject !== null) lists[highestObject.getName()].push(highestObject);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the instance out of a list of objects that has the highest zOrder.",
+      "fullName": "Pick the object with highest zOrder",
+      "functionType": "Condition",
+      "group": "",
+      "name": "PickHighestZCondition",
+      "private": false,
+      "sentence": "Pick the _PARAM1_ with the highest zOrder",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nlet highestObject = null;\r\nlet highestZOrder = -Infinity;\r\n\r\nfor (const listName in lists) {\r\n    for (const object of lists[listName]) {\r\n        const zOrder = object.getZOrder();\r\n        if (zOrder > highestZOrder) {\r\n            highestObject = object;\r\n            highestZOrder = zOrder;\r\n        };\r\n    }\r\n    lists[listName].length = 0;\r\n}\r\n\r\nif (highestObject !== null) lists[highestObject.getName()].push(highestObject);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the instance out of a list of objects that has the lowest zOrder.",
+      "fullName": "Pick the object with lowest zOrder",
+      "functionType": "Action",
+      "group": "",
+      "name": "PickLowestZAction",
+      "private": false,
+      "sentence": "Pick the _PARAM1_ with the lowest zOrder",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nlet lowestObject = null;\r\nlet lowestZOrder = Infinity;\r\n\r\nfor (const listName in lists) {\r\n    for (const object of lists[listName]) {\r\n        const zOrder = object.getZOrder();\r\n        if (zOrder < lowestZOrder) {\r\n            lowestObject = object;\r\n            lowestZOrder = zOrder;\r\n        };\r\n    }\r\n    lists[listName].length = 0;\r\n}\r\n\r\nif (lowestObject !== null) lists[lowestObject.getName()].push(lowestObject);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the instance out of a list of objects that has the lowest zOrder.",
+      "fullName": "Pick the object with lowest zOrder",
+      "functionType": "Condition",
+      "group": "",
+      "name": "PickLowestZCondition",
+      "private": false,
+      "sentence": "Pick the _PARAM1_ with the lowest zOrder",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nlet lowestObject = null;\r\nlet lowestZOrder = Infinity;\r\n\r\nfor (const listName in lists) {\r\n    for (const object of lists[listName]) {\r\n        const zOrder = object.getZOrder();\r\n        if (zOrder < lowestZOrder) {\r\n            lowestObject = object;\r\n            lowestZOrder = zOrder;\r\n        };\r\n    }\r\n    lists[listName].length = 0;\r\n}\r\n\r\nif (lowestObject !== null) lists[lowestObject.getName()].push(lowestObject);\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the first instance out of a list of objects.",
+      "fullName": "Pick the first object",
+      "functionType": "Action",
+      "group": "",
+      "name": "PickFirstAction",
+      "private": false,
+      "sentence": "Pick the first _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the first instance out of a list of objects.",
+      "fullName": "Pick the first object",
+      "functionType": "Condition",
+      "group": "",
+      "name": "PickFirstCondition",
+      "private": false,
+      "sentence": "Pick the first _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the last instance out of a list of objects.",
+      "fullName": "Pick the last object",
+      "functionType": "Action",
+      "group": "",
+      "name": "PickLastAction",
+      "private": false,
+      "sentence": "Pick the last _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    list[0] = list[list.length - 1];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the last instance out of a list of objects.",
+      "fullName": "Pick the last object",
+      "functionType": "Condition",
+      "group": "",
+      "name": "PickLastCondition",
+      "private": false,
+      "sentence": "Pick the last _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    list[0] = list[list.length - 1];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the Nth instance out of a list of objects.",
+      "fullName": "Pick the Nth object",
+      "functionType": "Action",
+      "group": "",
+      "name": "PickNthAction",
+      "private": false,
+      "sentence": "Pick the _PARAM2_th _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\nconst n = eventsFunctionContext.getObjectsLists(\"n\");\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    if (n >= list.length) continue;\r\n    list[0] = list[n];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The place in the objects lists an instance has to have to be picked",
+          "longDescription": "",
+          "name": "n",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Picks the Nth instance out of a list of objects.",
+      "fullName": "Pick the Nth object",
+      "functionType": "Condition",
+      "group": "",
+      "name": "PickNthCondition",
+      "private": false,
+      "sentence": "Pick the _PARAM2_th _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const lists = eventsFunctionContext.getObjectsLists(\"object\").items;\r\nconst n = eventsFunctionContext.getObjectsLists(\"n\");\r\n\r\nfor (const listName in lists) {\r\n    const list = lists[listName];\r\n    if (n >= list.length) continue;\r\n    list[0] = list[n];\r\n    list.length = 1;\r\n}\r\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object to select an instances from",
+          "longDescription": "",
+          "name": "object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The place in the objects lists an instance has to have to be picked",
+          "longDescription": "",
+          "name": "n",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/extensions/community/References.json
+++ b/extensions/community/References.json
@@ -1,0 +1,162 @@
+{
+  "author": "Arthur Pacaud (arthuro555)",
+  "category": "",
+  "description": "Adds actions to use references (variable that redirect any read/write to another variable) and pointers (unique numbers identifying a variable that can be resolved to a reference). Some usages are for callback variables in events based functions (getting a variable with a fixed name referring to a variable with a name passed as parameter), pointers to make advanced data structures like linked lists, and getting a top level variable dynamically.",
+  "extensionNamespace": "",
+  "fullName": "Variables/References",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXZhcmlhYmxlLWJveCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xOSAzSDVDMy45IDMgMyAzLjkgMyA1VjE5QzMgMjAuMSAzLjkgMjEgNSAyMUgxOUMyMC4xIDIxIDIxIDIwLjEgMjEgMTlWNUMyMSAzLjkgMjAuMSAzIDE5IDNNNy40IDE4QzUuOSAxNi41IDUgMTQuMyA1IDEyUzUuOSA3LjUgNy40IDZMOSA2LjdDNy43IDcuOSA3IDkuOSA3IDEyUzcuNyAxNi4xIDkgMTcuM0w3LjQgMThNMTIuNyAxNUwxMS45IDEzTDEwLjUgMTVIOUwxMS4zIDExLjlMMTAgOUgxMS4zTDEyLjEgMTFMMTMuNSA5SDE1TDEyLjggMTJMMTQuMSAxNUgxMi43TTE2LjYgMThMMTUgMTcuM0MxNi4zIDE2IDE3IDE0LjEgMTcgMTJTMTYuMyA3LjkgMTUgNi43TDE2LjYgNkMxOC4xIDcuNSAxOSA5LjcgMTkgMTJTMTguMSAxNi41IDE2LjYgMThaIiAvPjwvc3ZnPg==",
+  "name": "References",
+  "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/variable-box.svg",
+  "shortDescription": "Adds references and pointers for variables.",
+  "version": "1.0.0",
+  "tags": [
+    "advanced",
+    "variables",
+    "reference",
+    "pointer",
+    "ref",
+    "memory",
+    "callback"
+  ],
+  "authorIds": [
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Transforms a scene variable into a reference to another scene variable.",
+      "fullName": "Create reference to scene variable",
+      "functionType": "Action",
+      "group": "",
+      "name": "CreateReference",
+      "private": false,
+      "sentence": "Make variable _PARAM1_ a reference to _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const reference = eventsFunctionContext.getArgument(\"reference\");\nconst source = eventsFunctionContext.getArgument(\"source\");\n\n// Override each method \nfor (let func of Object.getOwnPropertyNames(gdjs.Variable.prototype))\n    reference[func] = gdjs.Variable.prototype[func].bind(source);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The scene variable to turn into a reference",
+          "longDescription": "",
+          "name": "reference",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The scene variable the reference will refer to",
+          "longDescription": "",
+          "name": "source",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Transforms a scene variable into a reference to a global variable.",
+      "fullName": "Create reference to global variable",
+      "functionType": "Action",
+      "group": "",
+      "name": "CreateGlobalReference",
+      "private": false,
+      "sentence": "Make variable _PARAM1_ a reference to _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const reference = eventsFunctionContext.getArgument(\"reference\");\nconst source = eventsFunctionContext.getArgument(\"source\");\n\n// Override each method \nfor (let func of Object.getOwnPropertyNames(gdjs.Variable.prototype))\n    reference[func] = gdjs.Variable.prototype[func].bind(source);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The scene variable to turn into a reference",
+          "longDescription": "",
+          "name": "reference",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The global variable the reference will refer to",
+          "longDescription": "",
+          "name": "source",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "globalvar"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Transforms a scene variable into a reference to an object's variable.",
+      "fullName": "Create reference to object variable",
+      "functionType": "Action",
+      "group": "",
+      "name": "CreateObjectReference",
+      "private": false,
+      "sentence": "Make variable _PARAM2_ a reference to variable _PARAM3_ of _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const reference = eventsFunctionContext.getArgument(\"reference\");\nconst source = eventsFunctionContext.getArgument(\"source\");\n\nconsole.log(reference, source)\n\n// Override each method \nfor (let func of Object.getOwnPropertyNames(gdjs.Variable.prototype))\n    reference[func] = gdjs.Variable.prototype[func].bind(source);\n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object that possesses the variable to refer to",
+          "longDescription": "",
+          "name": "Object",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The scene variable to turn into a reference",
+          "longDescription": "",
+          "name": "reference",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "scenevar"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "The object variable the reference will refer to",
+          "longDescription": "",
+          "name": "source",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectvar"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": []
+}

--- a/scripts/generate-extensions-registry.js
+++ b/scripts/generate-extensions-registry.js
@@ -143,7 +143,7 @@ const readExtensionsFromFolder = async (folderPath, tier) => {
         // Override the base extensions when fixing
         if (args['fix'])
           await writeJSONFile(
-            path.join(extensionsBasePath, `${name}.json`),
+            path.join(extensionsBasePath, tier, `${name}.json`),
             extension
           );
 

--- a/scripts/lib/ExtensionsValidatorExceptions.js
+++ b/scripts/lib/ExtensionsValidatorExceptions.js
@@ -160,6 +160,12 @@ const extensionsAllowedProperties = {
       runtimeSceneAllowedProperties: [],
       javaScriptObjectAllowedProperties: [],
     },
+    Geolocation: {
+      gdjsAllowedProperties: [],
+      gdjsEvtToolsAllowedProperties: ['geolocation'],
+      runtimeSceneAllowedProperties: [],
+      javaScriptObjectAllowedProperties: [],
+    },
     MQTT: {
       gdjsAllowedProperties: [],
       gdjsEvtToolsAllowedProperties: ['mqtt'],


### PR DESCRIPTION
Adds a few community extension I made some time ago and forgot to submit.

Geolocation - Allows to locate a player using the Web Geolocation API
References - Allows to make a scene variable a reference to some other variable (necessary for some algorithms and data structures, albeit rather advanced hence why it is an extension rather than a core feature)
ObjectPickingTools - An extension requested by Silver-Streak sometime ago to help with object picking by allowing to pick objects of an object list one-by-one, unpick them, pick the one with highest/lowest z-Order...

Also adds a small fix to the build code for the auto-fixing feature.