### PR TITLE
[Button] Add a private reset function for other extensions using the FSM

### DIFF
--- a/extensions/reviewed/PanelSpriteButton.json
+++ b/extensions/reviewed/PanelSpriteButton.json
@@ -8,7 +8,7 @@
   "name": "PanelSpriteButton",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Interface Elements/Interface Elements_interface_ui_button_ok_cta_clock_tap.svg",
   "shortDescription": "A button that can be customized.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": [
     "The button can be customized with a background for each state and a label. It handles user interactions and a simple condition can be used to check if it is clicked.",
     "",
@@ -691,6 +691,46 @@
           "functionType": "Action",
           "name": "onDeActivate",
           "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PanelSpriteButton::ButtonFSM::ResetState"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "PanelSpriteButton::ButtonFSM",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Reset the state of the button.",
+          "fullName": "Reset state",
+          "functionType": "Action",
+          "name": "ResetState",
+          "private": true,
+          "sentence": "Reset the button state of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",


### PR DESCRIPTION
### Changes
- Nothing change for users
- The toogle switch uses the reset function
  https://github.com/GDevelopApp/GDevelop-extensions/pull/804

### Demo
- https://github.com/GDevelopApp/GDevelop-examples/pull/488