### PR TITLE
[ShadowClones] [Reviewed] Added the ability to match horizontal and vertical flip of a sprite (thanks @fuzzystudios)

### DIFF
--- a/extensions/reviewed/ShadowClones.json
+++ b/extensions/reviewed/ShadowClones.json
@@ -1,7 +1,6 @@
 {
   "author": "Tristan Rhodes (https://victrisgames.itch.io/) and Entropy (https://www.youtube.com/channel/UClvkb12nOWFgWnQ56NF9Rcw)",
   "category": "Visual effect",
-  "description": "Select the primary object, the shadow clone object, the number of shadow clones, the number of frames between shadow clones, the rate that shadow clones will reduce opacity and size (if desired), the Z-value and the layer the shadow clones will be created on.\n\nThis extension can be used to:\n\n- Make an object look faster, such as during a speed powerup.  \n- Give a 3D-like feel to a character\n- Implement unique time-based elements, like teleporting a character back to a previous location\n- Simulate the movement of a caterpillar or slinky\n- Recreate games like snake or tron\n\nThese object variables are provided to manage the shadow clones:\n\n- ShadowCloneOrder: Shadow clone identifier, where 1 is the shadow clone closest to the primary object\n- FramesBehindPrimary: The number of frames that the shadow clone is behind the primary object\n\nNotes: \n- For shadow clones to work, this action must be run every frame.\n- The ShadowCloneObject cannot be the PrimaryObject, but it can be a duplicate object. \n- For animations to work, the PrimaryObject and ShadowCloneObject must use the same animation numbers.\n\nWatch this [tutorial video](https://youtu.be/2t4ANYgrrak) to see examples of how to use this extension.",
   "extensionNamespace": "",
   "fullName": "Animate Shadow Clones",
   "helpPath": "https://www.youtube.com/watch?v=2t4ANYgrrak",
@@ -9,7 +8,34 @@
   "name": "ShadowClones",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/vector-arrange-above.svg",
   "shortDescription": "Create and animate shadow clones that follow the path of a primary object.",
-  "version": "0.5.3",
+  "version": "0.6.0",
+  "description": [
+    "Select the primary object, the shadow clone object, the number of shadow clones, the number of frames between shadow clones, the rate that shadow clones will reduce opacity and size (if desired), the Z-value and the layer the shadow clones will be created on.",
+    "",
+    "This extension can be used to:",
+    "",
+    "- Make an object look faster, such as during a speed powerup.  ",
+    "- Give a 3D-like feel to a character",
+    "- Implement unique time-based elements, like teleporting a character back to a previous location",
+    "- Simulate the movement of a caterpillar or slinky",
+    "- Recreate games like snake or tron",
+    "",
+    "These object variables are provided to manage the shadow clones:",
+    "",
+    "- ShadowCloneOrder: Shadow clone identifier, where 1 is the shadow clone closest to the primary object",
+    "- FramesBehindPrimary: The number of frames that the shadow clone is behind the primary object",
+    "",
+    "Notes: ",
+    "- For shadow clones to work, this action must be run every frame.",
+    "- The ShadowCloneObject cannot be the PrimaryObject, but it can be a duplicate object. ",
+    "- For animations to work, the PrimaryObject and ShadowCloneObject must use the same animation numbers.",
+    "",
+    "Watch this [tutorial video](https://youtu.be/2t4ANYgrrak) to see examples of how to use this extension."
+  ],
+  "origin": {
+    "identifier": "ShadowClones",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "animate",
     "create",
@@ -21,7 +47,8 @@
   ],
   "authorIds": [
     "q8ubdigLvIRXLxsJDDTaokO41mc2",
-    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
+    "m4hBMBTUilft4s1V4FQQPakVDGx1"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -30,23 +57,18 @@
       "fullName": "Animate shadow clones that follow the path of a primary object",
       "functionType": "Action",
       "name": "AnimateShadowClones",
-      "private": false,
-      "sentence": "Create and animate _PARAM3_ copies of _PARAM2_ that follow the position of _PARAM1_, with _PARAM4_ empty frames between shadow clones, and fading the opacity of shadow clones by _PARAM5_ per clone.  Shrink scale of shadow clones by _PARAM6_ per clone. Shadow clones will be created on _PARAM7_ layer with a Z-value of _PARAM8_.  Match X scale: _PARAM9_  Match Y scale: _PARAM10_  Match angle: _PARAM11_  Match animation: _PARAM12_  Match animation frame: _PARAM13_  ",
+      "sentence": "Create and animate _PARAM3_ copies of _PARAM2_ that follow the position of _PARAM1_, with _PARAM4_ empty frames between shadow clones, and fading the opacity of shadow clones by _PARAM5_ per clone.  Shrink scale of shadow clones by _PARAM6_ per clone. Shadow clones will be created on _PARAM7_ layer with a Z-value of _PARAM8_.  Match X scale: _PARAM9_  Match Y scale: _PARAM10_  Match angle: _PARAM11_  Match animation: _PARAM12_  Match animation frame: _PARAM13_  Match vertical flip: _PARAM14_ Match horizontal flip: _PARAM15_",
       "events": [
         {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
-          "disabled": false,
-          "folded": false,
           "name": "Animate Shadow Clones",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::ForEach",
               "object": "PrimaryObject",
               "conditions": [],
@@ -57,15 +79,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Initialize variables",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -79,14 +97,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -94,12 +109,10 @@
                             "TotalShadowClones",
                             "=",
                             "GetArgumentAsNumber(\"NumberOfShadowClones\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -107,14 +120,11 @@
                             "FramesBetweenShadowClones",
                             "=",
                             "GetArgumentAsNumber(\"FramesBetweenShadowClones\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -128,13 +138,10 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -142,14 +149,12 @@
                                 "FramesBetweenShadowClones",
                                 "<",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -157,15 +162,11 @@
                                 "FramesBetweenShadowClones",
                                 "=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -179,14 +180,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -194,11 +192,9 @@
                                 "MaxFramesBehind",
                                 "=",
                                 "PrimaryObject.Variable(TotalShadowClones)*PrimaryObject.Variable(FramesBetweenShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -210,15 +206,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Create Shadow Clones",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -232,14 +224,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "VarObjet"
                           },
                           "parameters": [
@@ -247,19 +236,16 @@
                             "ClonesCreated",
                             "<",
                             "PrimaryObject.Variable(TotalShadowClones)"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -267,12 +253,10 @@
                                 "ObjectHistory[ToString((PrimaryObject.Variable(ClonesCreated) + 1) * PrimaryObject.Variable(FramesBetweenShadowClones))].xpos",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -280,8 +264,7 @@
                                 "ObjectHistory[ToString((PrimaryObject.Variable(ClonesCreated) + 1) * PrimaryObject.Variable(FramesBetweenShadowClones))].ypos",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ]
                         }
@@ -290,7 +273,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -298,14 +280,11 @@
                             "ClonesCreated",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -319,14 +298,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Create"
                               },
                               "parameters": [
@@ -335,12 +311,10 @@
                                 "PrimaryObject.X()",
                                 "PrimaryObject.Y()",
                                 "GetArgumentAsString(\"ShadowCloneLayer\")"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -348,35 +322,29 @@
                                 "ShadowCloneOrder",
                                 "=",
                                 "PrimaryObject.Variable(ClonesCreated)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangePlan"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "GetArgumentAsNumber(\"ShadowCloneZValue\")"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "LinkedObjects::LinkObjects"
                               },
                               "parameters": [
                                 "",
                                 "PrimaryObject",
                                 "ShadowCloneObject"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -388,36 +356,28 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Change shadow clones based on the history of the PrimaryObject",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::ForEach",
                       "object": "ShadowCloneObject",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "LinkedObjects::PickObjectsLinkedTo"
                           },
                           "parameters": [
                             "",
                             "PrimaryObject",
                             "ShadowCloneObject"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -431,14 +391,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MettreXY"
                               },
                               "parameters": [
@@ -447,47 +404,36 @@
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].xpos)",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].ypos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAngle\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetAngle"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].angle)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -501,52 +447,41 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchScaleX\""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeScaleWidth"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].xscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -560,116 +495,251 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchScaleY\""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeScaleHeight"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].yscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAnimation\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeAnimation"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].animation)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAnimationFrame\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeSprite"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].frame)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "GetArgumentAsBoolean"
+                              },
+                              "parameters": [
+                                "\"MatchHorizontalFlip\""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "ShadowCloneObject",
+                                "horizontalflip",
+                                "=",
+                                "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].horizontalflip)"
+                              ]
+                            }
+                          ],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "ObjectVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "horizontalflip",
+                                    "="
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "FlipX"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "no"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "ObjectVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "horizontalflip",
+                                    "True"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "FlipX"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "yes"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "GetArgumentAsBoolean"
+                              },
+                              "parameters": [
+                                "\"MatchVerticalFlip\""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "ShadowCloneObject",
+                                "verticalflip",
+                                "=",
+                                "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(ShadowCloneOrder)*PrimaryObject.Variable(FramesBetweenShadowClones))].verticalflip)"
+                              ]
+                            }
+                          ],
+                          "events": [
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "ObjectVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "verticalflip",
+                                    "="
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "FlipY"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "no"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [
+                                {
+                                  "type": {
+                                    "value": "ObjectVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "verticalflip",
+                                    "True"
+                                  ]
+                                }
+                              ],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "FlipY"
+                                  },
+                                  "parameters": [
+                                    "ShadowCloneObject",
+                                    "yes"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -683,76 +753,60 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"FadeSpeed\")",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Opacity"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Opacity()-GetArgumentAsNumber(\"FadeSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"FadeSpeed\")",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Opacity"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Opacity()"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -766,72 +820,56 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [],
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleWidth"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleX()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleHeight"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleY()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -845,13 +883,10 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -859,25 +894,21 @@
                                 "ShadowCloneOrder",
                                 ">",
                                 "PrimaryObject.Variable(TotalShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Delete"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -885,11 +916,9 @@
                                 "ClonesCreated",
                                 "-",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -901,15 +930,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Update history of the PrimaryObject ",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -923,14 +948,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -938,48 +960,39 @@
                             "DataCleaningCounter",
                             "=",
                             "PrimaryObject.Variable(MaxFramesBehind)+1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ObjectVariableChildExists"
                           },
                           "parameters": [
                             "PrimaryObject",
                             "ObjectHistory",
                             "ToString(PrimaryObject.Variable(DataCleaningCounter))"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ObjectVariableRemoveChild"
                           },
                           "parameters": [
                             "PrimaryObject",
                             "ObjectHistory",
                             "ToString(PrimaryObject.Variable(DataCleaningCounter))"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -987,15 +1000,11 @@
                             "DataCleaningCounter",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1009,14 +1018,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1024,15 +1030,11 @@
                             "DataMoveCounter",
                             "=",
                             "PrimaryObject.Variable(MaxFramesBehind)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1046,14 +1048,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "VarObjet"
                           },
                           "parameters": [
@@ -1061,16 +1060,13 @@
                             "DataMoveCounter",
                             ">",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "conditions": [],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -1084,14 +1080,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1099,12 +1092,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].xpos",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].xpos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1112,12 +1103,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].ypos",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].ypos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1125,12 +1114,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].angle",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].angle)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1138,12 +1125,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].animation",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].animation)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1151,12 +1136,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].frame",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].frame)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1164,12 +1147,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].xscale",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].xscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1177,12 +1158,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].yscale",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].yscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1190,12 +1169,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].width",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].width)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1203,12 +1180,32 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].height",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].height)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "PrimaryObject",
