### PR TITLE
[Reviewed] [Multitouch joystick] Add a multitouch controller mapper behavior for platformer characters.

### DIFF
--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -50,62 +50,6 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "fullName": "",
-      "functionType": "Action",
-      "name": "onFirstSceneLoaded",
-      "sentence": "",
-      "events": [
-        {
-          "disabled": true,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": true,
-                "value": "BuiltinCommonInstructions::Always"
-              },
-              "parameters": [
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "BuiltinCommonInstructions::CompareNumbers"
-              },
-              "parameters": [
-                "MultitouchJoystick::JoystickForce(0,\"\")",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "BuiltinCommonInstructions::CompareNumbers"
-              },
-              "parameters": [
-                "MultitouchJoystick::JoystickAngle(0,\"\")",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "BuiltinCommonInstructions::CompareNumbers"
-              },
-              "parameters": [
-                "MultitouchJoystick::DeadZone(0,\"\")",
-                "=",
-                "0"
-              ]
-            }
-          ],
-          "actions": []
-        }
-      ],
-      "parameters": [],
-      "objectGroups": []
-    },
-    {
       "description": "Check if a button is pressed on a gamepad.",
       "fullName": "Multitouch controller button pressed",
       "functionType": "Condition",
@@ -1234,64 +1178,6 @@
           "name": "onCreated",
           "sentence": "",
           "events": [
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "This is necessary because of a bug. It can be removed after the 5.1.152 release of GDevelop.",
-              "comment2": ""
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "BuiltinCommonInstructions::Always"
-                  },
-                  "parameters": [
-                    ""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareNumbers"
-                  },
-                  "parameters": [
-                    "MultitouchJoystick::JoystickForce(0,\"\")",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareNumbers"
-                  },
-                  "parameters": [
-                    "MultitouchJoystick::JoystickAngle(0,\"\")",
-                    "=",
-                    "0"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareNumbers"
-                  },
-                  "parameters": [
-                    "MultitouchJoystick::DeadZone(0,\"\")",
-                    "=",
-                    "0"
-                  ]
-                }
-              ],
-              "actions": []
-            },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
@@ -3723,7 +3609,6 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": true,
                             "value": "MultitouchJoystick::MultitouchButton::IsReleased"
                           },
                           "parameters": [

--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -8,7 +8,7 @@
   "name": "MultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Activate a joystick or buttons that can be controlled by interacting with a touchscreen.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": [
     "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.",
     "",
@@ -48,7 +48,1179 @@
     "v0YRpdAnIucZFgiRCCecqVnGKno2"
   ],
   "dependencies": [],
-  "eventsFunctions": [],
+  "eventsFunctions": [
+    {
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onFirstSceneLoaded",
+      "sentence": "",
+      "events": [
+        {
+          "disabled": true,
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "BuiltinCommonInstructions::Always"
+              },
+              "parameters": [
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareNumbers"
+              },
+              "parameters": [
+                "MultitouchJoystick::JoystickForce(0,\"\")",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareNumbers"
+              },
+              "parameters": [
+                "MultitouchJoystick::JoystickAngle(0,\"\")",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareNumbers"
+              },
+              "parameters": [
+                "MultitouchJoystick::DeadZone(0,\"\")",
+                "=",
+                "0"
+              ]
+            }
+          ],
+          "actions": []
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if a button is pressed on a gamepad.",
+      "fullName": "Multitouch controller button pressed",
+      "functionType": "Condition",
+      "name": "IsButtonPressed",
+      "sentence": "Button _PARAM2_ of multitouch controller _PARAM1_ is pressed",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "VarSceneTxt"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Buttons[GetArgumentAsString(\"Button\")].State",
+                "=",
+                "\"Pressed\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Button name",
+          "name": "Button",
+          "supplementaryInformation": "[\"A\",\"CROSS\",\"B\",\"CIRCLE\",\"X\",\"SQUARE\",\"Y\",\"TRIANGLE\",\"LB\",\"L1\",\"RB\",\"R1\",\"LT\",\"L2\",\"RT\",\"R2\",\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\",\"BACK\",\"SHARE\",\"START\",\"OPTIONS\",\"CLICK_STICK_LEFT\",\"CLICK_STICK_RIGHT\",\"PS_BUTTON\",\"CLICK_TOUCHPAD\"]",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if a button is released on a gamepad.",
+      "fullName": "Multitouch controller button released",
+      "functionType": "Condition",
+      "name": "IsButtonReleased",
+      "sentence": "Button _PARAM2_ of multitouch controller _PARAM1_ is released",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "VarSceneTxt"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Buttons[GetArgumentAsString(\"Button\")].State",
+                "=",
+                "\"Released\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Button name",
+          "name": "Button",
+          "supplementaryInformation": "[\"A\",\"CROSS\",\"B\",\"CIRCLE\",\"X\",\"SQUARE\",\"Y\",\"TRIANGLE\",\"LB\",\"L1\",\"RB\",\"R1\",\"LT\",\"L2\",\"RT\",\"R2\",\"UP\",\"DOWN\",\"LEFT\",\"RIGHT\",\"BACK\",\"SHARE\",\"START\",\"OPTIONS\",\"CLICK_STICK_LEFT\",\"CLICK_STICK_RIGHT\",\"PS_BUTTON\",\"CLICK_TOUCHPAD\"]",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change a button state for a multitouch controller.",
+      "fullName": "Button state",
+      "functionType": "Action",
+      "name": "SetButtonState",
+      "private": true,
+      "sentence": "Mark _PARAM2_ button as _PARAM3_ for multitouch controller _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Buttons[GetArgumentAsString(\"Button\")].State",
+                "=",
+                "GetArgumentAsString(\"ButtonState\")"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Button name",
+          "name": "Button",
+          "type": "string"
+        },
+        {
+          "description": "Button state",
+          "name": "ButtonState",
+          "supplementaryInformation": "[\"Idle\",\"Pressed\",\"Released\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the dead zone radius of a joystick. The deadzone is an area for which movement on sticks won't be taken into account (instead, the stick will be considered as not moved).",
+      "fullName": "Dead zone radius",
+      "functionType": "Action",
+      "name": "SetDeadZone",
+      "private": true,
+      "sentence": "Change the dead zone of multitouch joystick _PARAM2_ of multitouch controller _PARAM1_ to _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].DeadZone",
+                "=",
+                "GetArgumentAsNumber(\"DeadZoneRadius\")"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        },
+        {
+          "description": "Dead zone radius",
+          "name": "DeadZoneRadius",
+          "supplementaryInformation": "[]",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Return the dead zone radius of a joystick. The deadzone is an area for which movement on sticks won't be taken into account (instead, the stick will be considered as not moved).",
+      "fullName": "Dead zone radius",
+      "functionType": "Expression",
+      "name": "DeadZone",
+      "private": true,
+      "sentence": "Change multitouch joystick _PARAM2_ of multitouch controller _PARAM1_ dead zone to _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].DeadZone)"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "the direction index (left = 1, bottom = 1, right = 2, top = 3) for an angle (in degrees).",
+      "fullName": "Angle to 4-way index",
+      "functionType": "ExpressionAndCondition",
+      "name": "AngleTo4Way",
+      "private": true,
+      "sentence": "The angle _PARAM1_ 4-way index",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "mod(round(GetArgumentAsNumber(\"Angle\") * 4 / 360), 4)"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Angle",
+          "name": "Angle",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "the direction index (left = 1, bottom-left = 1... top-left = 7) for an angle (in degrees).",
+      "fullName": "Angle to 8-way index",
+      "functionType": "ExpressionAndCondition",
+      "name": "AngleTo8Way",
+      "private": true,
+      "sentence": "The angle _PARAM1_ 8-way index",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "mod(round(GetArgumentAsNumber(\"Angle\") * 8 / 360), 8)"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Angle",
+          "name": "Angle",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if angle is in a given direction.",
+      "fullName": "Angle 4-way direction",
+      "functionType": "Condition",
+      "name": "Angle4WayDirection",
+      "private": true,
+      "sentence": "The angle _PARAM1_ is the 4-way direction _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Right\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo4Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "0",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Down\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo4Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "1",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Left\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo4Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "2",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Up\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo4Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "3",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Angle",
+          "name": "Angle",
+          "type": "expression"
+        },
+        {
+          "description": "Direction",
+          "name": "Direction",
+          "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if angle is in a given direction.",
+      "fullName": "Angle 8-way direction",
+      "functionType": "Condition",
+      "name": "Angle8WayDirection",
+      "private": true,
+      "sentence": "The angle _PARAM1_ is the 8-way direction _PARAM2_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Right\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "0",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"DownRight\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "1",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Down\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "2",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"DownLeft\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "3",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Left\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "4",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"UpLeft\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "5",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"Up\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "6",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "GetArgumentAsString(\"Direction\")",
+                "=",
+                "\"UpRight\""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::AngleTo8Way"
+              },
+              "parameters": [
+                "",
+                "=",
+                "7",
+                "GetArgumentAsNumber(\"Angle\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Angle",
+          "name": "Angle",
+          "type": "expression"
+        },
+        {
+          "description": "Direction",
+          "name": "Direction",
+          "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\",\"UpLeft\",\"UpRight\",\"DownLeft\",\"DownRight\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if joystick is pushed in a given direction.",
+      "fullName": "Joystick pushed in a direction (4-way)",
+      "functionType": "Condition",
+      "name": "DirectionPushed4Way",
+      "sentence": "Joystick _PARAM2_ of multitouch controller _PARAM1_ is pushed in direction _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Make sure the joystick has moved from center",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "MultitouchJoystick::JoystickForce"
+              },
+              "parameters": [
+                "",
+                ">",
+                "MultitouchJoystick::DeadZone(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
+                "GetArgumentAsNumber(\"ControllerIdentifier\")",
+                "GetArgumentAsString(\"JoystickIdentifier\")",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::Angle4WayDirection"
+              },
+              "parameters": [
+                "",
+                "MultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
+                "GetArgumentAsString(\"Direction\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        },
+        {
+          "description": "Direction",
+          "name": "Direction",
+          "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if joystick is pushed in a given direction.",
+      "fullName": "Joystick pushed in a direction (8-way)",
+      "functionType": "Condition",
+      "name": "DirectionPushed8Way",
+      "sentence": "Joystick _PARAM2_ of multitouch controller _PARAM1_ is pushed in direction _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Make sure the joystick has moved from center",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "MultitouchJoystick::JoystickForce"
+              },
+              "parameters": [
+                "",
+                ">",
+                "MultitouchJoystick::DeadZone(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
+                "GetArgumentAsNumber(\"ControllerIdentifier\")",
+                "GetArgumentAsString(\"JoystickIdentifier\")",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "MultitouchJoystick::Angle8WayDirection"
+              },
+              "parameters": [
+                "",
+                "MultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
+                "GetArgumentAsString(\"Direction\")",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
+          "type": "string"
+        },
+        {
+          "description": "Direction",
+          "name": "Direction",
+          "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\",\"UpLeft\",\"UpRight\",\"DownLeft\",\"DownRight\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "the percentage the thumb has been pulled away from the joystick center (Range: 0 to 1).",
+      "fullName": "Joystick force",
+      "functionType": "ExpressionAndCondition",
+      "name": "JoystickForce",
+      "sentence": "Joystick _PARAM2_ of multitouch controller _PARAM1_ force",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Force)"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the percentage the thumb has been pulled away from the joystick center (Range: 0 to 1).",
+      "fullName": "Joystick force",
+      "functionType": "Action",
+      "name": "SetJoystickForce",
+      "private": true,
+      "sentence": "Change the force of the joystick _PARAM2_ of multitouch controller _PARAM1_ to _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Force",
+                "=",
+                "GetArgumentAsNumber(\"Value\")"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        },
+        {
+          "description": "Value",
+          "name": "Value",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Return the angle the joystick is pointing towards (Range: -180 to 180).",
+      "fullName": "Joystick angle",
+      "functionType": "Expression",
+      "name": "JoystickAngle",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Angle)"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the angle the joystick is pointing towards (Range: -180 to 180).",
+      "fullName": "Joystick angle",
+      "functionType": "Action",
+      "name": "SetJoystickAngle",
+      "private": true,
+      "sentence": "Change the angle of the joystick _PARAM2_ of multitouch controller _PARAM1_ to _PARAM3_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Angle",
+                "=",
+                "GetArgumentAsNumber(\"Value\")"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "name": "ControllerIdentifier",
+          "type": "expression"
+        },
+        {
+          "description": "Joystick name",
+          "name": "JoystickIdentifier",
+          "type": "string"
+        },
+        {
+          "description": "Value",
+          "name": "Value",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
   "eventsBasedBehaviors": [
     {
       "description": "Activate a joystick that can be controlled by interacting with a touchscreen.",
@@ -63,6 +1235,64 @@
           "sentence": "",
           "events": [
             {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "This is necessary because of a bug. It can be removed after the 5.1.152 release of GDevelop.",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "BuiltinCommonInstructions::Always"
+                  },
+                  "parameters": [
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "MultitouchJoystick::JoystickForce(0,\"\")",
+                    "=",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "MultitouchJoystick::JoystickAngle(0,\"\")",
+                    "=",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "MultitouchJoystick::DeadZone(0,\"\")",
+                    "=",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": []
+            },
+            {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
@@ -75,6 +1305,18 @@
                     "Behavior",
                     "=",
                     "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::SetDeadZone"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJoystickIdentifier()",
+                    "Object.Behavior::PropertyDeadZoneRadius()",
+                    ""
                   ]
                 }
               ]
@@ -533,6 +1775,18 @@
                                 "=",
                                 "0"
                               ]
+                            },
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::SetJoystickForce"
+                              },
+                              "parameters": [
+                                "",
+                                "Object.Behavior::PropertyControllerIdentifier()",
+                                "Object.Behavior::PropertyJoystickIdentifier()",
+                                "Object.Behavior::PropertyJoystickForce()",
+                                ""
+                              ]
                             }
                           ]
                         }
@@ -610,6 +1864,18 @@
                             "=",
                             "AngleBetweenPositions(Object.CenterX(),Object.CenterY(),TouchX(Object.Behavior::PropertyTouchID(),Object.Layer(),0),TouchY(Object.Behavior::PropertyTouchID(),Object.Layer(),0))"
                           ]
