### PR TITLE
Upgrade Cordova IAP to 11.0.0

### DIFF
--- a/extensions/reviewed/InAppPurchase.json
+++ b/extensions/reviewed/InAppPurchase.json
@@ -8,7 +8,7 @@
   "name": "InAppPurchase",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Shopping and Ecommerce/Shopping and Ecommerce_wallet_money_cash.svg",
   "shortDescription": "Add items to buy directly in your game (\"In-App Purchase\"), for games published on Android or iOS.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "tags": [
     "purchase",
     "iap",
@@ -25,7 +25,7 @@
       "exportName": "cordova-plugin-purchase",
       "name": "Purchase plugin",
       "type": "cordova",
-      "version": "10.6.1"
+      "version": "11.0.0"
     }
   ],
   "eventsFunctions": [

--- a/extensions/reviewed/InAppPurchase.json
+++ b/extensions/reviewed/InAppPurchase.json
@@ -8,7 +8,7 @@
   "name": "InAppPurchase",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Shopping and Ecommerce/Shopping and Ecommerce_wallet_money_cash.svg",
   "shortDescription": "Add items to buy directly in your game (\"In-App Purchase\"), for games published on Android or iOS.",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "tags": [
     "purchase",
     "iap",


### PR DESCRIPTION
Following 2 raised problems on the forum: 

- https://forum.gdevelop.io/t/inapppurchase-outdated/41962
- https://forum.gdevelop.io/t/inapppurchase-unsupported-version-of-play-billing/41926/16

I believe we can safely update the cordova plugin to handle the Play Billing v4
https://github.com/j3k0/cordova-plugin-purchase/releases