+                                "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].horizontalflip",
+                                "=",
+                                "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].horizontalflip)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "PrimaryObject",
+                                "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].verticalflip",
+                                "=",
+                                "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].verticalflip)"
+                              ]
+                            },
+                            {
+                              "type": {
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1216,17 +1213,13 @@
                                 "DataMoveCounter",
                                 "-",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1240,14 +1233,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1255,12 +1245,10 @@
                             "ObjectHistory.1.xpos",
                             "=",
                             "PrimaryObject.X()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1268,12 +1256,10 @@
                             "ObjectHistory.1.ypos",
                             "=",
                             "PrimaryObject.Y()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1281,12 +1267,10 @@
                             "ObjectHistory.1.animation",
                             "=",
                             "PrimaryObject.Animation()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1294,12 +1278,10 @@
                             "ObjectHistory.1.frame",
                             "=",
                             "PrimaryObject.Sprite()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1307,12 +1289,10 @@
                             "ObjectHistory.1.angle",
                             "=",
                             "PrimaryObject.Angle()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1320,12 +1300,10 @@
                             "ObjectHistory.1.xscale",
                             "=",
                             "PrimaryObject.ScaleX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1333,12 +1311,10 @@
                             "ObjectHistory.1.yscale",
                             "=",
                             "PrimaryObject.ScaleY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1346,12 +1322,10 @@
                             "ObjectHistory.1.width",
                             "=",
                             "PrimaryObject.Width()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1359,11 +1333,111 @@
                             "ObjectHistory.1.height",
                             "=",
                             "PrimaryObject.Height()"
-                          ],
-                          "subInstructions": []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "FlippedX"
+                          },
+                          "parameters": [
+                            "PrimaryObject"
+                          ]
                         }
                       ],
