### PR TITLE
[Marching Squares] Fix a preview crash when the "Must only draw what is on the screen" property was checked.

### DIFF
--- a/extensions/reviewed/MarchingSquares.json
+++ b/extensions/reviewed/MarchingSquares.json
@@ -1,7 +1,7 @@
 {
   "author": "D8H",
   "category": "",
-  "description": "It can be helpful to draw:\n* fog of wars\n* liquids effects (water, blobs, lava)\n* dynamically paint territories\n* other effects based on \"contour lines\"",
+  "description": "It can be helpful for:\n  * Liquid effects lik water, blobs or lava ([https://editor.gdevelop.io/?project=example://marching-squares-liquids](open the project online))\n  * Fog of wars ([https://editor.gdevelop.io/?project=example://marching-squares-fog-of-war](open the project online))\n  * Platformer with destructible platforms ([https://editor.gdevelop.io/?project=example://marching-squares-platforms-painter](open the project online))\n  * Dynamically paint territories ([https://editor.gdevelop.io/?project=example://marching-squares-qix](open the project online))\n  * Top-down relief with physics ([https://editor.gdevelop.io/?project=example://marching-squares-terraforming](open the project online))\n  * Island generator ([https://editor.gdevelop.io/?project=example://marching-squares-island-generator](open the project online))\n* other effects based on \"contour lines\"",
   "extensionNamespace": "",
   "fullName": "Marching Squares (experimental)",
   "helpPath": "/extensions/marching-squares",
@@ -9,7 +9,7 @@
   "name": "MarchingSquares",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/peanut-outline.svg",
   "shortDescription": "Allow to build a \"scalar field\" and draw contour lines of it: useful for fog of wars, liquid effects, paint the ground, etc...",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "origin": {
     "identifier": "MarchingSquares",
     "name": "gdevelop-extension-store"
@@ -1292,7 +1292,7 @@
           "events": [
             {
               "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "\nconst screenWidth = runtimeScene.getGame().getGameResolutionWidth();\nconst screenHeight = runtimeScene.getGame().getGameResolutionWidth();\n\nconst behaviorName = eventsFunctionContext.getBehaviorName(\"Behavior\");\n\nconst object = objects[0];\nconst behavior = object.getBehavior(behaviorName);\n\nif (behavior._behaviorData.MustOnlyDrawScreen) {\n    const layer = runtimeScene.getLayer(object.getLayer());\n    const screen1 = layer.convertCoords(0, 0);\n    const screen2 = layer.convertCoords(screenWidth, 0);\n    const screen3 = layer.convertCoords(0, screenHeight);\n    const screen4 = layer.convertCoords(screenWidth, screenHeight);\n\n    const screenLeft = Math.min(screen1[0], screen2[0], screen3[0], screen4[0]);\n    const screenTop = Math.min(screen1[1], screen2[1], screen3[1], screen4[1]);\n    const screenRight = Math.max(screen1[0], screen2[0], screen3[0], screen4[0]);\n    const screenBottom = Math.max(screen1[1], screen2[1], screen3[1], screen4[1]);\n\n    const minX = Math.max(0, Math.floor(behavior.convertToGridBasisX(screenLeft)));\n    const minY = Math.max(0, Math.floor(behavior.convertToGridBasisY(screenTop)));\n    // I don't know why the + 1 is needed\n    const maxX = Math.min(behavior.dimX(), 1 + Math.ceil(behavior.convertToGridBasisX(screenRight)));\n    const maxY = Math.min(behavior.dimY(), Math.ceil(behavior.convertToGridBasisY(screenBottom)));\n\n    behavior.drawField(minX, minY, maxX, maxY);\n}\nelse {\n    // This is useful for static content or games without scrolling.\n    behavior.drawField(0, 0, behavior.scalarField.dimX(), behavior.scalarField.dimY());\n}",
+              "inlineCode": "\nconst screenWidth = runtimeScene.getGame().getGameResolutionWidth();\nconst screenHeight = runtimeScene.getGame().getGameResolutionWidth();\n\nconst behaviorName = eventsFunctionContext.getBehaviorName(\"Behavior\");\n\nconst object = objects[0];\nconst behavior = object.getBehavior(behaviorName);\n\nif (behavior._behaviorData.MustOnlyDrawScreen) {\n    const layer = runtimeScene.getLayer(object.getLayer());\n    const screen1 = layer.convertCoords(0, 0);\n    const screen2 = layer.convertCoords(screenWidth, 0);\n    const screen3 = layer.convertCoords(0, screenHeight);\n    const screen4 = layer.convertCoords(screenWidth, screenHeight);\n\n    const screenLeft = Math.min(screen1[0], screen2[0], screen3[0], screen4[0]);\n    const screenTop = Math.min(screen1[1], screen2[1], screen3[1], screen4[1]);\n    const screenRight = Math.max(screen1[0], screen2[0], screen3[0], screen4[0]);\n    const screenBottom = Math.max(screen1[1], screen2[1], screen3[1], screen4[1]);\n\n    const minX = Math.max(0, Math.floor(behavior.coordConverter.convertToGridBasisX(screenLeft)));\n    const minY = Math.max(0, Math.floor(behavior.coordConverter.convertToGridBasisY(screenTop)));\n    // I don't know why the + 1 is needed\n    const maxX = Math.min(behavior.scalarField.dimX(), 1 + Math.ceil(behavior.coordConverter.convertToGridBasisX(screenRight)));\n    const maxY = Math.min(behavior.scalarField.dimY(), Math.ceil(behavior.coordConverter.convertToGridBasisY(screenBottom)));\n\n    behavior.drawField(minX, minY, maxX, maxY);\n}\nelse {\n    // This is useful for static content or games without scrolling.\n    behavior.drawField(0, 0, behavior.scalarField.dimX(), behavior.scalarField.dimY());\n}",
               "parameterObjects": "Object",
               "useStrict": true,
               "eventsSheetExpanded": true
@@ -2917,5 +2917,6 @@
         }
       ]
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
It's a very small change in the JS that I forgot to do in the previous update.

It also add examples links directly in the extension long description.

Note to the reviewer:
- The example contains the fixed version
- Launch a preview and it should work
- Downgrade to the current version
- Launch a preview, there should be exception every frame.

## Example
https://www.dropbox.com/s/u2juv7b7cypz5uu/LiquidMarchingSquareFix.zip?dl=1