### PR TITLE
Sine movement; Added actions to set the horizontal and vertical progress

### DIFF
--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -970,7 +970,7 @@
           "objectGroups": []
         },
         {
-          "description": "Set vertical distance.",
+          "description": "Change vertical amplitude.",
           "fullName": "Vertical distance",
           "functionType": "Action",
           "group": "Sine movement configuration",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -1239,7 +1239,7 @@
         {
           "value": "100",
           "type": "Number",
-          "label": "Horizontal distance: amplitude of the movement on X axis (0 to deactivate)",
+          "label": "Horizontal amplitude",
           "description": "",
           "group": "Sine movement",
           "extraInformation": [],

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -474,7 +474,7 @@
         },
         {
           "description": "Horizontal distance.",
-          "fullName": "Horizontal distance",
+          "fullName": "Horizontal amplitude",
           "functionType": "Expression",
           "group": "Sine movement configuration",
           "name": "HorizontalDistance",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -976,7 +976,7 @@
           "group": "Sine movement configuration",
           "name": "SetVerticalDistance",
           "private": false,
-          "sentence": "Set vertical distance of _PARAM0_ to _PARAM2_",
+          "sentence": "Change the vertical amplitude of _PARAM0_ to _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -473,7 +473,7 @@
           "objectGroups": []
         },
         {
-          "description": "Horizontal distance.",
+          "description": "Return the horizontal amplitude.",
           "fullName": "Horizontal amplitude",
           "functionType": "Expression",
           "group": "Sine movement configuration",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -909,7 +909,7 @@
           "objectGroups": []
         },
         {
-          "description": "Set horizontal distance.",
+          "description": "Change the horizontal amplitude.",
           "fullName": "Horizontal distance",
           "functionType": "Action",
           "group": "Sine movement configuration",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -521,7 +521,7 @@
           "objectGroups": []
         },
         {
-          "description": "Vertical distance.",
+          "description": "Return the vertical amplitude.",
           "fullName": "Vertical amplitude",
           "functionType": "Expression",
           "group": "Sine movement configuration",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -1,7 +1,7 @@
 {
   "author": "@4ian, Tristan Rhodes (https://victrisgames.itch.io/)",
   "category": "",
-  "description": "Allow an object to move smoothly on the X and/or Y axis following a sine wave, or an ellipsis.\n\n\nExample uses:\n- Floating objects, such as powerups or coins\n- Moveable platforms\n- Enemy movement patterns\n\nProperties:\n- Horizontal distance\n- Vertical distance\n- Horizontal speed\n- Vertical speed\n- Center of movement, X position\n- Center of movement, Y position\n\nTips:\n- For circular or elliptical movement, the horizontal and vertical speed need to be the same\n- For horizontal movement only, set vertical distance to 0\n- For vertical movement only, set horizontal distance to 0\n- For figure-8 movement, set horizontal speed to 1/2 of the vertical speed",
+  "description": "Allow an object to move smoothly on the X and/or Y axis following a sine wave, or an ellipsis.\n\nExample uses:\n- Floating objects, such as powerups or coins\n- Moveable platforms\n- Enemy movement patterns\n\nProperties:\n- Horizontal distance\n- Vertical distance\n- Horizontal speed\n- Vertical speed\n- Center of movement, X position\n- Center of movement, Y position\n\nTips:\n- For circular or elliptical movement, the horizontal and vertical speed need to be the same\n- For horizontal movement only, set vertical distance to 0\n- For vertical movement only, set horizontal distance to 0\n- For figure-8 movement, set horizontal speed to 1/2 of the vertical speed",
   "extensionNamespace": "",
   "fullName": "Sine (or ellipsis) Movement",
   "helpPath": "https://victrisgames.itch.io/extension-sinemovement-and-deptheffect",
@@ -32,7 +32,7 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Allow an object to move smoothly on the X and/or Y axis following a sine wave.\n\nExample uses:\n- Floating pickups\n- Moveable platforms\n- Enemy movement\n\nProperties:\n- Center of movement, X position\n- Center of movement, Y position\n- Horizontal distance\n- Vertical distance\n- Horizontal speed\n- Horizontal distance\n\nTips:\n- For circular or elliptical movement, the horizontal and vertical speed need to be the same\n- For horizontal movement, set vertical distance to 0\n- For vertical movement, set horizontal distance to 0\n- For figure-8 movement, set horizontal speed to 1/2 of the vertical speed.",
+      "description": "Allow an object to move smoothly on the X and/or Y axis following a sine wave.",
       "fullName": "Sine Movement",
       "name": "SineMovement",
       "objectType": "",
@@ -47,68 +47,73 @@
           "sentence": "",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Set the center of movement to the initial location of the object",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Save starting position if it was not set manually",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
                 {
-                  "type": {
-                    "value": "SineMovement::SineMovement::PropertyCenterPointX"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "SineMovement::SineMovement::PropertyCenterPointY"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "0"
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SineMovement::SineMovement::PropertyCenterPointX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SineMovement::SineMovement::PropertyCenterPointY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SineMovement::SineMovement::SetPropertyCenterPointX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.X()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SineMovement::SineMovement::SetPropertyCenterPointY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Y()"
+                      ]
+                    }
                   ]
                 }
               ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "SineMovement::SineMovement::SetPropertyCenterPointX"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.X()"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "SineMovement::SineMovement::SetPropertyCenterPointY"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Object.Y()"
-                  ]
-                }
-              ]
+              "parameters": []
             },
             {
               "type": "BuiltinCommonInstructions::Comment",
@@ -279,7 +284,7 @@
           "description": "Counter used to change the Y position of the object.",
           "fullName": "Sine progress Y",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement",
           "name": "SineProgressY",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -327,7 +332,7 @@
           "description": "Counter used to change the X position of the object.",
           "fullName": "Sine progress X",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement",
           "name": "SineProgressX",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -375,7 +380,7 @@
           "description": "Horizontal speed.",
           "fullName": "Horizontal speed ",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "HorizontalSpeed",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -423,7 +428,7 @@
           "description": "Vertical speed.",
           "fullName": "Vertical speed",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "VerticalSpeed",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -471,7 +476,7 @@
           "description": "Horizontal distance.",
           "fullName": "Horizontal distance",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "HorizontalDistance",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -519,7 +524,7 @@
           "description": "Vertical distance.",
           "fullName": "Vertical distance",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "VerticalDistance",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -567,7 +572,7 @@
           "description": "Center of movement, X position.",
           "fullName": "Center of movement, X position",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "CenterX",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -615,7 +620,7 @@
           "description": "Center of movement, Y position.",
           "fullName": "Center of movement, Y position",
           "functionType": "Expression",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "CenterY",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
@@ -661,9 +666,9 @@
         },
         {
           "description": "Set center Y position.",
-          "fullName": "Set center Y position",
+          "fullName": "Center Y position",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetCenterY",
           "private": false,
           "sentence": "Set center Y position of _PARAM0_ to _PARAM2_",
@@ -724,7 +729,7 @@
           "description": "Set the value used to calculate horizontal position. Consider using values between 0 to 360.",
           "fullName": "Horizontal progress",
           "functionType": "Action",
-          "group": "Advanced",
+          "group": "Sine movement configuration",
           "name": "SetSineProgressX",
           "private": false,
           "sentence": "Set horizontal progress of _PARAM0_ to _PARAM2_",
@@ -785,7 +790,7 @@
           "description": "Set the value used to calculate vertical position. Consider using values between 0 to 360.",
           "fullName": "Vertical progress",
           "functionType": "Action",
-          "group": "Advanced",
+          "group": "Sine movement configuration",
           "name": "SetSineProgressY",
           "private": false,
           "sentence": "Set vertical progress of _PARAM0_ to _PARAM2_",
@@ -844,9 +849,9 @@
         },
         {
           "description": "Set center X position.",
-          "fullName": "Set center X position",
+          "fullName": "Center X position",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetCenterX",
           "private": false,
           "sentence": "Set center X position of _PARAM0_ to _PARAM2_",
@@ -905,9 +910,9 @@
         },
         {
           "description": "Set horizontal distance.",
-          "fullName": "Set horizontal distance",
+          "fullName": "Horizontal distance",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetHorizontalDistance",
           "private": false,
           "sentence": "Set horizontal distance of _PARAM0_ to _PARAM2_",
@@ -966,9 +971,9 @@
         },
         {
           "description": "Set vertical distance.",
-          "fullName": "Set vertical distance",
+          "fullName": "Vertical distance",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetVerticalDistance",
           "private": false,
           "sentence": "Set vertical distance of _PARAM0_ to _PARAM2_",
@@ -1027,9 +1032,9 @@
         },
         {
           "description": "Set horizontal speed.",
-          "fullName": "Set horizontal speed",
+          "fullName": "Horizontal speed",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetHorizontalSpeed",
           "private": false,
           "sentence": "Set horizontal speed of _PARAM0_ to _PARAM2_",
@@ -1088,9 +1093,9 @@
         },
         {
           "description": "Set vertical speed.",
-          "fullName": "Set vertical speed",
+          "fullName": "Vertical speed",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement configuration",
           "name": "SetVerticalSpeed",
           "private": false,
           "sentence": "Set vertical speed of _PARAM0_ to _PARAM2_",
@@ -1148,13 +1153,13 @@
           "objectGroups": []
         },
         {
-          "description": "Reset sine progress counters. The object will return to the initial state.",
-          "fullName": "Reset sine progress counters",
+          "description": "Reset progress counters to make the object return to it's initial position.",
+          "fullName": "Reset to starting position",
           "functionType": "Action",
-          "group": "",
+          "group": "Sine movement",
           "name": "ResetSineCounters",
           "private": false,
-          "sentence": "Reset sine progress counters on _PARAM0_",
+          "sentence": "Reset _PARAM0_ to starting position",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1216,7 +1221,7 @@
           "type": "Number",
           "label": "Horizontal speed, in degrees per second",
           "description": "",
-          "group": "",
+          "group": "Sine movement",
           "extraInformation": [],
           "hidden": false,
           "name": "HorizontalSpeed"
@@ -1226,7 +1231,7 @@
           "type": "Number",
           "label": "Vertical speed, in degrees per second",
           "description": "",
-          "group": "",
+          "group": "Sine movement",
           "extraInformation": [],
           "hidden": false,
           "name": "VerticalSpeed"
@@ -1236,7 +1241,7 @@
           "type": "Number",
           "label": "Horizontal distance: amplitude of the movement on X axis (0 to deactivate)",
           "description": "",
-          "group": "",
+          "group": "Sine movement",
           "extraInformation": [],
           "hidden": false,
           "name": "HorizontalDistance"
@@ -1246,7 +1251,7 @@
           "type": "Number",
           "label": "Vertical distance: amplitude of the movement on Y axis (0 to deactivate)",
           "description": "",
-          "group": "",
+          "group": "Sine movement",
           "extraInformation": [],
           "hidden": false,
           "name": "VerticalDistance"
@@ -1256,7 +1261,7 @@
           "type": "Number",
           "label": "Center of movement, X position",
           "description": "",
-          "group": "",
+          "group": "Center position",
           "extraInformation": [],
           "hidden": false,
           "name": "CenterPointX"
@@ -1266,7 +1271,7 @@
           "type": "Number",
           "label": "Center of movement, Y position",
           "description": "",
-          "group": "",
+          "group": "Center position",
           "extraInformation": [],
           "hidden": false,
           "name": "CenterPointY"

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -1249,7 +1249,7 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Vertical distance: amplitude of the movement on Y axis (0 to deactivate)",
+          "label": "Vertical amplitude",
           "description": "",
           "group": "Sine movement",
           "extraInformation": [],

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -1,5 +1,6 @@
 {
   "author": "@4ian, Tristan Rhodes (https://victrisgames.itch.io/)",
+  "category": "",
   "description": "Allow an object to move smoothly on the X and/or Y axis following a sine wave, or an ellipsis.\n\n\nExample uses:\n- Floating objects, such as powerups or coins\n- Moveable platforms\n- Enemy movement patterns\n\nProperties:\n- Horizontal distance\n- Vertical distance\n- Horizontal speed\n- Vertical speed\n- Center of movement, X position\n- Center of movement, Y position\n\nTips:\n- For circular or elliptical movement, the horizontal and vertical speed need to be the same\n- For horizontal movement only, set vertical distance to 0\n- For vertical movement only, set horizontal distance to 0\n- For figure-8 movement, set horizontal speed to 1/2 of the vertical speed",
   "extensionNamespace": "",
   "fullName": "Sine (or ellipsis) Movement",
@@ -8,7 +9,11 @@
   "name": "SineMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/sine-wave.svg",
   "shortDescription": "Allow an object to move smoothly on the X and/or Y axis following a sine wave, or an ellipsis.",
-  "version": "0.0.5",
+  "version": "0.0.6",
+  "origin": {
+    "identifier": "SineMovement",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "sine",
     "ellipsis",
@@ -36,13 +41,12 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPreEvents",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -56,13 +60,10 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::PropertyCenterPointX"
                   },
                   "parameters": [
@@ -70,12 +71,10 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::PropertyCenterPointY"
                   },
                   "parameters": [
@@ -83,14 +82,12 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyCenterPointX"
                   },
                   "parameters": [
@@ -98,12 +95,10 @@
                     "Behavior",
                     "=",
                     "Object.X()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyCenterPointY"
                   },
                   "parameters": [
@@ -111,15 +106,11 @@
                     "Behavior",
                     "=",
                     "Object.Y()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -133,13 +124,10 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::PropertyHorizontalDistance"
                   },
                   "parameters": [
@@ -147,34 +135,27 @@
                     "Behavior",
                     "!=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MettreX"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "Object.Behavior::PropertyCenterPointX() + cos(ToRad(Object.Behavior::PropertySineProgressX())) * Object.Behavior::PropertyHorizontalDistance()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::PropertyVerticalDistance"
                   },
                   "parameters": [
@@ -182,29 +163,23 @@
                     "Behavior",
                     "!=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MettreY"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "Object.Behavior::PropertyCenterPointY() + sin(ToRad(Object.Behavior::PropertySineProgressY())) * Object.Behavior::PropertyVerticalDistance()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -218,14 +193,23 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SineMovement::SineMovement::PropertyHorizontalSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "!=",
+                    "0"
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertySineProgressX"
                   },
                   "parameters": [
@@ -233,21 +217,28 @@
                     "Behavior",
                     "+",
                     "Object.Behavior::PropertyHorizontalSpeed() * TimeDelta()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SineMovement::SineMovement::PropertyVerticalSpeed"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "!=",
+                    "0"
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertySineProgressY"
                   },
                   "parameters": [
@@ -255,11 +246,9 @@
                     "Behavior",
                     "+",
                     "Object.Behavior::PropertyVerticalSpeed() * TimeDelta()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -290,28 +279,24 @@
           "description": "Counter used to change the Y position of the object.",
           "fullName": "Sine progress Y",
           "functionType": "Expression",
+          "group": "",
           "name": "SineProgressY",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertySineProgressY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -342,28 +327,24 @@
           "description": "Counter used to change the X position of the object.",
           "fullName": "Sine progress X",
           "functionType": "Expression",
+          "group": "",
           "name": "SineProgressX",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertySineProgressX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -394,28 +375,24 @@
           "description": "Horizontal speed.",
           "fullName": "Horizontal speed ",
           "functionType": "Expression",
+          "group": "",
           "name": "HorizontalSpeed",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyHorizontalSpeed()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -446,28 +423,24 @@
           "description": "Vertical speed.",
           "fullName": "Vertical speed",
           "functionType": "Expression",
+          "group": "",
           "name": "VerticalSpeed",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyVerticalSpeed()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -498,28 +471,24 @@
           "description": "Horizontal distance.",
           "fullName": "Horizontal distance",
           "functionType": "Expression",
+          "group": "",
           "name": "HorizontalDistance",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyHorizontalDistance()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -550,28 +519,24 @@
           "description": "Vertical distance.",
           "fullName": "Vertical distance",
           "functionType": "Expression",
+          "group": "",
           "name": "VerticalDistance",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyVerticalDistance()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -602,28 +567,24 @@
           "description": "Center of movement, X position.",
           "fullName": "Center of movement, X position",
           "functionType": "Expression",
+          "group": "",
           "name": "CenterX",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyCenterPointX()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -654,28 +615,24 @@
           "description": "Center of movement, Y position.",
           "fullName": "Center of movement, Y position",
           "functionType": "Expression",
+          "group": "",
           "name": "CenterY",
           "private": false,
           "sentence": "Set initial Y of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
                     "Object.Behavior::PropertyCenterPointY()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -706,19 +663,17 @@
           "description": "Set center Y position.",
           "fullName": "Set center Y position",
           "functionType": "Action",
+          "group": "",
           "name": "SetCenterY",
           "private": false,
           "sentence": "Set center Y position of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyCenterPointY"
                   },
                   "parameters": [
@@ -726,11 +681,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -768,22 +721,142 @@
           "objectGroups": []
         },
         {
-          "description": "Set center X position.",
-          "fullName": "Set center X position",
+          "description": "Set the value used to calculate horizontal position. Consider using values between 0 to 360.",
+          "fullName": "Horizontal progress",
           "functionType": "Action",
-          "name": "SetCenterX",
+          "group": "Advanced",
+          "name": "SetSineProgressX",
           "private": false,
-          "sentence": "Set center X position of _PARAM0_ to _PARAM2_",
+          "sentence": "Set horizontal progress of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
+                    "value": "SineMovement::SineMovement::SetPropertySineProgressX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SineMovement::SineMovement",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Horizontal progress",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Set the value used to calculate vertical position. Consider using values between 0 to 360.",
+          "fullName": "Vertical progress",
+          "functionType": "Action",
+          "group": "Advanced",
+          "name": "SetSineProgressY",
+          "private": false,
+          "sentence": "Set vertical progress of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SineMovement::SineMovement::SetPropertySineProgressY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "SineMovement::SineMovement",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Vertical progress",
+              "longDescription": "",
+              "name": "Value",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Set center X position.",
+          "fullName": "Set center X position",
+          "functionType": "Action",
+          "group": "",
+          "name": "SetCenterX",
+          "private": false,
+          "sentence": "Set center X position of _PARAM0_ to _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
                     "value": "SineMovement::SineMovement::SetPropertyCenterPointX"
                   },
                   "parameters": [
@@ -791,11 +864,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -836,19 +907,17 @@
           "description": "Set horizontal distance.",
           "fullName": "Set horizontal distance",
           "functionType": "Action",
+          "group": "",
           "name": "SetHorizontalDistance",
           "private": false,
           "sentence": "Set horizontal distance of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyHorizontalDistance"
                   },
                   "parameters": [
@@ -856,11 +925,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -901,19 +968,17 @@
           "description": "Set vertical distance.",
           "fullName": "Set vertical distance",
           "functionType": "Action",
+          "group": "",
           "name": "SetVerticalDistance",
           "private": false,
           "sentence": "Set vertical distance of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyVerticalDistance"
                   },
                   "parameters": [
@@ -921,11 +986,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -966,19 +1029,17 @@
           "description": "Set horizontal speed.",
           "fullName": "Set horizontal speed",
           "functionType": "Action",
+          "group": "",
           "name": "SetHorizontalSpeed",
           "private": false,
           "sentence": "Set horizontal speed of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyHorizontalSpeed"
                   },
                   "parameters": [
@@ -986,11 +1047,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1031,19 +1090,17 @@
           "description": "Set vertical speed.",
           "fullName": "Set vertical speed",
           "functionType": "Action",
+          "group": "",
           "name": "SetVerticalSpeed",
           "private": false,
           "sentence": "Set vertical speed of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertyVerticalSpeed"
                   },
                   "parameters": [
@@ -1051,11 +1108,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"Value\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1096,19 +1151,17 @@
           "description": "Reset sine progress counters. The object will return to the initial state.",
           "fullName": "Reset sine progress counters",
           "functionType": "Action",
+          "group": "",
           "name": "ResetSineCounters",
           "private": false,
           "sentence": "Reset sine progress counters on _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertySineProgressX"
                   },
                   "parameters": [
@@ -1116,12 +1169,10 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SineMovement::SineMovement::SetPropertySineProgressY"
                   },
                   "parameters": [
@@ -1129,11 +1180,9 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1167,6 +1216,7 @@
           "type": "Number",
           "label": "Horizontal speed, in degrees per second",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "HorizontalSpeed"
@@ -1176,6 +1226,7 @@
           "type": "Number",
           "label": "Vertical speed, in degrees per second",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "VerticalSpeed"
@@ -1185,6 +1236,7 @@
           "type": "Number",
           "label": "Horizontal distance: amplitude of the movement on X axis (0 to deactivate)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "HorizontalDistance"
@@ -1194,6 +1246,7 @@
           "type": "Number",
           "label": "Vertical distance: amplitude of the movement on Y axis (0 to deactivate)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "VerticalDistance"
@@ -1203,6 +1256,7 @@
           "type": "Number",
           "label": "Center of movement, X position",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "CenterPointX"
@@ -1212,6 +1266,7 @@
           "type": "Number",
           "label": "Center of movement, Y position",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "CenterPointY"
@@ -1221,6 +1276,7 @@
           "type": "Number",
           "label": "Counter used to change X position",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "SineProgressX"
@@ -1230,6 +1286,7 @@
           "type": "Number",
           "label": "Counter used to change Y position",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "SineProgressY"

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -522,7 +522,7 @@
         },
         {
           "description": "Vertical distance.",
-          "fullName": "Vertical distance",
+          "fullName": "Vertical amplitude",
           "functionType": "Expression",
           "group": "Sine movement configuration",
           "name": "VerticalDistance",

--- a/extensions/reviewed/SineMovement.json
+++ b/extensions/reviewed/SineMovement.json
@@ -971,7 +971,7 @@
         },
         {
           "description": "Change vertical amplitude.",
-          "fullName": "Vertical distance",
+          "fullName": "Vertical amplitude",
           "functionType": "Action",
           "group": "Sine movement configuration",
           "name": "SetVerticalDistance",


### PR DESCRIPTION
A user requested this feature and I think it is useful also.

## Playable game

https://liluo.io/instant-builds/22eed7d5-6c41-4f15-9705-b1b50aab2947

## Project

[SineMovement-0.0.6.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/9467006/SineMovement-0.0.6.zip)

## Video

https://user-images.githubusercontent.com/8879811/187835369-8d94f1a6-9d31-4747-b559-51d6abe87cb6.mp4