-                      "events": []
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "PrimaryObject",
+                            "ObjectHistory.1.horizontalflip",
+                            "="
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlippedX"
+                          },
+                          "parameters": [
+                            "PrimaryObject"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "PrimaryObject",
+                            "ObjectHistory.1.horizontalflip",
+                            "True"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "FlippedY"
+                          },
+                          "parameters": [
+                            "PrimaryObject"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "PrimaryObject",
+                            "ObjectHistory.1.verticalflip",
+                            "="
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlippedY"
+                          },
+                          "parameters": [
+                            "PrimaryObject"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "PrimaryObject",
+                            "ObjectHistory.1.verticalflip",
+                            "True"
+                          ]
+                        }
+                      ]
                     }
                   ],
                   "parameters": []
@@ -1385,8 +1459,6 @@
           "type": "BuiltinCommonInstructions::Group",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::ForEach",
               "object": "PrimaryObject",
               "conditions": [],
@@ -1397,15 +1469,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Manage Shadows",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1419,14 +1487,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1434,12 +1499,10 @@
                             "TotalShadowClones",
                             "=",
                             "GetArgumentAsNumber(\"NumberOfShadowClones\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1447,14 +1510,11 @@
                             "FramesBetweenShadowClones",
                             "=",
                             "GetArgumentAsNumber(\"FramesBetweenShadowClones\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -1468,13 +1528,10 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -1482,14 +1539,12 @@
                                 "FramesBetweenShadowClones",
                                 "<",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1497,15 +1552,11 @@
                                 "FramesBetweenShadowClones",
                                 "=",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -1519,14 +1570,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1534,17 +1582,13 @@
                                 "MaxFramesBehind",
                                 "=",
                                 "PrimaryObject.Variable(TotalShadowClones)*PrimaryObject.Variable(FramesBetweenShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -1558,14 +1602,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "VarObjet"
                           },
                           "parameters": [
@@ -1573,19 +1614,16 @@
                             "FrameCounter",
                             "<",
                             "PrimaryObject.Variable(MaxFramesBehind)"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::Or"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -1593,12 +1631,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(FrameCounter)+1)].xpos",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "VarObjet"
                               },
                               "parameters": [
@@ -1606,8 +1642,7 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(FrameCounter)+1)].ypos",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ]
                         }
