### PR TITLE
[ToogleSwitch] Remove useless "Change" prefix in actions full name.

### DIFF
--- a/extensions/reviewed/ToggleSwitch.json
+++ b/extensions/reviewed/ToggleSwitch.json
@@ -9,7 +9,7 @@
   "name": "ToggleSwitch",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Interface Elements/Interface Elements_interface_ui_toggle_switch.svg",
   "shortDescription": "Toggle switch that users can click or touch.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "origin": {
     "identifier": "ToggleSwitch",
     "name": "gdevelop-extension-store"

--- a/extensions/reviewed/ToggleSwitch.json
+++ b/extensions/reviewed/ToggleSwitch.json
@@ -1801,13 +1801,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change width of track.",
-          "fullName": "Change width of track",
+          "description": "Change the track width.",
+          "fullName": "Track width",
           "functionType": "Action",
           "group": "",
           "name": "SetTrackWidth",
           "private": false,
-          "sentence": "Set track width of _PARAM0_ to _PARAM2_ pixels",
+          "sentence": "Change the track width of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1877,13 +1877,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change height of track.",
-          "fullName": "Change height of track",
+          "description": "Change the track height.",
+          "fullName": "Track height",
           "functionType": "Action",
           "group": "",
           "name": "SetTrackHeight",
           "private": false,
-          "sentence": "Set track height of _PARAM0_ to _PARAM2_ pixels",
+          "sentence": "Change the track height of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1953,13 +1953,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of thumb.",
-          "fullName": "Change opacity of thumb",
+          "description": "Change the thumb opacity.",
+          "fullName": "Thumb opacity",
           "functionType": "Action",
           "group": "",
           "name": "SetThumbOpacity",
           "private": false,
-          "sentence": "Set thumb opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the thumb opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2029,13 +2029,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of inactive track.",
-          "fullName": "Change opacity of inactive track",
+          "description": "Change the inactive track opacity.",
+          "fullName": "Inactive track opacity",
           "functionType": "Action",
           "group": "",
           "name": "SetInactiveTrackOpacity",
           "private": false,
-          "sentence": "Set inactive track opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the inactive track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2105,13 +2105,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of active track.",
-          "fullName": "Change opacity of active track",
+          "description": "Change the active track opacity.",
+          "fullName": "Active track opacity",
           "functionType": "Action",
           "group": "",
           "name": "SetActiveTrackOpacity",
           "private": false,
-          "sentence": "Set active track opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the active track opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2181,13 +2181,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of the halo (pressed).",
-          "fullName": "Change opacity of halo (pressed)",
+          "description": "Change the halo opacity when the thumb is pressed.",
+          "fullName": "Halo opacity (pressed)",
           "functionType": "Action",
           "group": "",
           "name": "SetHaloOpacityPressed",
           "private": false,
-          "sentence": "Set halo opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the halo opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2257,13 +2257,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of the halo (hover).",
-          "fullName": "Change opacity of halo (hover)",
+          "description": "Change opacity of the halo when the thumb is hovered.",
+          "fullName": "Halo opacity (hover)",
           "functionType": "Action",
           "group": "",
           "name": "SetHaloOpacityHover",
           "private": false,
-          "sentence": "Set halo opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the halo opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2333,13 +2333,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change offset (Y) of shadow on thumb.",
-          "fullName": "Change offset (Y) of shadow on thumb",
+          "description": "Change the offset on Y axis of the thumb shadow.",
+          "fullName": "Thumb shadow offset on Y axis",
           "functionType": "Action",
           "group": "",
           "name": "SetThumbShadowOffsetY",
           "private": false,
-          "sentence": "Set offset (Y) of shadow on thumb of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the offset on Y axis of the thumb shadow of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2409,13 +2409,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change offset (X) of shadow on thumb.",
-          "fullName": "Change offset (X) of shadow on thumb",
+          "description": "Change the offset on X axis of the thumb shadow.",
+          "fullName": "Thumb shadow offset on X axis",
           "functionType": "Action",
           "group": "",
           "name": "SetThumbShadowOffsetX",
           "private": false,