+                        },
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::SetJoystickAngle"
+                          },
+                          "parameters": [
+                            "",
+                            "Object.Behavior::PropertyControllerIdentifier()",
+                            "Object.Behavior::PropertyJoystickIdentifier()",
+                            "Object.Behavior::PropertyJoystickAngle()",
+                            ""
+                          ]
                         }
                       ]
                     },
@@ -669,6 +1935,18 @@
                             "Behavior",
                             "=",
                             "clamp(Object. Behavior::PropertyTouchDistance() / Object.Width()*2,0,1)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::SetJoystickForce"
+                          },
+                          "parameters": [
+                            "",
+                            "Object.Behavior::PropertyControllerIdentifier()",
+                            "Object.Behavior::PropertyJoystickIdentifier()",
+                            "Object.Behavior::PropertyJoystickForce()",
+                            ""
                           ]
                         }
                       ]
@@ -1080,342 +2358,35 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
                   },
                   "parameters": [
-                    "Object.Behavior::JoystickForce()",
+                    "Object",
+                    "Behavior",
                     ">",
-                    "0"
+                    "Object.Behavior::PropertyDeadZoneRadius()"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::Angle4WayDirection"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::JoystickAngle()",
+                    "GetArgumentAsString(\"Direction\")",
+                    ""
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "colorB": 224,
-                  "colorG": 16,
-                  "colorR": 189,
-                  "creationTime": 0,
-                  "name": "Range (-180 to 180)",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Up",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Up\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-135"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-45"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Down",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Down\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "45"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "135"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Left",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Left\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::Or"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "BuiltinCommonInstructions::And"
-                                      },
-                                      "parameters": [],
-                                      "subInstructions": [
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            ">=",
-                                            "-180"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            "<",
-                                            "-135"
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "BuiltinCommonInstructions::And"
-                                      },
-                                      "parameters": [],
-                                      "subInstructions": [
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            ">=",
-                                            "135"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            "<",
-                                            "180"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Right",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Right\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-45"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "45"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    }
-                  ],
-                  "parameters": []
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
                 }
               ]
             }
