### PR TITLE
[CameraShake] Fix compatibility with the extension version prior to 3.0.0

### DIFF
--- a/extensions/reviewed/CameraShake.json
+++ b/extensions/reviewed/CameraShake.json
@@ -9,7 +9,11 @@
   "name": "CameraShake",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-difference-ab.svg",
   "shortDescription": "Shake layer cameras with translation, rotation and zoom.",
-  "version": "3.0.0",
+  "version": "3.0.1",
+  "origin": {
+    "identifier": "CameraShake",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "shaking",
     "camera",
@@ -1037,49 +1041,6 @@
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "__CameraShake.LayerName",
-                    "=",
-                    "GetArgumentAsString(\"Layer\")"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareStrings"
-                  },
-                  "parameters": [
-                    "GetArgumentAsString(\"Layer\")",
-                    "=",
-                    "\"\""
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "__CameraShake.LayerName",
-                    "=",
-                    "\"__BaseLayer\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
                     "value": "VariableClearChildren"
                   },
                   "parameters": [
@@ -1093,7 +1054,7 @@
                   "parameters": [
                     "",
                     "",
-                    "VariableString(__CameraShake.LayerName)",
+                    "GetArgumentAsString(\"Layer\")",
                     ""
                   ]
                 }
@@ -1105,11 +1066,12 @@
               "actions": [
                 {
                   "type": {
-                    "value": "ResetTimer"
+                    "value": "ModVarScene"
                   },
                   "parameters": [
-                    "",
-                    "\"__CameraShake.DurationTimer\""
+                    "__CameraShake.Time",
+                    "=",
+                    "0"
                   ]
                 },
                 {
@@ -2989,5 +2951,6 @@
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
The example from Tristan was made for a previous update. It allows to see that it still works with the fix.
[CameraShakeExample.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/9639664/CameraShakeExample.zip)