@@ -1616,7 +1651,6 @@
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -1624,14 +1658,11 @@
                             "FrameCounter",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -1645,27 +1676,22 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "mod(PrimaryObject.Variable(FrameCounter),PrimaryObject.Variable(FramesBetweenShadowClones))",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Create"
                               },
                               "parameters": [
@@ -1674,12 +1700,10 @@
                                 "PrimaryObject.X()",
                                 "PrimaryObject.Y()",
                                 "GetArgumentAsString(\"ShadowCloneLayer\")"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1687,12 +1711,10 @@
                                 "FramesBehindPrimary",
                                 "=",
                                 "PrimaryObject.Variable(FrameCounter)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -1700,12 +1722,10 @@
                                 "ShadowCloneOrder",
                                 "=",
                                 "PrimaryObject.Variable(FrameCounter)/PrimaryObject.Variable(FramesBetweenShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjetTxt"
                               },
                               "parameters": [
@@ -1713,38 +1733,31 @@
                                 "ShadowCloneGroupID",
                                 "=",
                                 "GetArgumentAsString(\"ShadowCloneGroupID\")"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangePlan"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "GetArgumentAsNumber(\"ShadowCloneZValue\")"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "LinkedObjects::LinkObjects"
                               },
                               "parameters": [
                                 "",
                                 "PrimaryObject",
                                 "ShadowCloneObject"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -1758,212 +1771,167 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "GetArgumentAsBoolean"
                                   },
                                   "parameters": [
                                     "\"MatchAngle\""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "SetAngle"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.Angle()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "GetArgumentAsBoolean"
                                   },
                                   "parameters": [
                                     "\"MatchScaleX\""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                     "=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleWidth"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleX()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "GetArgumentAsBoolean"
                                   },
                                   "parameters": [
                                     "\"MatchScaleY\""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                     "=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleHeight"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleY()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "GetArgumentAsBoolean"
                                   },
                                   "parameters": [
                                     "\"MatchAnimation\""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeAnimation"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.Animation()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PauseAnimation"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "GetArgumentAsBoolean"
                                   },
                                   "parameters": [
                                     "\"MatchAnimationFrame\""
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeSprite"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.Sprite()"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "PauseAnimation"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -1977,42 +1945,33 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "GetArgumentAsNumber(\"FadeSpeed\")",
                                     "!=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Opacity"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "255-GetArgumentAsNumber(\"FadeSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -2026,66 +1985,52 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                     "!=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [],
                               "events": [
                                 {
-                                  "disabled": false,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "ChangeScaleWidth"
                                       },
                                       "parameters": [
                                         "ShadowCloneObject",
                                         "=",
                                         "PrimaryObject.ScaleX()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 },
                                 {
-                                  "disabled": false,
-                                  "folded": false,
                                   "type": "BuiltinCommonInstructions::Standard",
                                   "conditions": [],
                                   "actions": [
                                     {
                                       "type": {
-                                        "inverted": false,
                                         "value": "ChangeScaleHeight"
                                       },
                                       "parameters": [
                                         "ShadowCloneObject",
                                         "=",
                                         "PrimaryObject.ScaleY()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                      ],
-                                      "subInstructions": []
+                                      ]
                                     }
-                                  ],
-                                  "events": []
+                                  ]
                                 }
                               ]
                             }
@@ -2094,8 +2039,6 @@
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -2109,14 +2052,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::ForEach",
                       "object": "ShadowCloneObject",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "VarObjetTxt"
                           },
                           "parameters": [
@@ -2124,27 +2064,22 @@
                             "ShadowCloneGroupID",
                             "=",
                             "GetArgumentAsString(\"ShadowCloneGroupID\")"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "LinkedObjects::PickObjectsLinkedTo"
                           },
                           "parameters": [
                             "",
                             "PrimaryObject",
                             "ShadowCloneObject"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2158,14 +2093,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "MettreXY"
                               },
                               "parameters": [
@@ -2174,47 +2106,36 @@
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].xpos)",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].ypos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAngle\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "SetAngle"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].angle)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2228,52 +2149,41 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchScaleX\""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeScaleWidth"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].xscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2287,116 +2197,91 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchScaleY\""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeScaleHeight"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].yscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAnimation\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeAnimation"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].animation)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "GetArgumentAsBoolean"
                               },
                               "parameters": [
                                 "\"MatchAnimationFrame\""
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ChangeSprite"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(ShadowCloneObject.Variable(FramesBehindPrimary))].frame)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2411,26 +2296,22 @@
                         },
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "ShadowCloneObject.Variable(FramesBehindPrimary) / ShadowCloneObject.Variable(ShadowCloneOrder)",
                                 "!=",
                                 "PrimaryObject.Variable(FramesBetweenShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -2438,15 +2319,11 @@
                                 "FramesBehindPrimary",
                                 "=",
                                 "ShadowCloneObject.Variable(ShadowCloneOrder) * PrimaryObject.Variable(FramesBetweenShadowClones)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2461,19 +2338,16 @@
                         },
                         {
                           "disabled": true,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::Or"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "VarObjet"
                                   },
                                   "parameters": [
@@ -2481,20 +2355,17 @@
                                     "ShadowCloneOrder",
                                     ">",
                                     "PrimaryObject.Variable(TotalShadowClones)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject.Variable(FramesBehindPrimary) / ShadowCloneObject.Variable(ShadowCloneOrder)",
                                     "!=",
                                     "PrimaryObject.Variable(FramesBetweenShadowClones)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             }
@@ -2502,18 +2373,15 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Delete"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -2521,14 +2389,11 @@
                                 "FrameCounter",
                                 "-",
                                 "min(ShadowCloneObject.Variable(FramesBehindPrimary) / ShadowCloneObject.Variable(ShadowCloneOrder),PrimaryObject.Variable(FramesBetweenShadowClones))"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -2542,13 +2407,10 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "VarObjet"
                                   },
                                   "parameters": [
@@ -2556,14 +2418,12 @@
                                     "FrameCounter",
                                     "<",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ModVarObjet"
                                   },
                                   "parameters": [
@@ -2571,29 +2431,23 @@
                                     "FrameCounter",
                                     "=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "BuiltinCommonInstructions::Or"
                               },
                               "parameters": [],
                               "subInstructions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "VarObjet"
                                   },
                                   "parameters": [
@@ -2601,20 +2455,17 @@
                                     "FramesBehindPrimary",
                                     ">",
                                     "PrimaryObject.Variable(MaxFramesBehind)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 },
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "Egal"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject.Variable(FramesBehindPrimary) / ShadowCloneObject.Variable(ShadowCloneOrder)",
                                     "!=",
                                     "PrimaryObject.Variable(FramesBetweenShadowClones)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ]
                             }
