### PR TITLE
DragCameraWithPointer with scroll limitation

### DIFF
--- a/extensions/reviewed/DragCameraWithPointer.json
+++ b/extensions/reviewed/DragCameraWithPointer.json
@@ -1,7 +1,6 @@
 {
   "author": "@ddabrahim",
   "category": "Camera",
-  "description": "Move a camera by dragging the mouse (or touchscreen). \n\nHow to use:\n- Run this action on every frame that you want the camera to be movable by the mouse (or touchscreen)\n- Select the mouse button to use (choose \"left\" for touchscreen)\n- Select which directions the camera will move (vertical, horizontal, or both) \n- Select the layer that will be moved\n\nTips:\n- If no parameters are selected, the camera will move in both directions when the left mouse button (or touchscreen) are dragged.",
   "extensionNamespace": "",
   "fullName": "Drag camera with the mouse (or touchscreen)",
   "helpPath": "",
@@ -9,7 +8,22 @@
   "name": "DragCameraWithPointer",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/drag-variant.svg",
   "shortDescription": "Move a camera by dragging the mouse (or touchscreen).",
-  "version": "1.1.0",
+  "version": "1.2.0",
+  "description": [
+    "Move a camera by dragging the mouse (or touchscreen). ",
+    "",
+    "How to use:",
+    "- Run this action on every frame that you want the camera to be movable by the mouse (or touchscreen)",
+    "- Select the mouse button to use (choose \"left\" for touchscreen)",
+    "- Select which directions the camera will move (vertical, horizontal, or both) ",
+    "- Select the layer that will be moved",
+    "",
+    "Tips:",
+    "- If no parameters are selected, the camera will move in both directions when the left mouse button (or touchscreen) are dragged.",
+    "",
+    "Use the limiation action to set the maximal scroll top, bottom, left and right position.",
+    ""
+  ],
   "origin": {
     "identifier": "DragCameraWithPointer",
     "name": "gdevelop-extension-store"
@@ -23,7 +37,8 @@
   ],
   "authorIds": [
     "GfzRsieyUFVnsRR8OZThsPR29oq2",
-    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1",
+    "QvD9hVXs68deZuaMmqcVRQGxvlz2"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -31,14 +46,10 @@
       "description": "Move a camera by dragging the mouse (or touchscreen).",
       "fullName": "Drag camera with the mouse",
       "functionType": "Action",
-      "group": "",
       "name": "DragCameraWithPointer",
-      "private": false,
-      "sentence": "Drag camera on layer _PARAM2_ in _PARAM3_ directions using _PARAM4_ mouse button",
+      "sentence": "Drag camera _PARAM1_ on layer _PARAM2_ in _PARAM3_ directions using _PARAM4_ mouse button",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -52,45 +63,37 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::Or"
               },
               "parameters": [],
               "subInstructions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MouseButtonFromTextPressed"
                   },
                   "parameters": [
                     "",
                     "GetArgumentAsString(\"InputButton\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::And"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MouseButtonPressed"
                       },
                       "parameters": [
                         "",
                         "Left"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -99,8 +102,7 @@
                       },
                       "parameters": [
                         "\"InputButton\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -108,44 +110,35 @@
             },
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::Once"
               },
-              "parameters": [],
-              "subInstructions": []
+              "parameters": []
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__DragCameraWithPointer.scrollStartX",
                 "=",
                 "MouseX(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
