### PR TITLE
AutoTyping: Added multiple functions and a minor fix

### DIFF
--- a/extensions/reviewed/AutoTyping.json
+++ b/extensions/reviewed/AutoTyping.json
@@ -1,14 +1,19 @@
 {
   "author": "westboy, daliyoucefmedakram@gmail.com, @bouh",
-  "description": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.\n\nAdd the behavior to a Text object (BBText, Bitmap Text object) and choose the interval between characters.\n\n* When the text changes, the automatic typing starts again from the beginning with the new text.\n* You can change the speed of the text typing by changing the interval with events.\n* Use a condition to check if the typing finished.\n* You can also pause the typing and resume it after.",
+  "category": "",
+  "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.\n\nAdd the behavior to a Text object (BBText, Bitmap Text object) and choose the interval between characters.\n\n* When the text changes, the automatic typing starts again from the beginning with the new text.\n* You can change the speed of the text typing by changing the interval with events.\n* Use a condition to check if the typing finished.\n* You can also pause the typing and resume it after.",
   "extensionNamespace": "",
-  "fullName": "Auto typing animation for texts (\"typewriter\" effect)",
+  "fullName": "Auto typing animation for text (\"typewriter\" effect)",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXR5cGV3cml0ZXIiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMjAgMTNIMTZDMTYgMTQuMSAxNS4xIDE1IDE0IDE1SDEwQzguOSAxNSA4IDE0LjEgOCAxM0g0TDIgMThWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDIwQzIxLjEgMjIgMjIgMjEuMSAyMiAyMFYxOE02IDIwQzUuMTEgMjAgNC42NiAxOC45MiA1LjI5IDE4LjI5QzUuOTIgMTcuNjYgNyAxOC4xMSA3IDE5QzcgMTkuNTUgNi41NSAyMCA2IDIwTTEwIDIwQzkuMTEgMjAgOC42NiAxOC45MiA5LjI5IDE4LjI5QzkuOTIgMTcuNjYgMTEgMTguMTEgMTEgMTlDMTEgMTkuNTUgMTAuNTUgMjAgMTAgMjBNMTQgMjBDMTMuMTEgMjAgMTIuNjYgMTguOTIgMTMuMjkgMTguMjlDMTMuOTIgMTcuNjYgMTUgMTguMTEgMTUgMTlDMTUgMTkuNTUgMTQuNTUgMjAgMTQgMjBNMTggMjBDMTcuMTEgMjAgMTYuNjYgMTguOTIgMTcuMjkgMTguMjlDMTcuOTIgMTcuNjYgMTkgMTguMTEgMTkgMTlDMTkgMTkuNTUgMTguNTUgMjAgMTggMjBNMTggMTBWM0g2VjEwSDNWMTJIMjFWMTBNOCA1SDE2VjZIOE04IDdIMTRWOEg4IiAvPjwvc3ZnPg==",
   "name": "AutoTyping",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/typewriter.svg",
-  "shortDescription": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.",
-  "version": "1.0.3",
+  "shortDescription": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect).",
+  "version": "1.0.4",
+  "origin": {
+    "identifier": "AutoTyping",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "text",
     "bbtext",
@@ -24,7 +29,7 @@
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
       "fullName": "Auto typing text",
       "name": "Text_AutoTyping",
       "objectType": "TextObject::Text",
@@ -33,28 +38,24 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPostEvents",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -62,12 +63,10 @@
                     "_write_index",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjetTxt"
                   },
                   "parameters": [
@@ -75,102 +74,83 @@
                     "_txt_buffer",
                     "=",
                     "Object.String()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "TextObject::String"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "\"\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    "<",
+                    "<=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "TextObject::String"
                   },
                   "parameters": [
                     "Object",
                     "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, 1 + Object.Variable(_write_index))"
-                  ],
-                  "subInstructions": []
+                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\"",
                         "Object.Behavior::PropertyInterval()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -178,69 +158,56 @@
                         "_write_index",
                         "+",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    ">=",
