### PR TITLE
[Toggle switch] Add a "has just been checked" condition to allow radio button group

### DIFF
--- a/extensions/reviewed/SpriteToggleSwitch.json
+++ b/extensions/reviewed/SpriteToggleSwitch.json
@@ -8,7 +8,7 @@
   "name": "SpriteToggleSwitch",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/Line Hero Pack/Master/SVG/Interface Elements/8d0cd8cd0c9318f4f6efde6ee6b4c192bd19306467f80c9970387a259300f895_Interface Elements_interface_ui_toggle_switch_on_off.svg",
   "shortDescription": "Toggle switch that users can click or touch.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": [
     "Toggle switch that users can click or touch. The switch can be customized with sprites.",
     "",
@@ -22,7 +22,8 @@
     "ui",
     "widget",
     "toggle",
-    "switch"
+    "switch",
+    "check box"
   ],
   "authorIds": [
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2",
@@ -46,6 +47,49 @@
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyWasChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::IsChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyWasChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
@@ -61,94 +105,11 @@
               "actions": [
                 {
                   "type": {
-                    "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyWasChecked"
+                    "value": "SpriteToggleSwitch::SwitchFSM::TogglePropertyIsChecked"
                   },
                   "parameters": [
                     "Object",
-                    "Behavior",
-                    "no"
-                  ]
-                }
-              ],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "SpriteToggleSwitch::SwitchFSM::IsChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyWasChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "SpriteToggleSwitch::SwitchFSM::PropertyWasChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyIsChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "SpriteToggleSwitch::SwitchFSM::PropertyWasChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SpriteToggleSwitch::SwitchFSM::SetPropertyIsChecked"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "no"
-                      ]
-                    }
+                    "Behavior"
                   ]
                 }
               ]
@@ -173,7 +134,6 @@
           "description": "Check if the toggle switch is checked.",
           "fullName": "Is checked",
           "functionType": "Condition",
-          "group": "Switch finite state machine configuration",
           "name": "IsChecked",
           "sentence": "_PARAM0_ is checked",
           "events": [
@@ -218,13 +178,218 @@
           "objectGroups": []
         },
         {
+          "description": "Check if the toggle switch was checked in the current frame.",
+          "fullName": "Has just been checked",
+          "functionType": "Condition",
+          "name": "HasJustBeenChecked",
+          "sentence": "_PARAM0_ has just been checked",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::PropertyIsChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SpriteToggleSwitch::SwitchFSM::PropertyWasChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "SpriteToggleSwitch::SwitchFSM",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the toggle switch was unchecked in the current frame.",
+          "fullName": "Has just been unchecked",
+          "functionType": "Condition",
+          "name": "HasJustBeenUnchecked",
+          "sentence": "_PARAM0_ has just been unchecked",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "SpriteToggleSwitch::SwitchFSM::PropertyIsChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::PropertyWasChecked"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "SpriteToggleSwitch::SwitchFSM",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
           "description": "Check (or uncheck) the toggle switch.",
           "fullName": "Check (or uncheck)",
           "functionType": "Action",
-          "group": "Switch finite state machine configuration",
           "name": "SetChecked",
           "sentence": "Check _PARAM0_: _PARAM2_",
           "events": [
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Avoid a started touch to interfere with a state change from events.",
+              "comment2": ""
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Value\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SpriteToggleSwitch::SwitchFSM::IsChecked"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "GetArgumentAsBoolean"
+                          },
+                          "parameters": [
+                            "\"Value\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "SpriteToggleSwitch::SwitchFSM::IsChecked"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::ButtonFSM::ResetState"
+                  },
+                  "parameters": [
+                    "Object",
+                    "ButtonFSM",
+                    ""
+                  ]
+                }
+              ]
+            },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
@@ -999,6 +1164,45 @@
           "functionType": "Action",
           "name": "onDeActivate",
           "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::ButtonFSM::ResetState"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "SpriteToggleSwitch::ButtonFSM",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Reset the state of the button.",
+          "fullName": "Reset state",
+          "functionType": "Action",
+          "name": "ResetState",
+          "sentence": "Reset the button state of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1807,6 +2011,92 @@
                 {
                   "type": {
                     "value": "SpriteToggleSwitch::SwitchFSM::IsChecked"
+                  },
+                  "parameters": [
+                    "State",
+                    "SwitchFSM",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "SpriteToggleSwitch::SpriteToggleSwitch",
+              "type": "object"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the toggle switch was checked in the current frame.",
+          "fullName": "Has just been checked",
+          "functionType": "Condition",
+          "name": "HasJustBeenChecked",
+          "sentence": "_PARAM0_ has just been checked",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::HasJustBeenChecked"
+                  },
+                  "parameters": [
+                    "State",
+                    "SwitchFSM",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "SpriteToggleSwitch::SpriteToggleSwitch",
+              "type": "object"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the toggle switch was unchecked in the current frame.",
+          "fullName": "Has just been unchecked",
+          "functionType": "Condition",
+          "name": "HasJustBeenUnchecked",
+          "sentence": "_PARAM0_ has just been unchecked",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SpriteToggleSwitch::SwitchFSM::HasJustBeenUnchecked"
                   },
                   "parameters": [
                     "State",


### PR DESCRIPTION
### Changes
- Add "has just been checked" and  "has just been unchecked" conditions.
- Reset the button state when the "SetChecked" action is used to allow a sort of dragging for the toolbar of the example. It avoid a touch to end when the button has changed of state from events because the user intent would be inverted.

### Demo
- https://github.com/GDevelopApp/GDevelop-examples/pull/488