-              ],
-              "subInstructions": []
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
                 "__DragCameraWithPointer.scrollStartY",
                 "=",
                 "MouseY(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -159,45 +152,37 @@
           "comment2": ""
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::Or"
               },
               "parameters": [],
               "subInstructions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MouseButtonFromTextPressed"
                   },
                   "parameters": [
                     "",
                     "GetArgumentAsString(\"InputButton\")"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::And"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MouseButtonPressed"
                       },
                       "parameters": [
                         "",
                         "Left"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -206,8 +191,7 @@
                       },
                       "parameters": [
                         "\"InputButton\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -217,65 +201,52 @@
           "actions": [],
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__DragCameraWithPointer.scrollTargetX",
                     "=",
                     "MouseX(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__DragCameraWithPointer.scrollTargetY",
                     "=",
                     "MouseY(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__DragCameraWithPointer.scrollDistanceX",
                     "=",
                     "(Variable(__DragCameraWithPointer.scrollTargetX) - Variable(__DragCameraWithPointer.scrollStartX))"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarScene"
                   },
                   "parameters": [
                     "__DragCameraWithPointer.scrollDistanceY",
                     "=",
                     "(Variable(__DragCameraWithPointer.scrollTargetY) - Variable(__DragCameraWithPointer.scrollStartY))"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -289,52 +260,43 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"horizontal\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"both\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -342,8 +304,6 @@
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -357,27 +317,22 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "abs(Variable(__DragCameraWithPointer.scrollDistanceX))",
                         ">=",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraX"
                       },
                       "parameters": [
@@ -386,17 +341,13 @@
                         "Variable(__DragCameraWithPointer.scrollDistanceX)",
                         "GetArgumentAsString(\"CamLayer\")",
                         "GetArgumentAsNumber(\"CamNumber\")"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -410,52 +361,43 @@
               "comment2": ""
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"vertical\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"both\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "StrEqual"
                       },
                       "parameters": [
                         "GetArgumentAsString(\"Direction\")",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -463,8 +405,6 @@
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -478,27 +418,22 @@
                   "comment2": ""
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Egal"
                       },
                       "parameters": [
                         "abs(Variable(__DragCameraWithPointer.scrollDistanceY))",
                         ">=",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "SetCameraY"
                       },
                       "parameters": [
@@ -507,11 +442,9 @@
                         "Variable(__DragCameraWithPointer.scrollDistanceY)",
                         "GetArgumentAsString(\"CamLayer\")",
                         "GetArgumentAsNumber(\"CamNumber\")"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
@@ -520,48 +453,601 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Camera number (default: 0)",
-          "longDescription": "",
           "name": "CamNumber",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Camera layer (default: \"\")",
-          "longDescription": "",
           "name": "CamLayer",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "layer"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Directions that the camera can move (horizontal, vertical, both)",
-          "longDescription": "",
           "name": "Direction",
-          "optional": false,
           "supplementaryInformation": "[\"vertical\",\"horizontal\",\"both\"]",
           "type": "stringWithSelector"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Mouse button (use \"Left\" for touchscreen)",
-          "longDescription": "",
           "name": "InputButton",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "mouse"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Move a camera by dragging the mouse (or touchscreen) with maximal scroll by top, bottom, left and right limitation",
+      "fullName": "Drag camera with the mouse (limitation)",
+      "functionType": "Action",
+      "name": "DragCameraWithPointerMaxScroll",
+      "sentence": "Drag camera _PARAM1_ on layer _PARAM2_ in _PARAM3_ directions using _PARAM4_ mouse button with maximal position of ┤ _PARAM5_ ├ _PARAM6_ ┬ _PARAM7_ ┴_PARAM8_ ",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "When mouse button is pressed, get starting position of mouse",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Or"
+              },
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "value": "MouseButtonFromTextPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "GetArgumentAsString(\"InputButton\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::And"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"InputButton\""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": []
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__DragCameraWithPointer.scrollStartX",
+                "=",
+                "MouseX(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__DragCameraWithPointer.scrollStartY",
+                "=",
+                "MouseY(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "When mouse button is pressed, get current position of mouse and calculate distance between the previous and current position on X and Y axis",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Or"
+              },
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "value": "MouseButtonFromTextPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "GetArgumentAsString(\"InputButton\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::And"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"InputButton\""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__DragCameraWithPointer.scrollTargetX",
+                    "=",
+                    "MouseX(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__DragCameraWithPointer.scrollTargetY",
+                    "=",
+                    "MouseY(GetArgumentAsString(\"CamLayer\"),GetArgumentAsNumber(\"CamNumber\"))"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__DragCameraWithPointer.scrollDistanceX",
+                    "=",
+                    "(Variable(__DragCameraWithPointer.scrollTargetX) - Variable(__DragCameraWithPointer.scrollStartX))"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__DragCameraWithPointer.scrollDistanceY",
+                    "=",
+                    "(Variable(__DragCameraWithPointer.scrollTargetY) - Variable(__DragCameraWithPointer.scrollStartY))"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "If selected direction is horizontal, both, or left blank, move camera on X axis",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"horizontal\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"both\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Only move camera when the distance is more than one pixel",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "abs(Variable(__DragCameraWithPointer.scrollDistanceX))",
+                        ">=",
+                        "1"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "Variable(__DragCameraWithPointer.scrollDistanceX)",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "round(CameraBorderRight())",
+                        ">=",
+                        "round(GetArgumentAsNumber(\"maxRightPosition\"))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "CameraBorderRight() - GetArgumentAsNumber(\"maxRightPosition\")",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "round(CameraBorderLeft())",
+                        "<=",
+                        "round(GetArgumentAsNumber(\"maxLeftPosition\"))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraX"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "CameraBorderLeft() - GetArgumentAsNumber(\"maxLeftPosition\")",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "If direction is vertical, both, or left blank, move camera on Y axis",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"vertical\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"both\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "StrEqual"
+                      },
+                      "parameters": [
+                        "GetArgumentAsString(\"Direction\")",
+                        "=",
+                        "\"\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Only move camera when the distance is more than one pixel",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "abs(Variable(__DragCameraWithPointer.scrollDistanceY))",
+                        ">=",
+                        "1"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "Variable(__DragCameraWithPointer.scrollDistanceY)",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "round(CameraBorderTop())",
+                        "<=",
+                        "round(GetArgumentAsNumber(\"maxTopPosition\"))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraCenterY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "CameraBorderTop() - GetArgumentAsNumber(\"maxTopPosition\")",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "round(CameraBorderBottom())",
+                        ">=",
+                        "round(GetArgumentAsNumber(\"maxBottomPosition\"))"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetCameraCenterY"
+                      },
+                      "parameters": [
+                        "",
+                        "-",
+                        "CameraBorderBottom() - GetArgumentAsNumber(\"maxBottomPosition\")",
+                        "GetArgumentAsString(\"CamLayer\")",
+                        "GetArgumentAsNumber(\"CamNumber\")"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Camera number (default: 0)",
+          "name": "CamNumber",
+          "type": "expression"
+        },
+        {
+          "description": "Camera layer (default: \"\")",
+          "name": "CamLayer",
+          "type": "layer"
+        },
+        {
+          "description": "Directions that the camera can move (horizontal, vertical, both)",
+          "name": "Direction",
+          "supplementaryInformation": "[\"vertical\",\"horizontal\",\"both\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "description": "Mouse button (use \"Left\" for touchscreen)",
+          "name": "InputButton",
+          "type": "mouse"
+        },
+        {
+          "description": "maximal scroll right position",
+          "name": "maxRightPosition",
+          "supplementaryInformation": "TiledSpriteObject::TiledSprite",
+          "type": "expression"
+        },
+        {
+          "description": "maximal scroll left position",
+          "name": "maxLeftPosition",
+          "type": "expression"
+        },
+        {
+          "description": "maximal scroll top position",
+          "name": "maxTopPosition",
+          "type": "expression"
+        },
+        {
+          "description": "maximal scroll bottom position",
+          "name": "maxBottomPosition",
+          "type": "expression"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/DragCameraWithPointer.json
+++ b/extensions/reviewed/DragCameraWithPointer.json
@@ -477,7 +477,7 @@
       "objectGroups": []
     },
     {
-      "description": "Move a camera by dragging the mouse (or touchscreen) with maximal scroll by top, bottom, left and right limitation",
+      "description": "Move a camera by dragging the mouse (or touchscreen) with maximal scroll by top, bottom, left and right limitation.",
       "fullName": "Drag camera with the mouse (limitation)",
       "functionType": "Action",
       "name": "DragCameraWithPointerMaxScroll",


### PR DESCRIPTION
### Updates

New behaviour for the "DragCameraWithPointer" extension.
Added the possibility to add it for top, bottom, left and right limitation for the dragging of the camera.

### Configuration
<img width="844" alt="Screenshot 2023-02-04 at 10 17 33" src="https://user-images.githubusercontent.com/11426/216772688-d91424c8-b42a-42f6-a2fd-5cc8ac1db8cd.png">
<img width="1377" alt="Screenshot 2023-02-04 at 10 17 20" src="https://user-images.githubusercontent.com/11426/216772690-8031aeac-c1d4-4cff-b98e-ded73a304388.png">


### Project files
[Example App](https://github.com/fishme/DragCameraWithPointer_Demo_Limitation)