+                    ">",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "RemoveTimer"
                   },
                   "parameters": [
                     "",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "TextObject::String"
                       },
                       "parameters": [
                         "Object",
                         "!=",
                         "Object.VariableString(_txt_buffer)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -248,12 +215,10 @@
                         "_write_index",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -261,34 +226,28 @@
                         "_txt_buffer",
                         "=",
                         "Object.String()"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "TextObject::String"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -321,18 +280,16 @@
           "description": "Execute actions when the auto typing text ends.",
           "fullName": "Auto typing finished",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingFinished",
           "private": false,
           "sentence": "When _PARAM0_ finished auto typing",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
@@ -340,23 +297,19 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -387,29 +340,25 @@
           "description": "Pause animation auto typing.",
           "fullName": "Pause auto typing",
           "functionType": "Action",
+          "group": "",
           "name": "Pause",
           "private": false,
           "sentence": "Pause auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -440,29 +389,25 @@
           "description": "Resume auto typing after pause.",
           "fullName": "Resume after pause",
           "functionType": "Action",
+          "group": "",
           "name": "Resume",
           "private": false,
           "sentence": "Resume auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "UnPauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -493,40 +438,34 @@
           "description": "Detect if the auto typing is on pause.",
           "fullName": "Typing on pause",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingPause",
           "private": false,
           "sentence": "_PARAM0_ is on pause",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectTimerPaused"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -557,28 +496,24 @@
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
+          "group": "",
           "name": "ChangeInterval",
           "private": false,
           "sentence": "Change the interval between characters of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "AutoTyping::Text_AutoTyping::SetPropertyInterval"
                   },
                   "parameters": [
@@ -586,11 +521,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"interval\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -634,14 +567,25 @@
           "type": "Number",
           "label": "Interval between characters in seconds.",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "Interval"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "Time"
         }
       ]
     },
     {
-      "description": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
       "fullName": "Auto typing text",
       "name": "BitmapText_AutoTyping",
       "objectType": "BitmapText::BitmapTextObject",
@@ -650,28 +594,24 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPostEvents",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -679,12 +619,10 @@
                     "_write_index",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjetTxt"
                   },
                   "parameters": [
@@ -692,102 +630,83 @@
                     "_txt_buffer",
                     "=",
                     "Object.Text()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BitmapText::BitmapTextObject::SetText"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "\"\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    "<",
+                    "<=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BitmapText::BitmapTextObject::SetText"
                   },
                   "parameters": [
                     "Object",
                     "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index) + 1)"
-                  ],
-                  "subInstructions": []
+                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\"",
                         "Object.Behavior::PropertyInterval()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -795,69 +714,56 @@
                         "_write_index",
                         "+",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    ">=",
+                    ">",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "RemoveObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BitmapText::BitmapTextObject::Text"
                       },
                       "parameters": [
                         "Object",
                         "!=",
                         "Object.VariableString(_txt_buffer)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -865,12 +771,10 @@
                         "_write_index",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -878,34 +782,28 @@
                         "_txt_buffer",
                         "=",
                         "Object.Text()"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BitmapText::BitmapTextObject::SetText"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -938,18 +836,16 @@
           "description": "Execute actions when the auto typing text ends.",
           "fullName": "Auto typing finished",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingFinished",
           "private": false,
           "sentence": "When _PARAM0_ finished auto typing",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
@@ -957,23 +853,19 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1004,29 +896,25 @@
           "description": "Pause animation auto typing.",
           "fullName": "Pause auto typing",
           "functionType": "Action",
+          "group": "",
           "name": "Pause",
           "private": false,
           "sentence": "Pause auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1057,29 +945,25 @@
           "description": "Resume auto typing after pause.",
           "fullName": "Resume after pause",
           "functionType": "Action",
+          "group": "",
           "name": "Resume",
           "private": false,
           "sentence": "Resume auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "UnPauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1110,40 +994,34 @@
           "description": "Detect if the auto typing is on pause.",
           "fullName": "Typing on pause",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingPause",
           "private": false,
           "sentence": "_PARAM0_ is on pause",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectTimerPaused"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1174,28 +1052,24 @@
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
+          "group": "",
           "name": "ChangeInterval",
           "private": false,
           "sentence": "Set the interval between characters of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "AutoTyping::BitmapText_AutoTyping::SetPropertyInterval"
                   },
                   "parameters": [
@@ -1203,11 +1077,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"interval\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1251,6 +1123,7 @@
           "type": "Number",
           "label": "Interval between characters in seconds.",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "Interval"
@@ -1258,7 +1131,7 @@
       ]
     },
     {
-      "description": "Animate the text to simulate it being written character by character (also called \"typewriter\" effect), with a customizable time between each character. Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
       "fullName": "Auto typing text",
       "name": "BBText_AutoTyping",
       "objectType": "BBText::BBText",
@@ -1267,28 +1140,24 @@
           "description": "",
           "fullName": "",
           "functionType": "Action",
+          "group": "",
           "name": "doStepPostEvents",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -1296,12 +1165,10 @@
                     "_write_index",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjetTxt"
                   },
                   "parameters": [
@@ -1309,102 +1176,83 @@
                     "_txt_buffer",
                     "=",
                     "Object.GetBBText()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BBText::SetBBText"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "\"\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    "<",
+                    "<=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BBText::SetBBText"
                   },
                   "parameters": [
                     "Object",
                     "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index) + 1)"
-                  ],
-                  "subInstructions": []
+                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\"",
                         "Object.Behavior::PropertyInterval()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1412,69 +1260,56 @@
                         "_write_index",
                         "+",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
                     "Object",
                     "_write_index",
