### PR TITLE
[MultitouchJoystick] [Reviewed] Minor fixes (v1.1.1)

### DIFF
--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -1118,330 +1118,361 @@
           "sentence": "_PARAM0_ is pushed in direction _PARAM2_",
           "events": [
             {
-              "colorB": 224,
-              "colorG": 16,
-              "colorR": 189,
-              "creationTime": 0,
-              "name": "Range (-180 to 180)",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure the joystick has moved from center",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "Object.Behavior::JoystickForce()",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [],
               "events": [
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
+                  "colorB": 224,
+                  "colorG": 16,
+                  "colorR": 189,
                   "creationTime": 0,
-                  "name": "Up",
+                  "name": "Range (-180 to 180)",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Up\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Up",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-135"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "-45"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Up\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Down",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Down\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "45"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "135"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Left",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Left\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::Or"
-                              },
-                              "parameters": [],
-                              "subInstructions": [
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
                                 {
                                   "type": {
-                                    "value": "BuiltinCommonInstructions::And"
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                   },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "-180"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<",
-                                        "-135"
-                                      ]
-                                    }
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-135"
                                   ]
                                 },
                                 {
                                   "type": {
-                                    "value": "BuiltinCommonInstructions::And"
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                   },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "135"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<",
-                                        "180"
-                                      ]
-                                    }
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "-45"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
                                   ]
                                 }
                               ]
                             }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Right",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Right\""
                           ]
                         }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Down",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-45"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "45"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Down\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "45"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "135"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Left",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareStrings"
+                              },
+                              "parameters": [
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Left\""
+                              ]
+                            }
+                          ],
+                          "actions": [],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::Or"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "BuiltinCommonInstructions::And"
+                                      },
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            ">=",
+                                            "-180"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "<",
+                                            "-135"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "BuiltinCommonInstructions::And"
+                                      },
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            ">=",
+                                            "135"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "<",
+                                            "180"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Right",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareStrings"
+                              },
+                              "parameters": [
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Right\""
+                              ]
+                            }
+                          ],
+                          "actions": [],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-45"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "45"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
                     }
                   ],
                   "parameters": []
                 }
-              ],
-              "parameters": []
+              ]
             }
           ],
           "parameters": [
@@ -1488,598 +1519,629 @@
           "sentence": "_PARAM0_ is pushed in direction _PARAM2_",
           "events": [
             {
-              "colorB": 224,
-              "colorG": 16,
-              "colorR": 189,
-              "creationTime": 0,
-              "name": "Range (-180 to 180)",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Make sure the joystick has moved from center",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "Object.Behavior::JoystickForce()",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [],
               "events": [
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
+                  "colorB": 224,
+                  "colorG": 16,
+                  "colorR": 189,
                   "creationTime": 0,
-                  "name": "Up",
+                  "name": "Range (-180 to 180)",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Up\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Up",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-112.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "-67.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Up\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Down",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Down\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "67.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "112.5"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Left",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Left\""
-                          ]
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::Or"
-                              },
-                              "parameters": [],
-                              "subInstructions": [
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
                                 {
                                   "type": {
-                                    "value": "BuiltinCommonInstructions::And"
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                                   },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "-180"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<",
-                                        "-157.5"
-                                      ]
-                                    }
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-112.5"
                                   ]
                                 },
                                 {
                                   "type": {
-                                    "value": "BuiltinCommonInstructions::And"
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "-67.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Down",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareStrings"
+                              },
+                              "parameters": [
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Down\""
+                              ]
+                            }
+                          ],
+                          "actions": [],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "67.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "112.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Left",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareStrings"
+                              },
+                              "parameters": [
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Left\""
+                              ]
+                            }
+                          ],
+                          "actions": [],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::Or"
                                   },
                                   "parameters": [],
                                   "subInstructions": [
                                     {
                                       "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                        "value": "BuiltinCommonInstructions::And"
                                       },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "157.5"
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            ">=",
+                                            "-180"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "<",
+                                            "-157.5"
+                                          ]
+                                        }
                                       ]
                                     },
                                     {
                                       "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                        "value": "BuiltinCommonInstructions::And"
                                       },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<",
-                                        "180"
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            ">=",
+                                            "157.5"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "<",
+                                            "180"
+                                          ]
+                                        }
                                       ]
                                     }
                                   ]
                                 }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Right",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"Right\""
                           ]
                         }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Right",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-22.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "22.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"Right\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-22.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "22.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "UpRight",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"UpRight\""
-                          ]
-                        }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "UpRight",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-67.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "-22.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"UpRight\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-67.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "-22.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "UpLeft",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"UpLeft\""
-                          ]
-                        }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "UpLeft",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "-157.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "-112.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"UpLeft\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "-157.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "-112.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "DownLeft",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"DownLeft\""
-                          ]
-                        }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "DownLeft",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "112.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "157.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"DownLeft\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "112.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "157.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
-                    }
-                  ],
-                  "parameters": []
-                },
-                {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "DownRight",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareStrings"
-                          },
-                          "parameters": [
-                            "GetArgumentAsString(\"Direction\")",
-                            "=",
-                            "\"DownRight\""
-                          ]
-                        }
                       ],
