### PR TITLE
[AutoTyping, CursorType, ObjectSpaner] Remove useless "Change" prefix in actions full name

### DIFF
--- a/extensions/reviewed/AutoTyping.json
+++ b/extensions/reviewed/AutoTyping.json
@@ -8,7 +8,7 @@
   "name": "AutoTyping",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/typewriter.svg",
   "shortDescription": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "tags": [
     "text",
     "bbtext",
@@ -555,11 +555,11 @@
         },
         {
           "description": "Change the time between characters being typed. ",
-          "fullName": "Change the interval time",
+          "fullName": "Time between characters",
           "functionType": "Action",
           "name": "ChangeInterval",
           "private": false,
-          "sentence": "Set the interval between characters of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the interval between characters of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -1172,7 +1172,7 @@
         },
         {
           "description": "Change the time between characters being typed. ",
-          "fullName": "Change the interval time",
+          "fullName": "Time between characters",
           "functionType": "Action",
           "name": "ChangeInterval",
           "private": false,
@@ -1789,7 +1789,7 @@
         },
         {
           "description": "Change the time between characters being typed. ",
-          "fullName": "Change the interval time",
+          "fullName": "Time between characters",
           "functionType": "Action",
           "name": "ChangeInterval",
           "private": false,

--- a/extensions/reviewed/CursorType.json
+++ b/extensions/reviewed/CursorType.json
@@ -9,7 +9,7 @@
   "name": "CursorType",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/cursor-default-outline.svg",
   "shortDescription": "Provides an action to change the type of the cursor, and a behavior to change the cursor when an object is hovered.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "origin": {
     "identifier": "CursorType",
     "name": "gdevelop-extension-store"
@@ -27,12 +27,12 @@
   "eventsFunctions": [
     {
       "description": "Change the type of the cursor.",
-      "fullName": "Change the type of the cursor",
+      "fullName": "Cursor type",
       "functionType": "Action",
       "group": "",
       "name": "ChangeCursorType",
       "private": false,
-      "sentence": "Set cursor to _PARAM1_",
+      "sentence": "Change the cursor to _PARAM1_",
       "events": [
         {
           "disabled": false,

--- a/extensions/reviewed/ObjectSpawner.json
+++ b/extensions/reviewed/ObjectSpawner.json
@@ -9,7 +9,7 @@
   "name": "ObjectSpawner",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/plus-one.svg",
   "shortDescription": "Spawn (create) objects periodically.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "tags": [
     "spawn",
     "spawner",
@@ -499,7 +499,7 @@
         },
         {
           "description": "Change the offset X relative to origin of spawner (in pixels).",
-          "fullName": "Change the offset X",
+          "fullName": "Offset on X axis",
           "functionType": "Action",
           "group": "",
           "name": "SetOffsetX",
@@ -565,7 +565,7 @@
         },
         {
           "description": "Change the offset Y relative to origin of spawner (in pixels).",
-          "fullName": "Change the offset Y",
+          "fullName": "Offset on Y axis",
           "functionType": "Action",
           "group": "",
           "name": "SetOffsetY",
@@ -631,12 +631,12 @@
         },
         {
           "description": "Change the maximum number of living objects a spawner can create.",
-          "fullName": "Change the max quantity",
+          "fullName": "Maximum quantity",
           "functionType": "Action",
           "group": "",
           "name": "SetMaxQuantity",
           "private": false,
-          "sentence": "Change the max quantity of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the maximum quantity of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "disabled": false,
@@ -697,7 +697,7 @@
         },
         {
           "description": "Change the spawn period (in seconds).",
-          "fullName": "Change the spawn period",
+          "fullName": "Spawn period",
           "functionType": "Action",
           "group": "",
           "name": "SetSpawnPeriod",


### PR DESCRIPTION
It can be reviewed directly with the diff.