-                    ">=",
+                    ">",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "RemoveObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BBText::IsBBText"
                       },
                       "parameters": [
                         "Object",
                         "!=",
                         "Object.VariableString(_txt_buffer)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1482,12 +1317,10 @@
                         "_write_index",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -1495,34 +1328,28 @@
                         "_txt_buffer",
                         "=",
                         "Object.GetBBText()"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BBText::SetBBText"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ResetObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"Autotyping Write Timer\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -1555,18 +1382,16 @@
           "description": "Execute actions when the auto typing text ends.",
           "fullName": "Auto typing finished",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingFinished",
           "private": false,
           "sentence": "When _PARAM0_ finished auto typing",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "VarObjet"
                   },
                   "parameters": [
@@ -1574,23 +1399,19 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1621,29 +1442,25 @@
           "description": "Pause animation auto typing.",
           "fullName": "Pause auto typing",
           "functionType": "Action",
+          "group": "",
           "name": "Pause",
           "private": false,
           "sentence": "Pause auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1674,29 +1491,25 @@
           "description": "Resume auto typing after pause.",
           "fullName": "Resume after pause",
           "functionType": "Action",
+          "group": "",
           "name": "Resume",
           "private": false,
           "sentence": "Resume auto typing of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "UnPauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1727,40 +1540,34 @@
           "description": "Detect if the auto typing is on pause.",
           "fullName": "Typing on pause",
           "functionType": "Condition",
+          "group": "",
           "name": "TypingPause",
           "private": false,
           "sentence": "_PARAM0_ is on pause",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectTimerPaused"
                   },
                   "parameters": [
                     "Object",
                     "\"Autotyping Write Timer\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1791,28 +1598,24 @@
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
+          "group": "",
           "name": "ChangeInterval",
           "private": false,
           "sentence": "Set the interval between characters of _PARAM0_ to _PARAM2_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "AutoTyping::BBText_AutoTyping::SetPropertyInterval"
                   },
                   "parameters": [
@@ -1820,11 +1623,9 @@
                     "Behavior",
                     "=",
                     "GetArgumentAsNumber(\"interval\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
@@ -1868,6 +1669,7 @@
           "type": "Number",
           "label": "Interval between characters in seconds.",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "Interval"

--- a/extensions/reviewed/AutoTyping.json
+++ b/extensions/reviewed/AutoTyping.json
@@ -63,7 +63,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_txt_buffer",
+                        "__AutoTyping.txt_buffer",
                         "=",
                         "Object.String()"
                       ]
@@ -163,9 +163,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "<=",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -177,7 +177,7 @@
                       "parameters": [
                         "Object",
                         "=",
-                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                        "SubStr(Object.VariableString(__AutoTyping.txt_buffer), 0, Object.Variable(__AutoTyping.write_index))"
                       ]
                     }
                   ],
@@ -191,7 +191,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\"",
+                            "\"__AutoTyping.WriteTimer\"",
                             "Object.Behavior::PropertyInterval()"
                           ]
                         }
@@ -203,7 +203,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         },
                         {
@@ -212,7 +212,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "+",
                             "1"
                           ]
@@ -235,7 +235,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                            "StrAt(Object.VariableString(__AutoTyping.txt_buffer), Object.Variable(__AutoTyping.write_index))"
                           ]
                         }
                       ]
@@ -251,9 +251,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         ">",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -264,7 +264,7 @@
                       },
                       "parameters": [
                         "",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ],
@@ -279,7 +279,7 @@
                           "parameters": [
                             "Object",
                             "!=",
-                            "Object.VariableString(_txt_buffer)"
+                            "Object.VariableString(__AutoTyping.txt_buffer)"
                           ]
                         }
                       ],
@@ -290,7 +290,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "=",
                             "0"
                           ]
@@ -301,7 +301,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_txt_buffer",
+                            "__AutoTyping.txt_buffer",
                             "=",
                             "Object.String()"
                           ]
@@ -322,7 +322,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         }
                       ]
@@ -375,9 +375,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     ">=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ],
@@ -435,7 +435,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ],
@@ -552,7 +552,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -601,7 +601,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -650,9 +650,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ]
@@ -701,7 +701,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
                     "GetArgumentAsNumber(\"CharacterIndex\")"
                   ]
@@ -771,7 +771,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "=",
                         "0"
                       ]
@@ -792,7 +792,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ]
@@ -959,7 +959,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Variable(_write_index)"
+                    "Object.Variable(__AutoTyping.write_index)"
                   ]
                 }
               ]
@@ -1057,7 +1057,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_txt_buffer",
+                        "__AutoTyping.txt_buffer",
                         "=",
                         "Object.Text()"
                       ]
@@ -1157,9 +1157,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "<=",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -1171,7 +1171,7 @@
                       "parameters": [
                         "Object",
                         "=",
-                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                        "SubStr(Object.VariableString(__AutoTyping.txt_buffer), 0, Object.Variable(__AutoTyping.write_index))"
                       ]
                     }
                   ],
@@ -1185,7 +1185,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\"",
+                            "\"__AutoTyping.WriteTimer\"",
                             "Object.Behavior::PropertyInterval()"
                           ]
                         }
@@ -1197,7 +1197,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         },
                         {
@@ -1206,7 +1206,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "+",
                             "1"
                           ]
@@ -1229,7 +1229,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                            "StrAt(Object.VariableString(__AutoTyping.txt_buffer), Object.Variable(__AutoTyping.write_index))"
                           ]
                         }
                       ]
@@ -1245,9 +1245,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         ">",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -1258,7 +1258,7 @@
                       },
                       "parameters": [
                         "",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ],
@@ -1273,7 +1273,7 @@
                           "parameters": [
                             "Object",
                             "!=",
-                            "Object.VariableString(_txt_buffer)"
+                            "Object.VariableString(__AutoTyping.txt_buffer)"
                           ]
                         }
                       ],
@@ -1284,7 +1284,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "=",
                             "0"
                           ]
@@ -1295,7 +1295,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_txt_buffer",
+                            "__AutoTyping.txt_buffer",
                             "=",
                             "Object.Text()"
                           ]
@@ -1316,7 +1316,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         }
                       ]