@@ -1466,610 +2437,35 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
                   },
                   "parameters": [
-                    "Object.Behavior::JoystickForce()",
+                    "Object",
+                    "Behavior",
                     ">",
-                    "0"
+                    "Object.Behavior::PropertyDeadZoneRadius()"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::Angle8WayDirection"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::JoystickAngle()",
+                    "GetArgumentAsString(\"Direction\")",
+                    ""
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "colorB": 224,
-                  "colorG": 16,
-                  "colorR": 189,
-                  "creationTime": 0,
-                  "name": "Range (-180 to 180)",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Up",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Up\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-112.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-67.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Down",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Down\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "67.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "112.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Left",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Left\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "BuiltinCommonInstructions::Or"
-                                  },
-                                  "parameters": [],
-                                  "subInstructions": [
-                                    {
-                                      "type": {
-                                        "value": "BuiltinCommonInstructions::And"
-                                      },
-                                      "parameters": [],
-                                      "subInstructions": [
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            ">=",
-                                            "-180"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            "<",
-                                            "-157.5"
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": {
-                                        "value": "BuiltinCommonInstructions::And"
-                                      },
-                                      "parameters": [],
-                                      "subInstructions": [
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            ">=",
-                                            "157.5"
-                                          ]
-                                        },
-                                        {
-                                          "type": {
-                                            "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                          },
-                                          "parameters": [
-                                            "Object",
-                                            "Behavior",
-                                            "<",
-                                            "180"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "Right",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"Right\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-22.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "22.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "UpRight",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"UpRight\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-67.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-22.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "UpLeft",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"UpLeft\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "-157.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "-112.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "DownLeft",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"DownLeft\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "112.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "157.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    },
-                    {
-                      "colorB": 228,
-                      "colorG": 176,
-                      "colorR": 74,
-                      "creationTime": 0,
-                      "name": "DownRight",
-                      "source": "",
-                      "type": "BuiltinCommonInstructions::Group",
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareStrings"
-                              },
-                              "parameters": [
-                                "GetArgumentAsString(\"Direction\")",
-                                "=",
-                                "\"DownRight\""
-                              ]
-                            }
-                          ],
-                          "actions": [],
-                          "events": [
-                            {
-                              "type": "BuiltinCommonInstructions::Standard",
-                              "conditions": [
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    ">=",
-                                    "22.5"
-                                  ]
-                                },
-                                {
-                                  "type": {
-                                    "value": "MultitouchJoystick::MultitouchJoystick::PropertyJoystickAngle"
-                                  },
-                                  "parameters": [
-                                    "Object",
-                                    "Behavior",
-                                    "<",
-                                    "67.5"
-                                  ]
-                                }
-                              ],
-                              "actions": [
-                                {
-                                  "type": {
-                                    "value": "SetReturnBoolean"
-                                  },
-                                  "parameters": [
-                                    "True"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "parameters": []
-                    }
-                  ],
-                  "parameters": []
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
                 }
               ]
             }