@@ -2622,18 +2473,15 @@
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Delete"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 ""
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -2641,14 +2489,11 @@
                                 "FrameCounter",
                                 "-",
                                 "ShadowCloneObject.Variable(FramesBehindPrimary) / ShadowCloneObject.Variable(ShadowCloneOrder)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Comment",
                               "color": {
                                 "b": 109,
@@ -2662,13 +2507,10 @@
                               "comment2": ""
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "VarObjet"
                                   },
                                   "parameters": [
@@ -2676,14 +2518,12 @@
                                     "FrameCounter",
                                     "<",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ModVarObjet"
                                   },
                                   "parameters": [
@@ -2691,17 +2531,13 @@
                                     "FrameCounter",
                                     "=",
                                     "0"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2715,42 +2551,33 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"FadeSpeed\")",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Opacity"
                               },
                               "parameters": [
                                 "ShadowCloneObject",
                                 "=",
                                 "255-GetArgumentAsNumber(\"FadeSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -2764,66 +2591,52 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Egal"
                               },
                               "parameters": [
                                 "GetArgumentAsNumber(\"ShrinkSpeed\")",
                                 "!=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [],
                           "events": [
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleWidth"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleX()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             },
                             {
-                              "disabled": false,
-                              "folded": false,
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [],
                               "actions": [
                                 {
                                   "type": {
-                                    "inverted": false,
                                     "value": "ChangeScaleHeight"
                                   },
                                   "parameters": [
                                     "ShadowCloneObject",
                                     "=",
                                     "PrimaryObject.ScaleY()-(GetArgumentAsNumber(\"ShrinkSpeed\")*ShadowCloneObject.Variable(ShadowCloneOrder)/100)"
-                                  ],
-                                  "subInstructions": []
+                                  ]
                                 }
-                              ],
-                              "events": []
+                              ]
                             }
                           ]
                         }