@@ -1369,9 +1369,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     ">=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ],
@@ -1429,7 +1429,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ],
@@ -1546,7 +1546,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -1595,7 +1595,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -1644,9 +1644,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ]
@@ -1695,7 +1695,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
                     "GetArgumentAsNumber(\"CharacterIndex\")"
                   ]
@@ -1765,7 +1765,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "=",
                         "0"
                       ]
@@ -1786,7 +1786,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ]
@@ -1953,7 +1953,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Variable(_write_index)"
+                    "Object.Variable(__AutoTyping.write_index)"
                   ]
                 }
               ]
@@ -2051,7 +2051,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_txt_buffer",
+                        "__AutoTyping.txt_buffer",
                         "=",
                         "Object.GetBBText()"
                       ]
@@ -2151,9 +2151,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "<=",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -2165,7 +2165,7 @@
                       "parameters": [
                         "Object",
                         "=",
-                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                        "SubStr(Object.VariableString(__AutoTyping.txt_buffer), 0, Object.Variable(__AutoTyping.write_index))"
                       ]
                     }
                   ],
@@ -2179,7 +2179,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\"",
+                            "\"__AutoTyping.WriteTimer\"",
                             "Object.Behavior::PropertyInterval()"
                           ]
                         }
@@ -2191,7 +2191,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         },
                         {
@@ -2200,7 +2200,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "+",
                             "1"
                           ]
@@ -2223,7 +2223,7 @@
                             "Object",
                             "Behavior",
                             "=",
-                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                            "StrAt(Object.VariableString(__AutoTyping.txt_buffer), Object.Variable(__AutoTyping.write_index))"
                           ]
                         }
                       ]
@@ -2239,9 +2239,9 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         ">",
-                        "StrLength(Object.VariableString(_txt_buffer))"
+                        "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                       ]
                     }
                   ],
@@ -2252,7 +2252,7 @@
                       },
                       "parameters": [
                         "",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ],
@@ -2267,7 +2267,7 @@
                           "parameters": [
                             "Object",
                             "!=",
-                            "Object.VariableString(_txt_buffer)"
+                            "Object.VariableString(__AutoTyping.txt_buffer)"
                           ]
                         }
                       ],
@@ -2278,7 +2278,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_write_index",
+                            "__AutoTyping.write_index",
                             "=",
                             "0"
                           ]
@@ -2289,7 +2289,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "_txt_buffer",
+                            "__AutoTyping.txt_buffer",
                             "=",
                             "Object.GetBBText()"
                           ]
@@ -2310,7 +2310,7 @@
                           },
                           "parameters": [
                             "Object",
-                            "\"Autotyping Write Timer\""
+                            "\"__AutoTyping.WriteTimer\""
                           ]
                         }
                       ]
@@ -2363,9 +2363,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     ">=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ],
@@ -2423,7 +2423,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ],
@@ -2540,7 +2540,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -2589,7 +2589,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"Autotyping Write Timer\""
+                    "\"__AutoTyping.WriteTimer\""
                   ]
                 }
               ]
@@ -2638,9 +2638,9 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
+                    "StrLength(Object.VariableString(__AutoTyping.txt_buffer))"
                   ]
                 }
               ]
@@ -2689,7 +2689,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "_write_index",
+                    "__AutoTyping.write_index",
                     "=",
                     "GetArgumentAsNumber(\"CharacterIndex\")"
                   ]
@@ -2759,7 +2759,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "_write_index",
+                        "__AutoTyping.write_index",
                         "=",
                         "0"
                       ]
@@ -2780,7 +2780,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "\"Autotyping Write Timer\""
+                        "\"__AutoTyping.WriteTimer\""
                       ]
                     }
                   ]
@@ -2947,7 +2947,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Variable(_write_index)"
+                    "Object.Variable(__AutoTyping.write_index)"
                   ]
                 }
               ]