@@ -2407,10 +2803,11 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls.",
+          "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls. This action is deprecated.",
           "fullName": "Simulate a touch on joystick (based on position)",
           "functionType": "Action",
           "name": "SimulateTouch_Position",
+          "private": true,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ at position: _PARAM3_,_PARAM4_",
           "events": [
             {
@@ -2689,10 +3086,11 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls.",
+          "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls. This action is deprecated.",
           "fullName": "Simulate a touch on joystick (based on angle and force)",
           "functionType": "Action",
           "name": "SimulateTouch_AngleForce",
+          "private": true,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ to angle _PARAM3_ and force _PARAM4_",
           "events": [
             {
@@ -2864,10 +3262,11 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch ended.",
+          "description": "Simulate a touch ended. This action is deprecated.",
           "fullName": "Simulate a touch ended",
           "functionType": "Action",
           "name": "SimulateTouchEnded",
+          "private": true,
           "sentence": "Simulate a touch ended on joystick _PARAM0_ with thumb _PARAM2_",
           "events": [
             {
@@ -3017,6 +3416,56 @@
       ],
       "propertyDescriptors": [
         {
+          "value": "1",
+          "type": "Number",
+          "label": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ControllerIdentifier"
+        },
+        {
+          "value": "Primary",
+          "type": "String",
+          "label": "Joystick name",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "JoystickIdentifier"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Floating (allow joystick to be moved by dragging)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloatingEnabled"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Floating (allow joystick to be moved by dragging)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "FloatingEnabled"
+        },
+        {
+          "value": "0.4",
+          "type": "Number",
+          "label": "Dead zone radius (range: 0 to 1)",
+          "description": "The deadzone is an area for which movement on sticks won't be taken into account (instead, the stick will be considered as not moved)",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "DeadZoneRadius"
+        },
+        {
           "value": "0",
           "type": "Number",
           "label": "Joystick angle (range: -180 to 180)",
@@ -3065,16 +3514,6 @@
           "extraInformation": [],
           "hidden": true,
           "name": "TouchDistance"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Floating (allow joystick to be moved by dragging)",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": false,
-          "name": "FloatingEnabled"
         },
         {
           "value": "",
@@ -3219,6 +3658,17 @@
                                     "Behavior",
                                     "yes"
                                   ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MultitouchJoystick::MultitouchButton::SetButtonState"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "\"Pressed\"",
+                                    ""
+                                  ]
                                 }
                               ]
                             },
@@ -3270,7 +3720,19 @@
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "MultitouchJoystick::MultitouchButton::IsReleased"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ],
                       "actions": [
                         {
                           "type": {
@@ -3280,6 +3742,17 @@
                             "Object",
                             "Behavior",
                             "no"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "MultitouchJoystick::MultitouchButton::SetButtonState"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "\"Idle\"",
+                            ""
                           ]
                         }
                       ]
@@ -3325,6 +3798,17 @@
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
+                            {
+                              "type": {
+                                "value": "MultitouchJoystick::MultitouchButton::SetButtonState"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "\"Released\"",
+                                ""
+                              ]
+                            },
                             {
                               "type": {
                                 "value": "MultitouchJoystick::MultitouchButton::SetPropertyIsPressed"
@@ -3477,10 +3961,11 @@
           "objectGroups": []
         },
         {
-          "description": "Change button to pressed.",
+          "description": "Change button to pressed. This action is deprecated.",
           "fullName": "Change button to pressed",
           "functionType": "Action",
           "name": "SetPressed",
+          "private": true,
           "sentence": "Change button _PARAM0_ to pressed: _PARAM2_",
           "events": [
             {
@@ -3578,6 +4063,23 @@
                   ]
                 }
               ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::MultitouchButton::SetButtonState"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "\"Pressed\"",
+                    ""
+                  ]
+                }
+              ]
             }
           ],
           "parameters": [
@@ -3599,9 +4101,76 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "fullName": "Button state",
+          "functionType": "Action",
+          "name": "SetButtonState",
+          "private": true,
+          "sentence": "Mark the button _PARAM0_ as _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::SetButtonState"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyButtonIdentifier()",
+                    "GetArgumentAsString(\"ButtonState\")",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "MultitouchJoystick::MultitouchButton",
+              "type": "behavior"
+            },
+            {
+              "description": "Button state",
+              "name": "ButtonState",
+              "supplementaryInformation": "[\"Idle\",\"Pressed\",\"Released\"]",
+              "type": "stringWithSelector"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
+        {
+          "value": "1",
+          "type": "Number",
+          "label": "Multitouch controller identifier (1, 2, 3, 4...)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ControllerIdentifier"
+        },
+        {
+          "value": "A",
+          "type": "String",
+          "label": "Button identifier",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ButtonIdentifier"
+        },
         {
           "value": "",
           "type": "Boolean",
@@ -3651,6 +4220,229 @@
           "extraInformation": [],
           "hidden": true,
           "name": "IsReleased"
+        }
+      ],
+      "sharedPropertyDescriptors": []
+    },
+    {
+      "description": "Control a platformer character with a multitouch controller.",
+      "fullName": "Platformer multitouch controller mapper",
+      "name": "PlatformerMultitouchMapper",
+      "objectType": "",
+      "eventsFunctions": [
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::DirectionPushed4Way"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJoystickIdentifier()",
+                    "\"Left\"",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateLeftKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::DirectionPushed4Way"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJoystickIdentifier()",
+                    "\"Right\"",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateRightKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::DirectionPushed4Way"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJoystickIdentifier()",
+                    "\"Up\"",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateUpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateLadderKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::DirectionPushed4Way"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJoystickIdentifier()",
+                    "\"Down\"",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateDownKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "MultitouchJoystick::IsButtonPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Object.Behavior::PropertyControllerIdentifier()",
+                    "Object.Behavior::PropertyJumpButton()",
+                    "\"Down\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PlatformBehavior::SimulateJumpKey"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Property"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "MultitouchJoystick::PlatformerMultitouchMapper",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "Platform character behavior",
+          "description": "",
+          "group": "",
+          "extraInformation": [
+            "PlatformBehavior::PlatformerObjectBehavior"
+          ],
+          "hidden": false,
+          "name": "Property"
+        },
+        {
+          "value": "1",
+          "type": "Number",
+          "label": "Controller identifier (1, 2, 3, 4...)",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "ControllerIdentifier"
+        },
+        {
+          "value": "Primary",
+          "type": "String",
+          "label": "Joystick name",
+          "description": "",
+          "group": "Controls",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "JoystickIdentifier"
+        },
+        {
+          "value": "A",
+          "type": "String",
+          "label": "Jump button name",
+          "description": "",
+          "group": "Controls",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "JumpButton"
         }
       ],
       "sharedPropertyDescriptors": []

