### PR TITLE
Extension proposition : Authorized Platform Validation

### DIFF
--- a/extensions/reviewed/AuthorizedPlatformsValidation.json
+++ b/extensions/reviewed/AuthorizedPlatformsValidation.json
@@ -2,10 +2,10 @@
   "author": "",
   "category": "Network",
   "extensionNamespace": "",
-  "fullName": "Validate Execution Context",
+  "fullName": "Authorized Platform Validation",
   "helpPath": "https://oxey405.com/projects/execution-context/index.html",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNoZWNrLWRlY2FncmFtIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTIzLDEyTDIwLjU2LDkuMjJMMjAuOSw1LjU0TDE3LjI5LDQuNzJMMTUuNCwxLjU0TDEyLDNMOC42LDEuNTRMNi43MSw0LjcyTDMuMSw1LjUzTDMuNDQsOS4yMUwxLDEyTDMuNDQsMTQuNzhMMy4xLDE4LjQ3TDYuNzEsMTkuMjlMOC42LDIyLjQ3TDEyLDIxTDE1LjQsMjIuNDZMMTcuMjksMTkuMjhMMjAuOSwxOC40NkwyMC41NiwxNC43OEwyMywxMk0xMCwxN0w2LDEzTDcuNDEsMTEuNTlMMTAsMTQuMTdMMTYuNTksNy41OEwxOCw5TDEwLDE3WiIgLz48L3N2Zz4=",
-  "name": "ValidateExecutionContext",
+  "name": "AuthorizedPlatformsValidation",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/0d42bc9711bc135b0dfb0084a37469540468e243a560339b99e399bd77f48010_check-decagram.svg",
   "shortDescription": "Checks if the game is currently executed on an allowed platform (for web)",
   "version": "1.0.6",
@@ -25,7 +25,8 @@
     "Copyright",
     "Origin",
     "Referrer",