--- a/extensions/reviewed/AutoTyping.json
+++ b/extensions/reviewed/AutoTyping.json
@@ -1,15 +1,15 @@
 {
   "author": "westboy, daliyoucefmedakram@gmail.com, @bouh",
   "category": "",
-  "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.\n\nAdd the behavior to a Text object (BBText, Bitmap Text object) and choose the interval between characters.\n\n* When the text changes, the automatic typing starts again from the beginning with the new text.\n* You can change the speed of the text typing by changing the interval with events.\n* Use a condition to check if the typing finished.\n* You can also pause the typing and resume it after.",
+  "description": "Animate text to simulate it being written one character at at time (a \"typewriter\" effect), with a customizable time between each character. Useful for dialogue scenes or visual novels.\n\nHow to use:\n- Add the behavior to a Text object (BBText, Bitmap Text object) and choose the interval between characters.\n\nTips:\n- Change the typing speed with the \"Change interval\" action.\n- Pause the typing and resume it at any time.\n- Use the \"Skip to end of text\" action to give users a way to skip text they don't want to read \n- If the text changes, the automatic typing starts again from the beginning with the new text.\n- Use a condition to check if the typing finished.\n- Use a condition to check if a new text character was added. This is useful to trigger audio effects.\n- Use the \"CurrentCharacter\" expression to know when a specific character was displayed.\n",
   "extensionNamespace": "",
   "fullName": "Auto typing animation for text (\"typewriter\" effect)",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXR5cGV3cml0ZXIiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMjAgMTNIMTZDMTYgMTQuMSAxNS4xIDE1IDE0IDE1SDEwQzguOSAxNSA4IDE0LjEgOCAxM0g0TDIgMThWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDIwQzIxLjEgMjIgMjIgMjEuMSAyMiAyMFYxOE02IDIwQzUuMTEgMjAgNC42NiAxOC45MiA1LjI5IDE4LjI5QzUuOTIgMTcuNjYgNyAxOC4xMSA3IDE5QzcgMTkuNTUgNi41NSAyMCA2IDIwTTEwIDIwQzkuMTEgMjAgOC42NiAxOC45MiA5LjI5IDE4LjI5QzkuOTIgMTcuNjYgMTEgMTguMTEgMTEgMTlDMTEgMTkuNTUgMTAuNTUgMjAgMTAgMjBNMTQgMjBDMTMuMTEgMjAgMTIuNjYgMTguOTIgMTMuMjkgMTguMjlDMTMuOTIgMTcuNjYgMTUgMTguMTEgMTUgMTlDMTUgMTkuNTUgMTQuNTUgMjAgMTQgMjBNMTggMjBDMTcuMTEgMjAgMTYuNjYgMTguOTIgMTcuMjkgMTguMjlDMTcuOTIgMTcuNjYgMTkgMTguMTEgMTkgMTlDMTkgMTkuNTUgMTguNTUgMjAgMTggMjBNMTggMTBWM0g2VjEwSDNWMTJIMjFWMTBNOCA1SDE2VjZIOE04IDdIMTRWOEg4IiAvPjwvc3ZnPg==",
   "name": "AutoTyping",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/typewriter.svg",
-  "shortDescription": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect).",
-  "version": "1.0.4",
+  "shortDescription": "Animate text to simulate it being written one character at at time (a \"typewriter\" effect).",
+  "version": "1.1.0",
   "origin": {
     "identifier": "AutoTyping",
     "name": "gdevelop-extension-store"
@@ -23,13 +23,14 @@
     "bitmap"
   ],
   "authorIds": [
-    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92"
+    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92",
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
-      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (a \"typewriter\" effect).",
       "fullName": "Auto typing text",
       "name": "Text_AutoTyping",
       "objectType": "TextObject::Text",
@@ -39,172 +40,22 @@
           "fullName": "",
           "functionType": "Action",
           "group": "",
-          "name": "doStepPostEvents",
+          "name": "onCreated",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjetTxt"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_txt_buffer",
-                    "=",
-                    "Object.String()"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "\"\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ResetObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "<=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
-                  ]
-                }
-              ],
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Initialize object",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "ObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\"",
-                        "Object.Behavior::PropertyInterval()"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "+",
-                        "1"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    ">",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "RemoveTimer"
-                  },
-                  "parameters": [
-                    "",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "TextObject::String"
-                      },
-                      "parameters": [
-                        "Object",
-                        "!=",
-                        "Object.VariableString(_txt_buffer)"
-                      ]
-                    }
-                  ],
+                  "conditions": [],
                   "actions": [
                     {
                       "type": {
@@ -249,7 +100,257 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Reset trigger",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "AutoTyping::Text_AutoTyping::SetPropertyCharacterJustAdded"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "no"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update text based on timer",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "<=",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "TextObject::String"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "ObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\"",
+                            "Object.Behavior::PropertyInterval()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "+",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::Text_AutoTyping::SetPropertyCharacterJustAdded"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::Text_AutoTyping::SetPropertyCurrentCharacter"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        ">",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "RemoveTimer"
+                      },
+                      "parameters": [
+                        "",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "TextObject::String"
+                          },
+                          "parameters": [
+                            "Object",
+                            "!=",
+                            "Object.VariableString(_txt_buffer)"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjetTxt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_txt_buffer",
+                            "=",
+                            "Object.String()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "TextObject::String"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "\"\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
             }
           ],
           "parameters": [
@@ -297,6 +398,122 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect if the auto typing is on pause.",
+          "fullName": "Typing on pause",
+          "functionType": "Condition",
+          "group": "",
+          "name": "TypingPause",
+          "private": false,
+          "sentence": "_PARAM0_ is on pause",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectTimerPaused"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Autotyping Write Timer\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect when a new text character is displayed. Useful for triggering sound effects.",
+          "fullName": "New text character was just displayed",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsCharacterJustAdded",
+          "private": false,
+          "sentence": "Text character was just displayed on _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "AutoTyping::Text_AutoTyping::PropertyCharacterJustAdded"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
                   ]
                 }
               ],
@@ -435,34 +652,27 @@
           "objectGroups": []
         },
         {
-          "description": "Detect if the auto typing is on pause.",
-          "fullName": "Typing on pause",
-          "functionType": "Condition",
+          "description": "Skip to the end of the text.",
+          "fullName": "Skip to the end of the text",
+          "functionType": "Action",
           "group": "",
-          "name": "TypingPause",
+          "name": "SkipToEnd",
           "private": false,
-          "sentence": "_PARAM0_ is on pause",
+          "sentence": "Skip to the end of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "ObjectTimerPaused"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "SetReturnBoolean"
+                    "value": "ModVarObjet"
                   },
                   "parameters": [
-                    "True"
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "StrLength(Object.VariableString(_txt_buffer))"
                   ]
                 }
               ]