@@ -2837,15 +2650,11 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "disabled": false,
-                  "folded": false,
                   "name": "Update PrimaryObject history",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -2859,14 +2668,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -2874,48 +2680,39 @@
                             "DataCleaningCounter",
                             "=",
                             "PrimaryObject.Variable(MaxFramesBehind)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ObjectVariableChildExists"
                           },
                           "parameters": [
                             "PrimaryObject",
                             "ObjectHistory",
                             "ToString(PrimaryObject.Variable(DataCleaningCounter)+1)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ObjectVariableRemoveChild"
                           },
                           "parameters": [
                             "PrimaryObject",
                             "ObjectHistory",
                             "ToString(PrimaryObject.Variable(DataCleaningCounter)+1)"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -2923,15 +2720,11 @@
                             "DataCleaningCounter",
                             "+",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -2945,14 +2738,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -2960,15 +2750,11 @@
                             "DataMoveCounter",
                             "=",
                             "PrimaryObject.Variable(MaxFramesBehind)"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -2982,14 +2768,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "infiniteLoopWarning": true,
                       "type": "BuiltinCommonInstructions::While",
                       "whileConditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "VarObjet"
                           },
                           "parameters": [
@@ -2997,16 +2780,13 @@
                             "DataMoveCounter",
                             ">",
                             "1"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "conditions": [],
                       "actions": [],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Comment",
                           "color": {
                             "b": 109,
@@ -3020,14 +2800,11 @@
                           "comment2": ""
                         },
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3035,12 +2812,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].xpos",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].xpos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3048,12 +2823,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].ypos",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].ypos)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3061,12 +2834,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].angle",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].angle)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3074,12 +2845,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].animation",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].animation)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3087,12 +2856,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].frame",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].frame)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3100,12 +2867,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].xscale",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].xscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3113,12 +2878,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].yscale",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].yscale)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3126,12 +2889,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].width",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].width)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3139,12 +2900,10 @@
                                 "ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter))].height",
                                 "=",
                                 "PrimaryObject.Variable(ObjectHistory[ToString(PrimaryObject.Variable(DataMoveCounter)-1)].height)"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "ModVarObjet"
                               },
                               "parameters": [
@@ -3152,17 +2911,13 @@
                                 "DataMoveCounter",
                                 "-",
                                 "1"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Comment",
                       "color": {
                         "b": 109,
@@ -3176,14 +2931,11 @@
                       "comment2": ""
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3191,12 +2943,10 @@
                             "ObjectHistory.1.xpos",
                             "=",
                             "PrimaryObject.X()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3204,12 +2954,10 @@
                             "ObjectHistory.1.ypos",
                             "=",
                             "PrimaryObject.Y()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3217,12 +2965,10 @@
                             "ObjectHistory.1.animation",
                             "=",
                             "PrimaryObject.Animation()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3230,12 +2976,10 @@
                             "ObjectHistory.1.frame",
                             "=",
                             "PrimaryObject.Sprite()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3243,12 +2987,10 @@
                             "ObjectHistory.1.angle",
                             "=",
                             "PrimaryObject.Angle()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3256,12 +2998,10 @@
                             "ObjectHistory.1.xscale",
                             "=",
                             "PrimaryObject.ScaleX()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3269,12 +3009,10 @@
                             "ObjectHistory.1.yscale",
                             "=",
                             "PrimaryObject.ScaleY()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3282,12 +3020,10 @@
                             "ObjectHistory.1.width",
                             "=",
                             "PrimaryObject.Width()"
-                          ],
-                          "subInstructions": []
+                          ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "ModVarObjet"
                           },
                           "parameters": [
@@ -3295,11 +3031,9 @@
                             "ObjectHistory.1.height",
                             "=",
                             "PrimaryObject.Height()"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ],
                   "parameters": []