-          "sentence": "Set offset (X) of shadow on thumb of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the offset on X axis of the thumb shadow of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2485,13 +2485,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change opacity of shadow on thumb.",
-          "fullName": "Change opacity of shadow on thumb",
+          "description": "Change the thumb shadow opacity.",
+          "fullName": "Thumb shadow opacity",
           "functionType": "Action",
           "group": "",
           "name": "SetThumbShadowOpacity",
           "private": false,
-          "sentence": "Set thumb shadow opacity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the thumb shadow opacity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2561,13 +2561,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change radius of thumb.",
-          "fullName": "Change radius of thumb",
+          "description": "Change the thumb radius.",
+          "fullName": "Thumb radius",
           "functionType": "Action",
           "group": "",
           "name": "SetThumbRadius",
           "private": false,
-          "sentence": "Set thumb radius of _PARAM0_ to _PARAM2_ pixels",
+          "sentence": "Change the thumb radius of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2637,13 +2637,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change the radius of halo.",
-          "fullName": "Change radius of halo",
+          "description": "Change the halo radius.",
+          "fullName": "Halo radius",
           "functionType": "Action",
           "group": "",
           "name": "SetHaloRadius",
           "private": false,
-          "sentence": "Set halo radius of _PARAM0_ to _PARAM2_ pixels",
+          "sentence": "Change the halo radius of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2713,13 +2713,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change the color of the track that is LEFT of the thumb.",
-          "fullName": "Change color of active track",
+          "description": "Change the active track color (the part on the thumb left).",
+          "fullName": "Active track color",
           "functionType": "Action",
           "group": "",
           "name": "SetActiveTrackColor",
           "private": false,
-          "sentence": "Set active track color of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the active track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2789,13 +2789,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change the color of the track that is RIGHT of the thumb.",
-          "fullName": "Change color of inactive track",
+          "description": "Change the inactive track color (the part on the thumb right).",
+          "fullName": "Inactive track color",
           "functionType": "Action",
           "group": "",
           "name": "SetInactiveTrackColor",
           "private": false,
-          "sentence": "Set inactive track color of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the inactive track color of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2865,13 +2865,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change color of thumb (when unchecked).",
-          "fullName": "Change color of thumb (when unchecked)",
+          "description": "Change the thumb color (when unchecked).",
+          "fullName": "Thumb color (when unchecked)",
           "functionType": "Action",
           "group": "",
           "name": "SetInactiveThumbColor",
           "private": false,
-          "sentence": "Set thumb color of _PARAM0_  (when unchecked) to _PARAM2_",
+          "sentence": "Change the thumb color of _PARAM0_ (when unchecked) to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2941,13 +2941,13 @@
           "objectGroups": []
         },
         {
-          "description": "Change color of thumb (when checked).",
-          "fullName": "Change color of thumb (when checked)",
+          "description": "Change the thumb color (when checked).",
+          "fullName": "Thumb color (when checked)",
           "functionType": "Action",
           "group": "",
           "name": "SetActiveThumbColor",
           "private": false,
-          "sentence": "Set thumb color of _PARAM0_  (when checked) to _PARAM2_",
+          "sentence": "Change the thumb color of _PARAM0_ (when checked) to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -3017,8 +3017,8 @@
           "objectGroups": []
         },
         {
-          "description": "If checked, change to unchecked.  If unchecked, change to checked.",
-          "fullName": "Change toggle switch to opposite state",
+          "description": "If checked, change to unchecked. If unchecked, change to checked.",
+          "fullName": "Toggle the switch",
           "functionType": "Action",
           "group": "",
           "name": "ToggleChecked",


### PR DESCRIPTION
It can be reviewed directly with the diff.