-                      "actions": [],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "DownRight",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
                       "events": [
                         {
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                "value": "BuiltinCommonInstructions::CompareStrings"
                               },
                               "parameters": [
-                                "Object",
-                                "Behavior",
-                                ">=",
-                                "22.5"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                              },
-                              "parameters": [
-                                "Object",
-                                "Behavior",
-                                "<",
-                                "67.5"
+                                "GetArgumentAsString(\"Direction\")",
+                                "=",
+                                "\"DownRight\""
                               ]
                             }
                           ],
-                          "actions": [
+                          "actions": [],
+                          "events": [
                             {
-                              "type": {
-                                "value": "SetReturnBoolean"
-                              },
-                              "parameters": [
-                                "True"
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    ">=",
+                                    "22.5"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "<",
+                                    "67.5"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "SetReturnBoolean"
+                                  },
+                                  "parameters": [
+                                    "True"
+                                  ]
+                                }
                               ]
                             }
                           ]
                         }
-                      ]
+                      ],
+                      "parameters": []
                     }
                   ],
                   "parameters": []
                 }
-              ],
-              "parameters": []
+              ]
             }
           ],
           "parameters": [

--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -9,7 +9,7 @@
   "name": "MultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Activate a joystick or buttons that can be controlled by interacting with a touchscreen.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "origin": {
     "identifier": "MultitouchJoystick",
     "name": "gdevelop-extension-store"
@@ -141,13 +141,13 @@
           "objectGroups": []
         },
         {
-          "description": "Activate multitouch joystick.",
-          "fullName": "Activate multitouch joystick",
+          "description": "Animate multitouch joystick.",
+          "fullName": "Animate multitouch joystick",
           "functionType": "Action",
           "group": "",
           "name": "ActivateJoystick",
           "private": false,
-          "sentence": "Activate joystick _PARAM0_ using _PARAM2_ as the thumbstick",
+          "sentence": "Animate joystick _PARAM0_ using _PARAM2_ as the thumbstick",
           "events": [
             {
               "colorB": 228,
@@ -1173,7 +1173,7 @@
                                 "Object",
                                 "Behavior",
                                 "<",
-                                "45"
+                                "-45"
                               ]
                             }
                           ],
@@ -1403,40 +1403,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::Or"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::And"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "-45"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<",
-                                        "45"
-                                      ]
-                                    }
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-45"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "45"
                               ]
                             }
                           ],
@@ -1542,40 +1526,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::Or"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::And"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<=",
-                                        "-67.5"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "-112.5"
-                                      ]
-                                    }
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-112.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "-67.5"
                               ]
                             }
                           ],
@@ -1625,40 +1593,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::Or"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::And"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "67.5"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<=",
-                                        "112.5"
-                                      ]
-                                    }
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "67.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "112.5"
                               ]
                             }
                           ],
@@ -1725,8 +1677,8 @@
                                       "parameters": [
                                         "Object",
                                         "Behavior",
-                                        "<=",
-                                        "-157.5"
+                                        ">=",
+                                        "-180"
                                       ]
                                     },
                                     {
@@ -1736,8 +1688,8 @@
                                       "parameters": [
                                         "Object",
                                         "Behavior",
-                                        ">=",
-                                        "-180"
+                                        "<",
+                                        "-157.5"
                                       ]
                                     }
                                   ]
@@ -1755,8 +1707,8 @@
                                       "parameters": [
                                         "Object",
                                         "Behavior",
-                                        "<=",
-                                        "180"
+                                        ">=",
+                                        "157.5"
                                       ]
                                     },
                                     {
@@ -1766,8 +1718,8 @@
                                       "parameters": [
                                         "Object",
                                         "Behavior",
-                                        ">=",
-                                        "157.5"
+                                        "<",
+                                        "180"
                                       ]
                                     }
                                   ]
@@ -1821,40 +1773,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::Or"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::And"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        "<=",
-                                        "22.5"
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                      },
-                                      "parameters": [
-                                        "Object",
-                                        "Behavior",
-                                        ">=",
-                                        "-22.5"
-                                      ]
-                                    }
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-22.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "22.5"
                               ]
                             }
                           ],
@@ -1904,32 +1840,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::And"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">",
-                                    "-67.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-22.5"
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-67.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "-22.5"
                               ]
                             }
                           ],
@@ -1979,32 +1907,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::And"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-112.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">",
-                                    "-157.5"
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "-157.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "-112.5"
                               ]
                             }
                           ],
@@ -2054,32 +1974,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::And"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "157.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">",
-                                    "112.5"
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "112.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "157.5"
                               ]
                             }
                           ],
@@ -2129,32 +2041,24 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::And"
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
                               },
-                              "parameters": [],
-                              "subInstructions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "67.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">",
-                                    "22.5"
-                                  ]
-                                }
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ">=",
+                                "22.5"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "<",
+                                "67.5"
                               ]
                             }
                           ],


### PR DESCRIPTION
## Changes

- Fix the angle range on the "UP" condition
- Require joystick to be pushed from the center
- Change the wording from "Activate" to "Animate" since it must run every frame, not a one-time event

## Playable game
I built a better game to test these conditions:

4-way test
https://liluo.io/instant-builds/f8059352-1530-482c-82ca-ed427817d372

8-way test
https://liluo.io/instant-builds/8f33a138-221a-40e7-95bb-8fec365c5265

## Project files

[Multitouch-fixes.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/9915487/Multitouch-fixes.zip)

## Video

https://user-images.githubusercontent.com/8879811/199383607-76332db0-0dee-4171-9759-c068cb444318.mp4