@@ -3312,133 +3046,82 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Object that shadow clones will follow",
-          "longDescription": "",
           "name": "PrimaryObject",
-          "optional": false,
           "supplementaryInformation": "Sprite",
           "type": "objectList"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Shadows clones will be made of this object (Cannot be the same object used for primary object)",
-          "longDescription": "",
           "name": "ShadowCloneObject",
-          "optional": false,
           "supplementaryInformation": "Sprite",
           "type": "objectList"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Number of shadow clones (Default: 1)",
-          "longDescription": "",
           "name": "NumberOfShadowClones",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Number of empty frames between shadow clones (Default: 1)",
-          "longDescription": "",
           "name": "FramesBetweenShadowClones",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Fade speed (Range: 0 to 255) (Default: 0)",
           "longDescription": "Decrease in opacity for each consecutive shadow clone ",
           "name": "FadeSpeed",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Shrink speed (Range: 0 to 100) (Default: 0)",
           "longDescription": "Decrease in scale for each consecutive shadow clone ",
           "name": "ShrinkSpeed",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Shadow clones will be created on this layer. (Default: \"\") (Base Layer)",
-          "longDescription": "",
           "name": "ShadowCloneLayer",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "layer"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Z value for created shadow clones",
-          "longDescription": "",
           "name": "ShadowCloneZValue",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Match X scale of primary object:",
-          "longDescription": "",
           "name": "MatchScaleX",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "yesorno"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Match Y scale of primary object:",
-          "longDescription": "",
           "name": "MatchScaleY",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "yesorno"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Match angle of primary object:",
-          "longDescription": "",
           "name": "MatchAngle",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "yesorno"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Match animation of primary object:",
-          "longDescription": "",
           "name": "MatchAnimation",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "yesorno"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Match animation frame of primary object:",
-          "longDescription": "",
           "name": "MatchAnimationFrame",
-          "optional": false,
-          "supplementaryInformation": "",
+          "type": "yesorno"
+        },
+        {
+          "description": "Match the vertical flip of primary object:",
+          "name": "MatchVerticalFlip",
+          "type": "yesorno"
+        },
+        {
+          "description": "Match the horizontal flip of primary object:",
+          "name": "MatchHorizontalFlip",
           "type": "yesorno"
         }
       ],
@@ -3449,43 +3132,35 @@
       "fullName": "Delete shadow clone objects that are linked to a primary object",
       "functionType": "Action",
       "name": "DeleteShadowClones",
-      "private": false,
       "sentence": "Delete all _PARAM2_ that are linked to _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::ForEach",
           "object": "ShadowClones",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "LinkedObjects::PickObjectsLinkedTo"
               },
               "parameters": [
                 "",
                 "ShadowClones",
                 "PrimaryObject"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "Delete"
               },
               "parameters": [
                 "ShadowClones",
                 ""
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarObjet"
               },
               "parameters": [
@@ -3493,12 +3168,10 @@
                 "ClonesCreated",
                 "=",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarObjet"
               },
               "parameters": [
@@ -3506,48 +3179,35 @@
                 "TotalShadowClones",
                 "=",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ObjectVariableClearChildren"
               },
               "parameters": [
                 "PrimaryObject",
                 "ObjectHistory"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Primary object",
-          "longDescription": "",
           "name": "PrimaryObject",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "objectList"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Shadow clones",
-          "longDescription": "",
           "name": "ShadowClones",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "objectList"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
This is based on PR #477, with a small change to use Boolean variables.