### PR TITLE
Make the clipboard extension ✨true async✨

### DIFF
--- a/extensions/reviewed/Clipboard.json
+++ b/extensions/reviewed/Clipboard.json
@@ -1,7 +1,6 @@
 {
   "author": "@Bouh, @arthuro555",
   "category": "User interface",
-  "description": "This extension adds tools to access the clipboard.",
   "extensionNamespace": "",
   "fullName": "Clipboard",
   "helpPath": "",
@@ -9,7 +8,12 @@
   "name": "Clipboard",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/clipboard-text-multiple-outline.svg",
   "shortDescription": "Read and write the clipboard.",
-  "version": "1.0.0",
+  "version": "2.0.0",
+  "description": "This extension allows to access the clipboard.",
+  "origin": {
+    "identifier": "Clipboard",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "clipboard",
     "pasteboard",
@@ -31,18 +35,59 @@
   ],
   "eventsFunctions": [
     {
-      "description": "Read the text from the clipboard asynchronously. As this is \"asynchronous\", this means that the variable won't be immediately filled with the text from the clipboard. Instead, it will be filled a few milliseconds later.\n\nNote also that on web browsers, the user might be asked for permissions to read from the clipboard.",
+      "async": true,
+      "description": "Read the text from the clipboard asynchronously. \n\nNote also that on web browsers, the user might be asked for permissions to read from the clipboard.",
       "fullName": "Get text from the clipboard",
       "functionType": "Action",
-      "name": "ReadTextCrossPlaform",
-      "private": false,
+      "name": "AsynchronouslyReadTextCrossPlaform",
       "sentence": "Read clipboard and store text in _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst callback =\n    runtimeScene\n        .getVariables()\n        .get(eventsFunctionContext.getArgument(\"callback\"));\n\nif (electron !== null && electron.clipboard)\n    callback.setString(electron.clipboard.readText());\nelse if (\n    typeof cordova !== \"undefined\" &&\n    cordova.plugins &&\n    cordova.plugins.clipboard\n) cordova.plugins.clipboard.paste(text => callback.setString(text));\nelse if (\n    typeof navigator !== \"undefined\" &&\n    navigator.clipboard &&\n    navigator.clipboard.readText\n) {\n    navigator.clipboard.readText()\n        .then(text => callback.setString(text))\n        .catch(err =>\n            console.error(\"Error occured while getting clipboard content: \", err.message)\n        );\n} else console.error(\"Unable to read from the clipboard: no method found for this platform.\")\n",
+          "inlineCode": [
+            "const electron = runtimeScene.getGame().getRenderer().getElectron();",
+            "const callback = eventsFunctionContext.getArgument(\"callback\");",
+            "const { task } = eventsFunctionContext;",
+            "const logger = this.logger || (this.logger = new gdjs.Logger(\"Clipboard extension\"));",
+            "",
+            "if (electron !== null && electron.clipboard) {",
+            "    callback.setString(electron.clipboard.readText());",
+            "    task.resolve();",
+            "} else if (",
+            "    typeof cordova !== \"undefined\" &&",
+            "    cordova.plugins &&",
+            "    cordova.plugins.clipboard",
+            ") {",
+            "    cordova.plugins.clipboard.paste(",
+            "        text => {",
+            "            callback.setString(text);",
+            "            task.resolve();",
+            "        },",
+            "        error => {",
+            "            logger.error(\"An error occured while getting clipboard content: \", error);",
+            "            task.resolve();",
+            "        }",
+            "    );",
+            "} else if (",
+            "    typeof navigator !== \"undefined\" &&",
+            "    navigator.clipboard &&",
+            "    navigator.clipboard.readText",
+            ") {",
+            "    navigator.clipboard.readText()",
+            "        .then(text => {",
+            "            callback.setString(text);",
+            "            task.resolve();",
+            "        })",
+            "        .catch(error => {",
+            "            logger.error(\"An error occured while getting clipboard content: \", error.message);",
+            "            task.resolve();",
+            "        });",
+            "} else {",
+            "    logger.error(\"Unable to read from the clipboard: no method found for this platform.\");",
+            "    task.resolve();",
+            "}",
+            ""
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -50,14 +95,9 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Callback variable where to store the result",
-          "longDescription": "",
+          "description": "Callback variable where to store the clipboard contents",
           "name": "callback",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
+          "type": "scenevar"
         }
       ],
       "objectGroups": []
@@ -67,14 +107,31 @@
       "fullName": "Write text to the clipboard",
       "functionType": "Action",
       "name": "WriteText",
-      "private": false,
       "sentence": "Write _PARAM1_ to clipboard",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst text = eventsFunctionContext.getArgument(\"text\");\n\nif (electron !== null && electron.clipboard)\n  electron.clipboard.writeText(text);\nelse if (\n  typeof cordova !== \"undefined\" &&\n  cordova.plugins &&\n  cordova.plugins.clipboard\n) cordova.plugins.clipboard.copy(text);\nelse if (\n  typeof navigator !== \"undefined\" &&\n  navigator.clipboard &&\n  navigator.clipboard.writeText\n) navigator.clipboard\n  .writeText(text)\n  .catch(e => console.error(\"Error while writing clipboard: \", e));\nelse console.error(\"Unable to write to the clipboard: no method found for this platform.\"); \n",
+          "inlineCode": [
+            "const electron = runtimeScene.getGame().getRenderer().getElectron();",
+            "const text = eventsFunctionContext.getArgument(\"text\");",
+            "",
+            "if (electron !== null && electron.clipboard)",
+            "  electron.clipboard.writeText(text);",
+            "else if (",
+            "  typeof cordova !== \"undefined\" &&",
+            "  cordova.plugins &&",
+            "  cordova.plugins.clipboard",
+            ") cordova.plugins.clipboard.copy(text);",
+            "else if (",
+            "  typeof navigator !== \"undefined\" &&",
+            "  navigator.clipboard &&",
+            "  navigator.clipboard.writeText",
+            ") navigator.clipboard",
+            "  .writeText(text)",
+            "  .catch(e => console.error(\"Error while writing clipboard: \", e));",
+            "else console.error(\"Unable to write to the clipboard: no method found for this platform.\"); ",
+            ""
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -82,29 +139,73 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Text to write to clipboard",
-          "longDescription": "",
           "name": "text",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "string"
         }
       ],
       "objectGroups": []
     },
     {
-      "description": "Read the text from the clipboard (Windows, macOS, Linux only)",
-      "fullName": "Get text from the clipboard (Windows, macOS, Linux)",
+      "description": "Read the text from the clipboard asynchronously. As this is \"asynchronous\", the variable won't be immediately filled with the text from the clipboard. You will have to wait a few frames before it will be. If you want your subsequent actions and subevents to automatically wait for the read to finish, use the waiting version of this action instead (recomended). \n\nNote also that on web browsers, the user might be asked for permissions to read from the clipboard.",
+      "fullName": "(No waiting) Get text from the clipboard",
+      "functionType": "Action",
+      "name": "ReadTextCrossPlaform",
+      "private": true,
+      "sentence": "Read clipboard and store text in _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "const electron = runtimeScene.getGame().getRenderer().getElectron();",
+            "const callback =",
+            "    runtimeScene",
+            "        .getVariables()",
+            "        .get(eventsFunctionContext.getArgument(\"callback\"));",
+            "",
+            "if (electron !== null && electron.clipboard)",
+            "    callback.setString(electron.clipboard.readText());",
+            "else if (",
+            "    typeof cordova !== \"undefined\" &&",
+            "    cordova.plugins &&",
+            "    cordova.plugins.clipboard",
+            ") cordova.plugins.clipboard.paste(text => callback.setString(text));",
+            "else if (",
+            "    typeof navigator !== \"undefined\" &&",
+            "    navigator.clipboard &&",
+            "    navigator.clipboard.readText",
+            ") {",
+            "    navigator.clipboard.readText()",
+            "        .then(text => callback.setString(text))",
+            "        .catch(err =>",
+            "            console.error(\"Error occured while getting clipboard content: \", err.message)",
+            "        );",
+            "} else console.error(\"Unable to read from the clipboard: no method found for this platform.\")",
+            ""
+          ],
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Callback variable where to store the result",
+          "name": "callback",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "[DEPRECATED] Read the text from the clipboard (Windows, macOS, Linux only)",
+      "fullName": "[DEPRECATED] Get text from the clipboard (Windows, macOS, Linux)",
       "functionType": "StringExpression",
       "name": "ReadText",
       "private": true,
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -114,22 +215,28 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "This is here for retrocompatibility. Try to use the asynchronous readTextCrossPlatform action instead.",
+          "comment": "This is here for retrocompatibility. Try to use the AsynchronouslyReadTextCrossPlatform action instead.",
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nif (electron && electron.clipboard) eventsFunctionContext.returnValue = electron.clipboard.readText();\n",
+          "inlineCode": [
+            "const electron = runtimeScene.getGame().getRenderer().getElectron();",
+            "if (electron && electron.clipboard) eventsFunctionContext.returnValue = electron.clipboard.readText();",
+            ""
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
         }
       ],
+      "expressionType": {
+        "type": "string"
+      },
       "parameters": [],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
This adds a new action for the clipboard extension that is an async action. 
Relies on https://github.com/4ian/GDevelop/pull/4819

Additionally:
 - Changed the parameter from a string to an actual variable field on the new action
 - Privated the old one to discourage further use
 - Added `[DEPRECATED]` in front of the original clipboard read expression that did not work cross-platform