-    "Execution Context"
+    "Execution Context",
+    "Platform"
   ],
   "authorIds": [
     "Mk7N5tFrpcePEmbe3ZLC4peEULY2"

--- a/extensions/reviewed/AuthorizedPlatformsValidation.json
+++ b/extensions/reviewed/AuthorizedPlatformsValidation.json
@@ -8,7 +8,7 @@
   "name": "AuthorizedPlatformsValidation",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/0d42bc9711bc135b0dfb0084a37469540468e243a560339b99e399bd77f48010_check-decagram.svg",
   "shortDescription": "Checks if the game is currently executed on an allowed platform (for web)",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": [
     "**check if your web game is being played on a platform your intended to publish on**",
     "Some web game platforms may steal your game to publish it on their own without your knowledge or consent!",
@@ -43,8 +43,15 @@
         {
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": [
-            "let currentReferrer = new URL(document.referrer);\r",
-            "eventsFunctionContext.returnValue = (gdjs._ValidateExecutionContext.validContexts.includes(currentReferrer.hostname));"
+            "let currentReferrer = \"\";\r",
+            "try {\r",
+            "    currentReferrer = new URL(document.referrer).hostname;\r",
+            "\r",
+            "} catch(err) {\r",
+            "    //We generally do not care about an error while parsing the URL\r",
+            "    console.log(\"Game is not running on a web platform\")\r",
+            "}\r",
+            "eventsFunctionContext.returnValue = gdjs._authorizedPlatforms.validPlatforms.includes(currentReferrer.hostname);"
           ],
           "parameterObjects": "",
           "useStrict": true,
@@ -63,7 +70,15 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "eventsFunctionContext.returnValue = new URL(document.referrer).hostname;",
+          "inlineCode": [
+            "let location = \"\";\r",
+            "try {\r",
+            "    location = new URL(document.referrer).hostname\r",
+            "} catch(err) {\r",
+            "    //If we could not parse the referrer into an URL, it means we are running locally\r",
+            "}\r",
+            "eventsFunctionContext.returnValue = location;"
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -84,7 +99,7 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "gdjs._ValidateExecutionContext.validContexts.push(eventsFunctionContext.getArgument(\"domain\"));",
+          "inlineCode": "gdjs._authorizedPlatforms.validPlatforms.push(eventsFunctionContext.getArgument(\"domain\"));",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -112,7 +127,7 @@
         },
         {
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "gdjs._ValidateExecutionContext = {validContexts: [\"\"]}",
+          "inlineCode": "gdjs._authorizedPlatforms = {validPlatforms: [\"\"]}",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false

--- a/extensions/reviewed/AuthorizedPlatformsValidation.json
+++ b/extensions/reviewed/AuthorizedPlatformsValidation.json
@@ -2,31 +2,41 @@
   "author": "",
   "category": "Network",
   "extensionNamespace": "",
-  "fullName": "Authorized Platform Validation",
+  "fullName": "Platforms Validation",
   "helpPath": "https://oxey405.com/projects/execution-context/index.html",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNoZWNrLWRlY2FncmFtIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTIzLDEyTDIwLjU2LDkuMjJMMjAuOSw1LjU0TDE3LjI5LDQuNzJMMTUuNCwxLjU0TDEyLDNMOC42LDEuNTRMNi43MSw0LjcyTDMuMSw1LjUzTDMuNDQsOS4yMUwxLDEyTDMuNDQsMTQuNzhMMy4xLDE4LjQ3TDYuNzEsMTkuMjlMOC42LDIyLjQ3TDEyLDIxTDE1LjQsMjIuNDZMMTcuMjksMTkuMjhMMjAuOSwxOC40NkwyMC41NiwxNC43OEwyMywxMk0xMCwxN0w2LDEzTDcuNDEsMTEuNTlMMTAsMTQuMTdMMTYuNTksNy41OEwxOCw5TDEwLDE3WiIgLz48L3N2Zz4=",
   "name": "AuthorizedPlatformsValidation",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/0d42bc9711bc135b0dfb0084a37469540468e243a560339b99e399bd77f48010_check-decagram.svg",
-  "shortDescription": "Checks if the game is currently executed on an allowed platform (for web)",
-  "version": "1.0.8",
+  "shortDescription": "Checks if the game is currently executed on an allowed platform (for web).",
+  "version": "1.0.0",
   "description": [
-    "**check if your web game is being played on a platform your intended to publish on**",
+    "# About",
+    "**Checks if your web game is being played on a platform your intended to publish on.**",
     "Some web game platforms may steal your game to publish it on their own without your knowledge or consent!",
-    "This extension is here to check if the game is being played on an authorized platform you can set!",
+    "This extension is here to check if the game is being played from a platform you intended!",
+    "You can for example prevents users from playing your game on a platform that republished it without your consent. ",
     "",
-    "*How to use*",
-    "an authorized platform is a domain name of a website where the game is supposed to run, for example : gd.games.",
+    "# How to use",
+    "An authorized platform is a domain name of a website where the game is supposed to run, for example : gd.games.",
     "1. You can get the current domain where the game is being played by using getReferrer()",
     "2. You can add an authorized platform domain name (it's recommended to do this at the beginning of the scene)",
-    "3. You can then check if the game is running on an authorized platform and make the game react accordingly"
+    "3. You can then check if the game is running on an authorized platform and make the game react accordingly",
+    "",
+    "# Example",
+    "[Download an example here](https://oxey405.com/projects/execution-context)."
   ],
   "tags": [
-    "DRM",
-    "Copyright",
-    "Origin",
-    "Referrer",
-    "Execution Context",
-    "Platform"
+    "drm",
+    "copyright",
+    "origin",
+    "referrer",
+    "execution context",
+    "platform",
+    "copy",
+    "protect",
+    "anti-theft",
+    "steal",
+    "theft"
   ],
   "authorIds": [
     "Mk7N5tFrpcePEmbe3ZLC4peEULY2"
@@ -113,7 +123,7 @@
       "objectGroups": []
     },
     {
-      "description": "Get the referrer's location (the domain of the root page where your game is embedded).",
+      "description": "Get the referrer's location (the domain of the website that hosts your game).",
       "fullName": "Get referrer location",
       "functionType": "StringExpression",
       "name": "CurrentRefferer",
@@ -122,8 +132,9 @@
         {
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": [
-            "//If the document referrer is not empty, return the hostname (the domain name) else, return an empty string.\r",
-            "eventsFunctionContext.returnValue = document.referrer ? new URL(document.referrer).hostname : \"\" ;"
+            "// If the document referrer is not empty, return the hostname (the domain name) else, return an empty string.\r",
+            "eventsFunctionContext.returnValue = document.referrer ? new URL(document.referrer).hostname : \"\" ;\r",
+            ""
           ],
           "parameterObjects": "",
           "useStrict": true,
@@ -137,7 +148,7 @@
       "objectGroups": []
     },
     {
-      "description": "Adds a new valid platform aka a domain name where the game is expected to be played (e.g : gd.games).",
+      "description": "Adds a new valid platform (domain name where the game is expected to be played, for example, gd.games).",
       "fullName": "Add a valid platform",
       "functionType": "Action",
       "name": "AddExecution",
@@ -153,7 +164,7 @@
               },
               "parameters": [
                 "__AuthorizedPlatformsValidation.AuthorizedPlatforms",
-                "GetArgumentAsString(\"domain\")"
+                "GetArgumentAsString(\"Domain\")"
               ]
             }
           ]