--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -1,7 +1,6 @@
 {
   "author": "",
   "category": "Input",
-  "description": "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.\n\nMulitouch buttons can be used whenever a game allows the user to press multiple locations at once.\n\nHow to use:\n\n- Add the joystick behavior to a sprite that will be the joystick \n- Place the joystick object on the scene\n- Run the \"Activate joystick\" action on every frame and specify the thumb object\n- The joystick thumb object will automatically be created and moved\n\nTips:\n\n- Use \"Simulate a touch\" functions to provide mouse and gamepad controls\n- More than one joystick or button can be used at the same time\n- Joystick and thumb objects should have all sides the same length\n- Thumb object must be smaller than the joystick object",
   "extensionNamespace": "",
   "fullName": "Multitouch joystick and buttons",
   "helpPath": "https://wiki.gdevelop.io/gdevelop5/extensions/multitouch-joystick/start",
@@ -10,6 +9,25 @@
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Activate a joystick or buttons that can be controlled by interacting with a touchscreen.",
   "version": "1.1.1",
+  "description": [
+    "Users can interact with the multitouch joystick to specify angle and force values.  These values can be used to control other objects in the scene such as movement and rotation, such as for twin-stick shooter games.",
+    "",
+    "Mulitouch buttons can be used whenever a game allows the user to press multiple locations at once.",
+    "",
+    "How to use:",
+    "",
+    "- Add the joystick behavior to a sprite that will be the joystick ",
+    "- Place the joystick object on the scene",
+    "- Run the \"Activate joystick\" action on every frame and specify the thumb object",
+    "- The joystick thumb object will automatically be created and moved",
+    "",
+    "Tips:",
+    "",
+    "- Use \"Simulate a touch\" functions to provide mouse and gamepad controls",
+    "- More than one joystick or button can be used at the same time",
+    "- Joystick and thumb objects should have all sides the same length",
+    "- Thumb object must be smaller than the joystick object"
+  ],
   "origin": {
     "identifier": "MultitouchJoystick",
     "name": "gdevelop-extension-store"
@@ -39,12 +57,9 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "onCreated",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -67,22 +82,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -90,12 +96,9 @@
           "objectGroups": []
         },
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "onActivate",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -118,22 +121,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -144,9 +138,7 @@
           "description": "Animate multitouch joystick.",
           "fullName": "Animate multitouch joystick",
           "functionType": "Action",
-          "group": "",
           "name": "ActivateJoystick",
-          "private": false,
           "sentence": "Animate joystick _PARAM0_ using _PARAM2_ as the thumbstick",
           "events": [
             {
@@ -911,33 +903,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Joystick thumb",
-              "longDescription": "",
               "name": "JoystickThumb",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "objectList"
             }
           ],
@@ -947,9 +925,7 @@
           "description": "Percentage the thumb has been pulled away from the joystick center (Range: 0 to 1).",
           "fullName": "Joystick force",
           "functionType": "Expression",
-          "group": "",
           "name": "JoystickForce",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -967,24 +943,18 @@
               ]
             }
           ],