@@ -550,12 +760,60 @@
             {
               "codeOnly": false,
               "defaultValue": "",
-              "description": "Interval tme",
+              "description": "Interval time",
               "longDescription": "",
               "name": "interval",
               "optional": false,
               "supplementaryInformation": "",
               "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return the text character that was last displayed.",
+          "fullName": "Current text character",
+          "functionType": "StringExpression",
+          "group": "",
+          "name": "CurrentCharacter",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnString"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyCurrentCharacter()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
             }
           ],
           "objectGroups": []
@@ -574,18 +832,28 @@
         },
         {
           "value": "",
-          "type": "Number",
-          "label": "",
+          "type": "Boolean",
+          "label": "Detect if a new text character was just displayed",
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
-          "name": "Time"
+          "hidden": true,
+          "name": "CharacterJustAdded"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Text character that was most recently displayed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CurrentCharacter"
         }
       ]
     },
     {
-      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (a \"typewriter\" effect).",
       "fullName": "Auto typing text",
       "name": "BitmapText_AutoTyping",
       "objectType": "BitmapText::BitmapTextObject",
@@ -595,172 +863,22 @@
           "fullName": "",
           "functionType": "Action",
           "group": "",
-          "name": "doStepPostEvents",
+          "name": "onCreated",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjetTxt"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_txt_buffer",
-                    "=",
-                    "Object.Text()"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "BitmapText::BitmapTextObject::SetText"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "\"\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ResetObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "<=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "BitmapText::BitmapTextObject::SetText"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
-                  ]
-                }
-              ],
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Initialize object",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "ObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\"",
-                        "Object.Behavior::PropertyInterval()"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "+",
-                        "1"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    ">",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "RemoveObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "BitmapText::BitmapTextObject::Text"
-                      },
-                      "parameters": [
-                        "Object",
-                        "!=",
-                        "Object.VariableString(_txt_buffer)"
-                      ]
-                    }
-                  ],
+                  "conditions": [],
                   "actions": [
                     {
                       "type": {
@@ -805,7 +923,257 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Reset trigger",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "AutoTyping::BitmapText_AutoTyping::SetPropertyCharacterJustAdded"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update text based on timer",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "<=",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "BitmapText::BitmapTextObject::SetText"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "ObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\"",
+                            "Object.Behavior::PropertyInterval()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "+",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::BitmapText_AutoTyping::SetPropertyCharacterJustAdded"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::BitmapText_AutoTyping::SetPropertyCurrentCharacter"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        ">",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "RemoveTimer"
+                      },
+                      "parameters": [
+                        "",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BitmapText::BitmapTextObject::Text"
+                          },
+                          "parameters": [
+                            "Object",
+                            "!=",
+                            "Object.VariableString(_txt_buffer)"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjetTxt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_txt_buffer",
+                            "=",
+                            "Object.Text()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BitmapText::BitmapTextObject::SetText"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "\"\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
             }
           ],
           "parameters": [
@@ -853,6 +1221,122 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect if the auto typing is on pause.",
+          "fullName": "Typing on pause",
+          "functionType": "Condition",
+          "group": "",
+          "name": "TypingPause",
+          "private": false,
+          "sentence": "_PARAM0_ is on pause",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectTimerPaused"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Autotyping Write Timer\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect when a new text character is displayed. Useful for triggering sound effects.",
+          "fullName": "New text character was just displayed",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsCharacterJustAdded",
+          "private": false,
+          "sentence": "Text character was just displayed on _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "AutoTyping::BitmapText_AutoTyping::PropertyCharacterJustAdded"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
                   ]
                 }
               ],
@@ -991,34 +1475,27 @@
           "objectGroups": []
         },
         {
-          "description": "Detect if the auto typing is on pause.",
-          "fullName": "Typing on pause",
-          "functionType": "Condition",
+          "description": "Skip to the end of the text.",
+          "fullName": "Skip to the end of the text",
+          "functionType": "Action",
           "group": "",
-          "name": "TypingPause",
+          "name": "SkipToEnd",
           "private": false,
-          "sentence": "_PARAM0_ is on pause",
+          "sentence": "Skip to the end of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "ObjectTimerPaused"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "SetReturnBoolean"
+                    "value": "ModVarObjet"
                   },
                   "parameters": [
-                    "True"
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "StrLength(Object.VariableString(_txt_buffer))"
                   ]
                 }
               ]
