### PR TITLE
[Reviewed] [Stay on screen] Use the bounding box instead of the position and the dimensions

### DIFF
--- a/extensions/reviewed/StayOnScreen.json
+++ b/extensions/reviewed/StayOnScreen.json
@@ -1,7 +1,6 @@
 {
   "author": "@4ian",
   "category": "Movement",
-  "description": "Force the object to stay visible on the screen by setting back its position inside the viewport of the camera.",
   "extensionNamespace": "",
   "fullName": "Stay On Screen",
   "helpPath": "",
@@ -9,7 +8,12 @@
   "name": "StayOnScreen",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/monitor-screenshot.svg",
   "shortDescription": "Force the object to stay visible on the screen by setting back its position inside the viewport of the camera.",
-  "version": "0.0.2",
+  "version": "0.0.3",
+  "description": "Force the object to stay visible on the screen by setting back its position inside the viewport of the camera.",
+  "origin": {
+    "identifier": "StayOnScreen",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "positioning",
     "camera",
@@ -29,65 +33,371 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "doStepPostEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MettreX"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "min(max(Object.X(), CameraX(Object.Layer(), 0) - CameraWidth(Object.Layer(), 0)/2 + Object.Behavior::PropertyMarginLeft()), CameraX(Object.Layer(), 0) + CameraWidth(Object.Layer(), 0)/2 - Object.Width() - Object.Behavior::PropertyMarginRight())"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MettreY"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "min(max(Object.Y(), CameraY(Object.Layer(), 0) - CameraHeight(Object.Layer(), 0)/2+ Object.Behavior::PropertyMarginTop()), CameraY(Object.Layer(), 0) + CameraHeight(Object.Layer(), 0)/2 - Object.Height() - Object.Behavior::PropertyMarginBottom())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "the top margin (in pixels) to leave between the object and the screen border.",
+          "fullName": "Screen top margin",
+          "functionType": "ExpressionAndCondition",
+          "group": "Stay on Screen configuration",
+          "name": "MarginTop",
+          "sentence": "the top margin",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyMarginTop()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "expressionType": {
+            "type": "expression"
+          },
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "ActionWithOperator",
+          "getterName": "MarginTop",
+          "name": "SetMarginTop",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "StayOnScreen::StayOnScreen::SetPropertyMarginTop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "the bottom margin (in pixels) to leave between the object and the screen border.",
+          "fullName": "Screen bottom margin",
+          "functionType": "ExpressionAndCondition",
+          "group": "Stay on Screen configuration",
+          "name": "MarginBottom",
+          "sentence": "the bottom margin (in pixels)",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyMarginBottom()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "expressionType": {
+            "type": "expression"
+          },
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "ActionWithOperator",
+          "getterName": "MarginBottom",
+          "name": "SetMarginBottom",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "StayOnScreen::StayOnScreen::SetPropertyMarginBottom"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "the left margin (in pixels) to leave between the object and the screen border.",
+          "fullName": "Screen left margin",
+          "functionType": "ExpressionAndCondition",
+          "group": "Stay on Screen configuration",
+          "name": "MarginLeft",
+          "sentence": "the left margin (in pixels)",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyMarginLeft()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "expressionType": {
+            "type": "expression"
+          },
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "ActionWithOperator",
+          "getterName": "MarginLeft",
+          "name": "SetMarginLeft",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "StayOnScreen::StayOnScreen::SetPropertyMarginLeft"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "the right margin (in pixels) to leave between the object and the screen border.",
+          "fullName": "Screen right margin",
+          "functionType": "ExpressionAndCondition",
+          "group": "Stay on Screen configuration",
+          "name": "MarginRight",
+          "sentence": "the right margin (in pixels)",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyMarginRight()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "expressionType": {
+            "type": "expression"
+          },
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "StayOnScreen::StayOnScreen",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "ActionWithOperator",
+          "getterName": "MarginRight",
+          "name": "SetMarginRight",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "StayOnScreen::StayOnScreen::SetPropertyMarginRight"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"Value\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
               "supplementaryInformation": "StayOnScreen::StayOnScreen",
               "type": "behavior"
             }
@@ -99,8 +409,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Top margin, in pixels",
+          "label": "Top margin (in pixels)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "MarginTop"
@@ -108,8 +419,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Bottom margin, in pixels",
+          "label": "Bottom margin (in pixels)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "MarginBottom"
@@ -117,8 +429,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Left margin, in pixels",
+          "label": "Left margin (in pixels)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "MarginLeft"
@@ -126,13 +439,16 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "Right margin, in pixels",
+          "label": "Right margin (in pixels)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "MarginRight"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/StayOnScreen.json
+++ b/extensions/reviewed/StayOnScreen.json
@@ -8,7 +8,7 @@
   "name": "StayOnScreen",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/monitor-screenshot.svg",
   "shortDescription": "Force the object to stay visible on the screen by setting back its position inside the viewport of the camera.",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Force the object to stay visible on the screen by setting back its position inside the viewport of the camera.",
   "origin": {
     "identifier": "StayOnScreen",
@@ -21,7 +21,8 @@
   ],
   "authorIds": [
     "wWP8BSlAW0UP4NeaHa2LcmmDzmH2",
-    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92"
+    "2OwwM8ToR9dx9RJ2sAKTcrLmCB92",
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
   "eventsFunctions": [],
@@ -48,8 +49,18 @@
                   },
                   "parameters": [
                     "Object",
-                    "=",
-                    "min(max(Object.X(), CameraX(Object.Layer(), 0) - CameraWidth(Object.Layer(), 0)/2 + Object.Behavior::PropertyMarginLeft()), CameraX(Object.Layer(), 0) + CameraWidth(Object.Layer(), 0)/2 - Object.Width() - Object.Behavior::PropertyMarginRight())"
+                    "+",
+                    "max(0, CameraBorderLeft(Object.Layer()) + Object.Behavior::PropertyMarginLeft() - Object.BoundingBoxLeft())\n"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "MettreX"
+                  },
+                  "parameters": [
+                    "Object",
+                    "+",
+                    "min(0, CameraBorderRight(Object.Layer()) - Object.Behavior::PropertyMarginRight() - Object.BoundingBoxRight())\n"
                   ]
                 },
                 {
@@ -58,8 +69,18 @@
                   },
                   "parameters": [
                     "Object",
-                    "=",
-                    "min(max(Object.Y(), CameraY(Object.Layer(), 0) - CameraHeight(Object.Layer(), 0)/2+ Object.Behavior::PropertyMarginTop()), CameraY(Object.Layer(), 0) + CameraHeight(Object.Layer(), 0)/2 - Object.Height() - Object.Behavior::PropertyMarginBottom())"
+                    "+",
+                    "max(0, CameraBorderTop(Object.Layer()) + Object.Behavior::PropertyMarginTop() - Object.BoundingBoxTop())\n"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "MettreY"
+                  },
+                  "parameters": [
+                    "Object",
+                    "+",
+                    "min(0, CameraBorderBottom(Object.Layer()) - Object.Behavior::PropertyMarginBottom() - Object.BoundingBoxBottom())\n"
                   ]
                 }
               ]
@@ -167,7 +188,7 @@
           "functionType": "ExpressionAndCondition",
           "group": "Stay on Screen configuration",
           "name": "MarginBottom",
-          "sentence": "the bottom margin (in pixels)",
+          "sentence": "the bottom margin",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -248,7 +269,7 @@
           "functionType": "ExpressionAndCondition",
           "group": "Stay on Screen configuration",
           "name": "MarginLeft",
-          "sentence": "the left margin (in pixels)",
+          "sentence": "the left margin",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -329,7 +350,7 @@
           "functionType": "ExpressionAndCondition",
           "group": "Stay on Screen configuration",
           "name": "MarginRight",
-          "sentence": "the right margin (in pixels)",
+          "sentence": "the right margin",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",


### PR DESCRIPTION
### Changes
- Use the bounding box instead of position and dimensions.
- Add actions to change the margins.

### Demo
- https://github.com/GDevelopApp/GDevelop-examples/pull/452