### PR TITLE
Clean markdown files and fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,22 +10,26 @@ about: Create a bug report about an extension (for GDevelop itself, go to https:
 -->
 
 ## Describe the bug of the extension
+
 Enter the name of the extension.
 Then a clear and concise description of what the bug is.
 
 Please double check that the bug is not already reported in the issues list.
 
 ## To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Use action '....'
 3. Launch the game
-4. See it's not workinng properly
+4. See it's not working properly
 
 * Please include a link to a game if possible!
 * If applicable, add screenshots to help explain your problem.
 
 ## Other details
+
 * Include any OS/browser version/smartphone that you're using
 * Which version of GDevelop are you using? The desktop app or the web-app?
 * Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ If you've created an extension with GDevelop, you can submit it to be shared wit
 4. Submit it! You can either:
    - **Easy**: [submit it here](https://github.com/4ian/GDevelop-extensions/issues/new/choose), attaching the _.json file_ (as a zip, because GitHub won't accept json files directly).
    - **If you know how to use git**: fork this repository, clone the git, add your .json file in `extensions/community` folder. Finally [open a Pull Request](https://github.com/4ian/GDevelop-extensions/compare).
-   
-5. Your extension will be added after a automated checks and a *quick safety check*. 🚀
-  > **Note**: If automated checks are failing, please adapt your extension and submit it again to get it added! Even if we don't do a full review of all extensions, just safety checks, the automated checks must pass. Look at automated comments that will be added to the *Pull Request* corresponding to your submission.
+5. Your extension will be added after a automated checks and a _quick safety check_. 🚀
+
+  > **Note**: If automated checks are failing, please adapt your extension and submit it again to get it added! Even if we don't do a full review of all extensions, just safety checks, the automated checks must pass. Look at automated comments that will be added to the _Pull Request_ corresponding to your submission.
 
 ## Get your extension (reviewed extensions)
 
 Reviewed extensions are community extensions that got reviewed and adapted to meet all **[the best practices that are listed here](https://wiki.gdevelop.io/gdevelop5/extensions/best-practices)**.
 
-If your community extension is very useful and you think its quality is good enough: 
+If your community extension is very useful and you think its quality is good enough:
 
-1. open a *Pull Request* to move it from the `community` folder to the `reviewed` folder. 
-2. A member of the *GDevelop Extensions Team* will then review it and give you feedback on what to do to have it reviewed.
+1. open a _Pull Request_ to move it from the `community` folder to the `reviewed` folder.
+2. A member of the _GDevelop Extensions Team_ will then review it and give you feedback on what to do to have it reviewed.
 3. When it's ready, it will be merged and the extension now accessible in the "reviewed" extensions.
 
 > **Note**: When your extension gets reviewed, the extension team will ask you to adapt your extension to reach a fairly high quality bar. It's normal! The feedback is here to help get the extension in a state where it's super flexible and useful for all users.

--- a/extensions/community/PauseFocusLost.json
+++ b/extensions/community/PauseFocusLost.json
@@ -11,7 +11,7 @@
   "shortDescription": "Pauses when focus is lost, restarts when focus is regained.",
   "version": "0.0.2",
   "tags": [
-    "Puse",
+    "Pause",
     "focus"
   ],
   "authorIds": [

--- a/scripts/check-single-extension.js
+++ b/scripts/check-single-extension.js
@@ -13,7 +13,7 @@ exports.verifyExtension = async function (
   extensionsFolder = `${__dirname}/../extensions`
 ) {
   // Make sure the name is valid, as dots are not allowed in the name
-  // and could be used to do relative path schenanigans that could result in skipping automatic checks.
+  // and could be used to do relative path shenanigans that could result in skipping automatic checks.
   if (!isValidExtensionName(extensionName))
     return { code: 'invalid-file-name' };
 

--- a/scripts/extract-extension.js
+++ b/scripts/extract-extension.js
@@ -34,7 +34,7 @@ exports.extractExtension = async function (
   if (ext !== '.json') return { error: 'invalid-file-name' };
 
   // Ensure no special characters are in the extension name to prevent relative path
-  // name schenanigans with dots that could put the extension in the reviewed folder.
+  // name shenanigans with dots that could put the extension in the reviewed folder.
   if (dir) return { error: 'invalid-file-name' };
   if (!isValidExtensionName(extensionName))
     return { error: 'invalid-file-name' };

--- a/scripts/lib/ExtensionNameValidator.js
+++ b/scripts/lib/ExtensionNameValidator.js
@@ -9,7 +9,7 @@ exports.isValidExtensionName = (extensionName) => {
   const len = extensionName.length;
   for (let i = 1; i < len; i++) {
     const charCode = extensionName.charCodeAt(i);
-    // Use the ascii table to check quickly if a character is a normal upper- or lowecase character or a number,
+    // Use the ascii table to check quickly if a character is a normal upper- or lowercase character or a number,
     // as only those are allowed as extension names.
     if (
       // If below numbers range...

--- a/scripts/lib/ExtensionsValidatorExceptions.js
+++ b/scripts/lib/ExtensionsValidatorExceptions.js
@@ -86,7 +86,7 @@ const extensionsAllowedProperties = {
     // Events tools are wrappers of the JavaScript APIs allowing them to be called by events.
     // They should not be used 99% of the time, the only base exception being
     // `common` as it contains utility functions like `clamp` that are not available
-    // in JavaScript by default. Appart from this, the JavaScript functions should be used instead.
+    // in JavaScript by default. Apart from this, the JavaScript functions should be used instead.
     gdjsEvtToolsAllowedProperties: ['common'],
     runtimeSceneAllowedProperties: [
       'getVariables',


### PR DESCRIPTION
Updated
- Add black line
- Remove trailing whitespace
- Emphasis style consistently
- Typo
  - workinng -> working