@@ -1115,6 +1592,54 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Return the text character that was last displayed.",
+          "fullName": "Current character",
+          "functionType": "StringExpression",
+          "group": "",
+          "name": "CurrentCharacter",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnString"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyCurrentCharacter()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -1127,11 +1652,31 @@
           "extraInformation": [],
           "hidden": false,
           "name": "Interval"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Detect if a new text character was just displayed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CharacterJustAdded"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Text character that was most recently displayed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CurrentCharacter"
         }
       ]
     },
     {
-      "description": "Animate text to simulate it being written one character at at time (also called \"typewriter\" effect), with a customizable time between each character.  Add the behavior to the object, and it will get animated when the text is changed. You can also pause/resume it.",
+      "description": "Animate text to simulate it being written one character at at time (a \"typewriter\" effect).",
       "fullName": "Auto typing text",
       "name": "BBText_AutoTyping",
       "objectType": "BBText::BBText",
@@ -1141,172 +1686,22 @@
           "fullName": "",
           "functionType": "Action",
           "group": "",
-          "name": "doStepPostEvents",
+          "name": "onCreated",
           "private": false,
           "sentence": "",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjetTxt"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_txt_buffer",
-                    "=",
-                    "Object.GetBBText()"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "BBText::SetBBText"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "\"\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ResetObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    "<=",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "BBText::SetBBText"
-                  },
-                  "parameters": [
-                    "Object",
-                    "=",
-                    "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
-                  ]
-                }
-              ],
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Initialize object",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "ObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\"",
-                        "Object.Behavior::PropertyInterval()"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "+",
-                        "1"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "_write_index",
-                    ">",
-                    "StrLength(Object.VariableString(_txt_buffer))"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "RemoveObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "BBText::IsBBText"
-                      },
-                      "parameters": [
-                        "Object",
-                        "!=",
-                        "Object.VariableString(_txt_buffer)"
-                      ]
-                    }
-                  ],
+                  "conditions": [],
                   "actions": [
                     {
                       "type": {
@@ -1351,7 +1746,257 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "group": "",
+          "name": "doStepPostEvents",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Reset trigger",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "AutoTyping::BBText_AutoTyping::SetPropertyCharacterJustAdded"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            },
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Update text based on timer",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "<=",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "BBText::SetBBText"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "SubStr(Object.VariableString(_txt_buffer), 0, Object.Variable(_write_index))"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "ObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\"",
+                            "Object.Behavior::PropertyInterval()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "+",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::BBText_AutoTyping::SetPropertyCharacterJustAdded"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "AutoTyping::BBText_AutoTyping::SetPropertyCurrentCharacter"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "StrAt(Object.VariableString(_txt_buffer), Object.Variable(_write_index))"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        ">",
+                        "StrLength(Object.VariableString(_txt_buffer))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "RemoveTimer"
+                      },
+                      "parameters": [
+                        "",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BBText::IsBBText"
+                          },
+                          "parameters": [
+                            "Object",
+                            "!=",
+                            "Object.VariableString(_txt_buffer)"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ModVarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_write_index",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarObjetTxt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "_txt_buffer",
+                            "=",
+                            "Object.GetBBText()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BBText::SetBBText"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "\"\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Autotyping Write Timer\""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
             }
           ],
           "parameters": [
@@ -1399,6 +2044,122 @@
                     "_write_index",
                     ">=",
                     "StrLength(Object.VariableString(_txt_buffer))"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect if the auto typing is on pause.",
+          "fullName": "Typing on pause",
+          "functionType": "Condition",
+          "group": "",
+          "name": "TypingPause",
+          "private": false,
+          "sentence": "_PARAM0_ is on pause",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectTimerPaused"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Autotyping Write Timer\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Detect when a new text character is displayed. Useful for triggering sound effects.",
+          "fullName": "New text character was just displayed",
+          "functionType": "Condition",
+          "group": "",
+          "name": "IsCharacterJustAdded",
+          "private": false,
+          "sentence": "Text character was just displayed on _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "AutoTyping::BBText_AutoTyping::PropertyCharacterJustAdded"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
                   ]
                 }
               ],
@@ -1537,34 +2298,27 @@
           "objectGroups": []
         },
         {
-          "description": "Detect if the auto typing is on pause.",
-          "fullName": "Typing on pause",
-          "functionType": "Condition",
+          "description": "Skip to the end of the text.",
+          "fullName": "Skip to the end of the text",
+          "functionType": "Action",
           "group": "",
-          "name": "TypingPause",
+          "name": "SkipToEnd",
           "private": false,
-          "sentence": "_PARAM0_ is on pause",
+          "sentence": "Skip to the end of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "ObjectTimerPaused"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"Autotyping Write Timer\""
-                  ]
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "SetReturnBoolean"
+                    "value": "ModVarObjet"
                   },
                   "parameters": [
-                    "True"
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "StrLength(Object.VariableString(_txt_buffer))"
                   ]
                 }
               ]
@@ -1661,6 +2415,54 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Return the text character that was last displayed.",
+          "fullName": "Current character",
+          "functionType": "StringExpression",
+          "group": "",
+          "name": "CurrentCharacter",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnString"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyCurrentCharacter()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -1673,6 +2475,26 @@
           "extraInformation": [],
           "hidden": false,
           "name": "Interval"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Detect if a new text character was just displayed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CharacterJustAdded"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Text character that was most recently displayed",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "CurrentCharacter"
         }
       ]
     }

--- a/extensions/reviewed/AutoTyping.json
+++ b/extensions/reviewed/AutoTyping.json
@@ -59,17 +59,6 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -81,21 +70,12 @@
                     },
                     {
                       "type": {
-                        "value": "TextObject::String"
+                        "value": "AutoTyping::Text_AutoTyping::StartAtBeginning"
                       },
                       "parameters": [
                         "Object",
-                        "=",
-                        "\"\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
+                        "Behavior",
+                        ""
                       ]
                     }
                   ]