+          "expressionType": {
+            "type": "expression"
+          },
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -995,9 +965,7 @@
           "description": "Angle the joystick is pointing towards (Range: -180 to 180).",
           "fullName": "Joystick angle",
           "functionType": "Expression",
-          "group": "",
           "name": "JoystickAngle",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -1015,24 +983,18 @@
               ]
             }
           ],
+          "expressionType": {
+            "type": "expression"
+          },
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -1043,9 +1005,7 @@
           "description": "Check if joystick force is greater or equal to a value.",
           "fullName": "Joystick force",
           "functionType": "Condition",
-          "group": "",
           "name": "CheckJoystickForce",
-          "private": false,
           "sentence": "Force of _PARAM0_ is  greater or equal to _PARAM2_",
           "events": [
             {
@@ -1076,32 +1036,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Joystick force (Range: 0 to 1)",
-              "longDescription": "",
               "name": "Force",
-              "optional": false,
               "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
               "type": "expression"
             }
@@ -1112,9 +1059,7 @@
           "description": "Check if joystick is pushed in a given direction.",
           "fullName": "Joystick pushed in a direction (4-way movement)",
           "functionType": "Condition",
-          "group": "",
           "name": "DirectionPushed",
-          "private": false,
           "sentence": "_PARAM0_ is pushed in direction _PARAM2_",
           "events": [
             {
@@ -1477,32 +1422,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Direction",
-              "longDescription": "",
               "name": "Direction",
-              "optional": false,
               "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\"]",
               "type": "stringWithSelector"
             }
@@ -1513,9 +1445,7 @@
           "description": "Check if joystick is pushed in a given direction.",
           "fullName": "Joystick pushed in a direction (8-way movement)",
           "functionType": "Condition",
-          "group": "",
           "name": "DirectionPushed8Way",
-          "private": false,
           "sentence": "_PARAM0_ is pushed in direction _PARAM2_",
           "events": [
             {
@@ -2146,32 +2076,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Direction",
-              "longDescription": "",
               "name": "Direction",
-              "optional": false,
               "supplementaryInformation": "[\"Up\",\"Down\",\"Left\",\"Right\",\"UpLeft\",\"UpRight\",\"DownLeft\",\"DownRight\"]",
               "type": "stringWithSelector"
             }
@@ -2182,9 +2099,7 @@
           "description": "Check if joystick is floating.",
           "fullName": "Check if joystick is floating",
           "functionType": "Condition",
-          "group": "",
           "name": "IsFloating",
-          "private": false,
           "sentence": "Joystick _PARAM0_ is floating",
           "events": [
             {
@@ -2214,22 +2129,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -2240,9 +2146,7 @@
           "description": "Enable (or disable) floating on a joystick.",
           "fullName": "Enable (or disable) floating on a joystick",
           "functionType": "Action",
-          "group": "",
           "name": "SetFloating",
-          "private": false,
           "sentence": "Enable floating on joystick _PARAM0_: _PARAM2_",
           "events": [
             {
@@ -2299,33 +2203,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Value",
-              "longDescription": "",
               "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "yesorno"
             }
           ],
@@ -2335,9 +2225,7 @@
           "description": "Check if a joystick is pressed.",
           "fullName": "Joystick pressed",
           "functionType": "Condition",
-          "group": "",
           "name": "IsPressed",
-          "private": false,
           "sentence": "Joystick _PARAM0_ is pressed",
           "events": [
             {
@@ -2367,22 +2255,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             }
@@ -2393,9 +2272,7 @@
           "description": "Change joystick to pressed.",
           "fullName": "Change joystick to pressed",
           "functionType": "Action",
-          "group": "",
           "name": "SetPressed",
-          "private": false,
           "sentence": "Change joystick _PARAM0_ to pressed: _PARAM2_",
           "events": [
             {
@@ -2511,33 +2388,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Value",
-              "longDescription": "",
               "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "yesorno"
             }
           ],
@@ -2547,9 +2410,7 @@
           "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls.",
           "fullName": "Simulate a touch on joystick (based on position)",
           "functionType": "Action",
-          "group": "",
           "name": "SimulateTouch_Position",
-          "private": false,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ at position: _PARAM3_,_PARAM4_",
           "events": [
             {
@@ -2799,53 +2660,29 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "JoystickThumb",
-              "longDescription": "",
               "name": "JoystickThumb",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "objectList"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "X position of simulated touch",
-              "longDescription": "",
               "name": "SimulatedTouchX",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Y position of simulated touch",
-              "longDescription": "",
               "name": "SimulatedTouchY",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -2855,9 +2692,7 @@
           "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls.",
           "fullName": "Simulate a touch on joystick (based on angle and force)",
           "functionType": "Action",
-          "group": "",
           "name": "SimulateTouch_AngleForce",
-          "private": false,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ to angle _PARAM3_ and force _PARAM4_",
           "events": [
             {
@@ -3000,53 +2835,29 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "JoystickThumb",
-              "longDescription": "",
               "name": "JoystickThumb",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "objectList"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Angle (Range: -180 to 180)",
-              "longDescription": "",
               "name": "Angle",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Force (Range: 0 to 1)",
-              "longDescription": "",
               "name": "Force",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -3056,9 +2867,7 @@
           "description": "Simulate a touch ended.",
           "fullName": "Simulate a touch ended",
           "functionType": "Action",
-          "group": "",
           "name": "SimulateTouchEnded",
-          "private": false,
           "sentence": "Simulate a touch ended on joystick _PARAM0_ with thumb _PARAM2_",
           "events": [
             {
@@ -3187,33 +2996,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchJoystick",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "JoystickThumb",
-              "longDescription": "",
               "name": "JoystickThumb",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "objectList"
             }
           ],
@@ -3301,7 +3096,8 @@
           "hidden": true,
           "name": "TouchCounter"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     },
     {
       "description": "Detect button presses made from a touchscreen.",
@@ -3310,12 +3106,9 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "doStepPreEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -3576,22 +3369,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchButton",
               "type": "behavior"
             }
@@ -3602,9 +3386,7 @@
           "description": "Check if button is released.",
           "fullName": "Button released",
           "functionType": "Condition",
-          "group": "",
           "name": "IsReleased",
-          "private": false,
           "sentence": "Button _PARAM0_ is released",
           "events": [
             {
@@ -3634,22 +3416,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchButton",
               "type": "behavior"
             }
@@ -3660,9 +3433,7 @@
           "description": "Check if button is pressed.",
           "fullName": "Button pressed",
           "functionType": "Condition",
-          "group": "",
           "name": "IsPressed",
-          "private": false,
           "sentence": "Button _PARAM0_ is pressed",
           "events": [
             {
@@ -3692,22 +3463,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchButton",
               "type": "behavior"
             }
@@ -3718,9 +3480,7 @@
           "description": "Change button to pressed.",
           "fullName": "Change button to pressed",
           "functionType": "Action",
-          "group": "",
           "name": "SetPressed",
-          "private": false,
           "sentence": "Change button _PARAM0_ to pressed: _PARAM2_",
           "events": [
             {
@@ -3822,33 +3582,19 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "MultitouchJoystick::MultitouchButton",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Value",
-              "longDescription": "",
               "name": "Value",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "yesorno"
             }
           ],
@@ -3906,7 +3652,8 @@
           "hidden": true,
           "name": "IsReleased"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
   ],
   "eventsBasedObjects": []

--- a/extensions/reviewed/MultitouchJoystick.json
+++ b/extensions/reviewed/MultitouchJoystick.json
@@ -2689,11 +2689,10 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls. This action is deprecated.",
+          "description": "Simulate a touch on joystick (based on position).  Can be used for mouse controls.",
           "fullName": "Simulate a touch on joystick (based on position)",
           "functionType": "Action",
           "name": "SimulateTouch_Position",
-          "private": true,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ at position: _PARAM3_,_PARAM4_",
           "events": [
             {
@@ -2972,11 +2971,10 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls. This action is deprecated.",
+          "description": "Simulate a touch on joystick (based on angle and force).  Can be used for gamepad controls.",
           "fullName": "Simulate a touch on joystick (based on angle and force)",
           "functionType": "Action",
           "name": "SimulateTouch_AngleForce",
-          "private": true,
           "sentence": "Simulate a touch on joystick _PARAM0_ with thumb _PARAM2_ to angle _PARAM3_ and force _PARAM4_",
           "events": [
             {
@@ -3148,11 +3146,10 @@
           "objectGroups": []
         },
         {
-          "description": "Simulate a touch ended. This action is deprecated.",
+          "description": "Simulate a touch ended.",
           "fullName": "Simulate a touch ended",
           "functionType": "Action",
           "name": "SimulateTouchEnded",
-          "private": true,
           "sentence": "Simulate a touch ended on joystick _PARAM0_ with thumb _PARAM2_",
           "events": [
             {


### PR DESCRIPTION
### Changes
- Add properties on the stick and button behaviors to identify a controller.
- Add free condition and expression for these controllers (a bit like the gamepad extension).
- Add a behavior to map a controller to a platformer character.

### Example
- https://github.com/GDevelopApp/GDevelop-examples/pull/415