@@ -162,7 +173,7 @@
       "parameters": [
         {
           "description": "Domain name (e.g : gd.games)",
-          "name": "domain",
+          "name": "Domain",
           "type": "string"
         }
       ],

--- a/extensions/reviewed/AuthorizedPlatformsValidation.json
+++ b/extensions/reviewed/AuthorizedPlatformsValidation.json
@@ -8,7 +8,7 @@
   "name": "AuthorizedPlatformsValidation",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/0d42bc9711bc135b0dfb0084a37469540468e243a560339b99e399bd77f48010_check-decagram.svg",
   "shortDescription": "Checks if the game is currently executed on an allowed platform (for web)",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": [
     "**check if your web game is being played on a platform your intended to publish on**",
     "Some web game platforms may steal your game to publish it on their own without your knowledge or consent!",
@@ -34,35 +34,86 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Checks if the game is executed on an authorized platform",
+      "description": "Checks if the game is executed on an authorized platform (preferably, run this only once at beginning of the game).",
       "fullName": "Is the game running on an authorized platform",
       "functionType": "Condition",
       "name": "CheckExecution",
       "sentence": "The game is running on a authorized platform",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": [
-            "let currentReferrer = \"\";\r",
-            "try {\r",
-            "    currentReferrer = new URL(document.referrer).hostname;\r",
-            "\r",
-            "} catch(err) {\r",
-            "    //We generally do not care about an error while parsing the URL\r",
-            "    console.log(\"Game is not running on a web platform\")\r",
-            "}\r",
-            "eventsFunctionContext.returnValue = gdjs._authorizedPlatforms.validPlatforms.includes(currentReferrer.hostname);"
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Default return value is false",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Or"
+              },
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "value": "AuthorizedPlatformsValidation::Includes"
+                  },
+                  "parameters": [
+                    "",
+                    "AuthorizedPlatformsValidation::CurrentRefferer()",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SystemInfo::IsPreview"
+                  },
+                  "parameters": [
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SystemInfo::IsNativeMobileApp"
+                  },
+                  "parameters": []
+                },
+                {
+                  "type": {
+                    "value": "SystemInfo::IsNativeDesktopApp"
+                  },
+                  "parameters": [
+                    ""
+                  ]
+                }
+              ]
+            }
           ],
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": false
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
         }
       ],
       "parameters": [],
       "objectGroups": []
     },
     {
-      "description": "Get the referrer's location aka the domain of the page (at the root)",
+      "description": "Get the referrer's location (the domain of the root page where your game is embedded).",
       "fullName": "Get referrer location",
       "functionType": "StringExpression",
       "name": "CurrentRefferer",
@@ -71,13 +122,8 @@
         {
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": [
-            "let location = \"\";\r",
-            "try {\r",
-            "    location = new URL(document.referrer).hostname\r",
-            "} catch(err) {\r",
-            "    //If we could not parse the referrer into an URL, it means we are running locally\r",
-            "}\r",
-            "eventsFunctionContext.returnValue = location;"
+            "//If the document referrer is not empty, return the hostname (the domain name) else, return an empty string.\r",
+            "eventsFunctionContext.returnValue = document.referrer ? new URL(document.referrer).hostname : \"\" ;"
           ],
           "parameterObjects": "",
           "useStrict": true,
@@ -91,18 +137,26 @@
       "objectGroups": []
     },
     {
-      "description": "Adds a new valid platform aka a domain name where the game is expected to be played (e.g : gd.games)",
+      "description": "Adds a new valid platform aka a domain name where the game is expected to be played (e.g : gd.games).",
       "fullName": "Add a valid platform",
       "functionType": "Action",
       "name": "AddExecution",
       "sentence": "Add _PARAM1_ as valid platform",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "gdjs._authorizedPlatforms.validPlatforms.push(eventsFunctionContext.getArgument(\"domain\"));",
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": false
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "GlobalVariablePushString"
+              },
+              "parameters": [
+                "__AuthorizedPlatformsValidation.AuthorizedPlatforms",
+                "GetArgumentAsString(\"domain\")"
+              ]
+            }
+          ]
         }
       ],
       "parameters": [
@@ -115,25 +169,42 @@
       "objectGroups": []
     },
     {
-      "fullName": "",
-      "functionType": "Action",
-      "name": "onFirstSceneLoaded",
-      "sentence": "",
+      "description": "Check if a domain is contained in the authorized list array.",
+      "fullName": "Check if a domain is contained in the authorized list",
+      "functionType": "Condition",
+      "name": "Includes",
+      "private": true,
+      "sentence": "Check if _PARAM1_ is in the list of authorized platforms",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": []
-        },
-        {
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "gdjs._authorizedPlatforms = {validPlatforms: [\"\"]}",
+          "inlineCode": [
+            "const authorizedPlatformsVariableReference = runtimeScene.getGame()\r",
+            "    .getVariables()\r",
+            "    .get(\"__AuthorizedPlatformsValidation\")\r",
+            "    .getChild(\"AuthorizedPlatforms\");\r",
+            "    \r",
+            "authorizedPlatformsVariableReference.castTo(\"array\");\r",
+            "\r",
+            "eventsFunctionContext.returnValue = \r",
+            "    authorizedPlatformsVariableReference.toJSObject()\r",
+            "    .includes(\r",
+            "        eventsFunctionContext.getArgument(\"DomainToCheck\")\r",
+            "        );\r",
+            ""
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
         }
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "description": "Domain to check",
+          "name": "DomainToCheck",
+          "type": "string"
+        }
+      ],
       "objectGroups": []
     }
   ],