@@ -703,6 +683,149 @@
           "objectGroups": []
         },
         {
+          "description": "Jump to a specific position in the text. Positions start at \"0\" and increase by one for every character.",
+          "fullName": "Jump to a specific position in the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "JumpToPosition",
+          "private": false,
+          "sentence": "Jump to position _PARAM2_ in the text _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "GetArgumentAsNumber(\"CharacterIndex\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Character position",
+              "longDescription": "",
+              "name": "CharacterIndex",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Start at the beginning of text.",
+          "fullName": "Start at the beginning of the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "StartAtBeginning",
+          "private": false,
+          "sentence": "Start at the beginning of _PARAM0_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Start at beginning",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "TextObject::String"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "\"\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
@@ -817,6 +940,54 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Return the index of the text character that was last displayed.",
+          "fullName": "Index of current text character",
+          "functionType": "Expression",
+          "group": "",
+          "name": "CurrentCharacterIndex",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Variable(_write_index)"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextObject::Text",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::Text_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -882,17 +1053,6 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -904,21 +1064,12 @@
                     },
                     {
                       "type": {
-                        "value": "BitmapText::BitmapTextObject::SetText"
+                        "value": "AutoTyping::BitmapText_AutoTyping::StartAtBeginning"
                       },
                       "parameters": [
                         "Object",
-                        "=",
-                        "\"\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
+                        "Behavior",
+                        ""
                       ]
                     }
                   ]
@@ -1526,6 +1677,149 @@
           "objectGroups": []
         },
         {
+          "description": "Jump to a specific position in the text. Positions start at \"0\" and increase by one for every character.",
+          "fullName": "Jump to a specific position in the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "JumpToPosition",
+          "private": false,
+          "sentence": "Jump to position _PARAM2_ in the text _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "GetArgumentAsNumber(\"CharacterIndex\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Character position",
+              "longDescription": "",
+              "name": "CharacterIndex",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Start at the beginning of text.",
+          "fullName": "Start at the beginning of the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "StartAtBeginning",
+          "private": false,
+          "sentence": "Start at the beginning of _PARAM0_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Start at beginning",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BitmapText::BitmapTextObject::SetText"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "\"\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
@@ -1640,6 +1934,54 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Return the index of the text character that was last displayed.",
+          "fullName": "Index of current text character",
+          "functionType": "Expression",
+          "group": "",
+          "name": "CurrentCharacterIndex",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Variable(_write_index)"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BitmapText::BitmapTextObject",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BitmapText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -1705,17 +2047,6 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "_write_index",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
                         "value": "ModVarObjetTxt"
                       },
                       "parameters": [
@@ -1727,21 +2058,12 @@
                     },
                     {
                       "type": {
-                        "value": "BBText::SetBBText"
+                        "value": "AutoTyping::BBText_AutoTyping::StartAtBeginning"
                       },
                       "parameters": [
                         "Object",
-                        "=",
-                        "\"\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Autotyping Write Timer\""
+                        "Behavior",
+                        ""
                       ]
                     }
                   ]
@@ -2349,6 +2671,149 @@
           "objectGroups": []
         },
         {
+          "description": "Jump to a specific position in the text. Positions start at \"0\" and increase by one for every character.",
+          "fullName": "Jump to a specific position in the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "JumpToPosition",
+          "private": false,
+          "sentence": "Jump to position _PARAM2_ in the text _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "_write_index",
+                    "=",
+                    "GetArgumentAsNumber(\"CharacterIndex\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Character position",
+              "longDescription": "",
+              "name": "CharacterIndex",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Start at the beginning of text.",
+          "fullName": "Start at the beginning of the text",
+          "functionType": "Action",
+          "group": "",
+          "name": "StartAtBeginning",
+          "private": false,
+          "sentence": "Start at the beginning of _PARAM0_",
+          "events": [
+            {
+              "colorB": 228,
+              "colorG": 176,
+              "colorR": 74,
+              "creationTime": 0,
+              "name": "Start at beginning",
+              "source": "",
+              "type": "BuiltinCommonInstructions::Group",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarObjet"
+                      },
+                      "parameters": [
+                        "Object",
+                        "_write_index",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BBText::SetBBText"
+                      },
+                      "parameters": [
+                        "Object",
+                        "=",
+                        "\"\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Autotyping Write Timer\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Change the time between characters being typed. ",
           "fullName": "Time between characters",
           "functionType": "Action",
@@ -2435,6 +2900,54 @@
                   },
                   "parameters": [
                     "Object.Behavior::PropertyCurrentCharacter()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "BBText::BBText",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "AutoTyping::BBText_AutoTyping",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Return the index of the text character that was last displayed.",
+          "fullName": "Index of current text character",
+          "functionType": "Expression",
+          "group": "",
+          "name": "CurrentCharacterIndex",
+          "private": false,
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Variable(_write_index)"
                   ]
                 }
               ]


### PR DESCRIPTION
## Changes

- Added an action to skip to end of text
- Added a condition to check when a new character was displayed (to trigger sound effects)
- Added an expression to return the character that was just displayed (to perform conditional logic)
- Before this change, it would always show the first character, even if you paused it at the beginning of the scene.

## Playable game
https://liluo.io/instant-builds/b94cd280-c4a7-4262-bb14-072c8a9c27b3

## Project files
[AutoTyping.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/9557419/AutoTyping.zip)

## Video
https://user-images.githubusercontent.com/8879811/189468539-d620bce0-0dc7-40c8-88a5-e5a8e36a5625.mp4


