### PR TITLE
[Multitouch joystick] Exclude the thumb from the collision mask

### DIFF
--- a/extensions/reviewed/SpriteMultitouchJoystick.json
+++ b/extensions/reviewed/SpriteMultitouchJoystick.json
@@ -8,7 +8,7 @@
   "name": "SpriteMultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Joysticks or buttons for touchscreens.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": [
     "Multitouch joysticks can be used the same way as physical gamepads:",
     "- 4 or 8 directions",
@@ -3560,6 +3560,15 @@
                   },
                   "parameters": [
                     "Object",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetIncludedInParentCollisionMask"
+                  },
+                  "parameters": [
+                    "Thumb",
                     ""
                   ]
                 }


### PR DESCRIPTION
* It allows to use the anchor behavior without the joystick shifting when players move the thumb.

### Demo
- https://github.com/GDevelopApp/GDevelop-examples/pull/464