--- a/extensions/reviewed/AuthorizedPlatformsValidation.json
+++ b/extensions/reviewed/AuthorizedPlatformsValidation.json
@@ -15,7 +15,7 @@
     "This extension is here to check if the game is being played on an authorized platform you can set!",
     "",
     "*How to use*",
-    "Here, an execution context is an authorized platform domain name, for example : gd.games.",
+    "an authorized platform is a domain name of a website where the game is supposed to run, for example : gd.games.",
     "1. You can get the current domain where the game is being played by using getReferrer()",
     "2. You can add an authorized platform domain name (it's recommended to do this at the beginning of the scene)",
     "3. You can then check if the game is running on an authorized platform and make the game react accordingly"
@@ -35,10 +35,10 @@
   "eventsFunctions": [
     {
       "description": "Checks if the game is executed on an authorized platform",
-      "fullName": "Is the game running on a valid context",
+      "fullName": "Is the game running on an authorized platform",
       "functionType": "Condition",
       "name": "CheckExecution",
-      "sentence": "The game is running on a valid context",
+      "sentence": "The game is running on a authorized platform",
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
@@ -76,11 +76,11 @@
       "objectGroups": []
     },
     {
-      "description": "Adds a new valid execution context aka a domain name where the game is expected to be played (e.g : gd.games)",
-      "fullName": "Add a valid execution context",
+      "description": "Adds a new valid platform aka a domain name where the game is expected to be played (e.g : gd.games)",
+      "fullName": "Add a valid platform",
       "functionType": "Action",
       "name": "AddExecution",
-      "sentence": "Add _PARAM1_ as valid execution context",
+      "sentence": "Add _PARAM1_ as valid platform",
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",

--- a/extensions/reviewed/ValidateExecutionContext.json
+++ b/extensions/reviewed/ValidateExecutionContext.json
@@ -1,0 +1,126 @@
+{
+  "author": "",
+  "category": "Network",
+  "extensionNamespace": "",
+  "fullName": "Validate Execution Context",
+  "helpPath": "https://oxey405.com/projects/execution-context/index.html",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNoZWNrLWRlY2FncmFtIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTIzLDEyTDIwLjU2LDkuMjJMMjAuOSw1LjU0TDE3LjI5LDQuNzJMMTUuNCwxLjU0TDEyLDNMOC42LDEuNTRMNi43MSw0LjcyTDMuMSw1LjUzTDMuNDQsOS4yMUwxLDEyTDMuNDQsMTQuNzhMMy4xLDE4LjQ3TDYuNzEsMTkuMjlMOC42LDIyLjQ3TDEyLDIxTDE1LjQsMjIuNDZMMTcuMjksMTkuMjhMMjAuOSwxOC40NkwyMC41NiwxNC43OEwyMywxMk0xMCwxN0w2LDEzTDcuNDEsMTEuNTlMMTAsMTQuMTdMMTYuNTksNy41OEwxOCw5TDEwLDE3WiIgLz48L3N2Zz4=",
+  "name": "ValidateExecutionContext",
+  "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/0d42bc9711bc135b0dfb0084a37469540468e243a560339b99e399bd77f48010_check-decagram.svg",
+  "shortDescription": "Checks if the game is currently executed on an allowed platform (for web)",
+  "version": "1.0.6",
+  "description": [
+    "**check if your web game is being played on a platform your intended to publish on**",
+    "Some web game platforms may steal your game to publish it on their own without your knowledge or consent!",
+    "This extension is here to check if the game is being played on an authorized platform you can set!",
+    "",
+    "*How to use*",
+    "Here, an execution context is an authorized platform domain name, for example : gd.games.",
+    "1. You can get the current domain where the game is being played by using getReferrer()",
+    "2. You can add an authorized platform domain name (it's recommended to do this at the beginning of the scene)",
+    "3. You can then check if the game is running on an authorized platform and make the game react accordingly"
+  ],
+  "tags": [
+    "DRM",
+    "Copyright",
+    "Origin",
+    "Referrer",
+    "Execution Context"
+  ],
+  "authorIds": [
+    "Mk7N5tFrpcePEmbe3ZLC4peEULY2"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Checks if the game is executed on an authorized platform",
+      "fullName": "Is the game running on a valid context",
+      "functionType": "Condition",
+      "name": "CheckExecution",
+      "sentence": "The game is running on a valid context",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "let currentReferrer = new URL(document.referrer);\r",
+            "eventsFunctionContext.returnValue = (gdjs._ValidateExecutionContext.validContexts.includes(currentReferrer.hostname));"
+          ],
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Get the referrer's location aka the domain of the page (at the root)",
+      "fullName": "Get referrer location",
+      "functionType": "StringExpression",
+      "name": "CurrentRefferer",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "eventsFunctionContext.returnValue = new URL(document.referrer).hostname;",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "expressionType": {
+        "type": "string"
+      },
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Adds a new valid execution context aka a domain name where the game is expected to be played (e.g : gd.games)",
+      "fullName": "Add a valid execution context",
+      "functionType": "Action",
+      "name": "AddExecution",
+      "sentence": "Add _PARAM1_ as valid execution context",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs._ValidateExecutionContext.validContexts.push(eventsFunctionContext.getArgument(\"domain\"));",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Domain name (e.g : gd.games)",
+          "name": "domain",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onFirstSceneLoaded",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": []
+        },
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "gdjs._ValidateExecutionContext = {validContexts: [\"\"]}",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
+}


### PR DESCRIPTION
This is a small extension made to check where a game exported to web is executed to insure it is not being published and played on an unauthorized platform.
Some platforms scraps websites such as itch.io (and gd.games) in the search to republish small but relatively popular games on their website without the owner's content and then display ads on the page to make profit out of a game they did not even have the right to publish !
This extension allows for gamedevs to define with events which platforms are allowed and can use the "The game is running on a valid context" conditon to act accordingly for example, displaying a warning message or block the game entirely.