### PR TITLE
Add "Start dragging object" to enable custom picking of object to be dragged

### DIFF
--- a/extensions/reviewed/DraggablePhysics.json
+++ b/extensions/reviewed/DraggablePhysics.json
@@ -106,8 +106,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Create mouse joints and save the joint ID",
-                  "comment2": ""
+                  "comment": "Create mouse joints and save the joint ID"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -214,8 +213,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Delete the mouse joint",
-                  "comment2": ""
+                  "comment": "Delete the mouse joint"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -262,8 +260,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Update the position of the mouse joint to follow the mouse",
-                  "comment2": ""
+                  "comment": "Update the position of the mouse joint to follow the mouse"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -314,7 +311,7 @@
           "objectGroups": []
         },
         {
-          "description": "Start dragging the object.",
+          "description": "Start dragging object.",
           "fullName": "Start dragging object",
           "functionType": "Action",
           "name": "StartDragging",

--- a/extensions/reviewed/DraggablePhysics.json
+++ b/extensions/reviewed/DraggablePhysics.json
@@ -8,7 +8,7 @@
   "name": "DraggablePhysics",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Virtual Reality/Virtual Reality_hand_vr_ar_360.svg",
   "shortDescription": "Drag a physics object with the mouse (or touch).",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": [
     "Enables players to click and drag on physics objects to move them.  The object retains velocity when the click is released, allowing players to fling objects across the screen.",
     "",
@@ -112,6 +112,17 @@
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
+                    {
+                      "type": {
+                        "value": "DraggablePhysics::DraggablePhysics::PropertyMouseButton"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "!=",
+                        "\"None (Disable automatic dragging)\""
+                      ]
+                    },
                     {
                       "type": {
                         "value": "MouseButtonFromTextPressed"
@@ -759,6 +770,61 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Start dragging the object.  The \"Release drag\" action can be used if automatic dragging is disabled.",
+          "fullName": "Start dragging the object",
+          "functionType": "Action",
+          "name": "StartDragging",
+          "sentence": "Start dragging (physics) _PARAM0_ ",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Physics2::AddMouseJoint"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PhysicsBehavior",
+                    "MouseX(Object.Layer(),0)",
+                    "MouseY(Object.Layer(),0)",
+                    "Object.Behavior::PropertyMaxForce()",
+                    "Object.Behavior::PropertyFrequency()",
+                    "Object.Behavior::PropertyDamping()",
+                    "__DraggablePhysics.MouseJointID"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Variable(__DraggablePhysics.MouseJointID)"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "DraggablePhysics::DraggablePhysics",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -783,7 +849,8 @@
           "extraInformation": [
             "Left",
             "Right",
-            "Middle"
+            "Middle",
+            "None (Disable automatic dragging)"
           ],
           "hidden": false,
           "name": "MouseButton"

--- a/extensions/reviewed/DraggablePhysics.json
+++ b/extensions/reviewed/DraggablePhysics.json
@@ -114,29 +114,12 @@
                   "conditions": [
                     {
                       "type": {
-                        "value": "DraggablePhysics::DraggablePhysics::PropertyMouseButton"
+                        "value": "DraggablePhysics::DraggablePhysics::PropertyEnableAutomaticDragging"
                       },
                       "parameters": [
                         "Object",
-                        "Behavior",
-                        "!=",
-                        "\"None (Disable automatic dragging)\""
+                        "Behavior"
                       ]
-                    },
-                    {
-                      "type": {
-                        "value": "MouseButtonFromTextPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Object.Behavior::PropertyMouseButton()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": []
                     }
                   ],
                   "actions": [],
@@ -146,52 +129,75 @@
                       "conditions": [
                         {
                           "type": {
-                            "inverted": true,
-                            "value": "DraggablePhysics::DraggablePhysics::IsBeingDragged"
+                            "value": "MouseButtonFromTextPressed"
                           },
                           "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
+                            "",
+                            "Object.Behavior::PropertyMouseButton()"
                           ]
                         },
                         {
                           "type": {
-                            "value": "SourisSurObjet"
+                            "value": "BuiltinCommonInstructions::Once"
                           },
-                          "parameters": [
-                            "Object",
-                            "",
-                            "",
-                            ""
-                          ]
+                          "parameters": []
                         }
                       ],
-                      "actions": [
+                      "actions": [],
+                      "events": [
                         {
-                          "type": {
-                            "value": "Physics2::AddMouseJoint"
-                          },
-                          "parameters": [
-                            "Object",
-                            "PhysicsBehavior",
-                            "MouseX(Object.Layer(),0)",
-                            "MouseY(Object.Layer(),0)",
-                            "Object.Behavior::PropertyMaxForce()",
-                            "Object.Behavior::PropertyFrequency()",
-                            "Object.Behavior::PropertyDamping()",
-                            "__DraggablePhysics.MouseJointID"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "Variable(__DraggablePhysics.MouseJointID)"
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "DraggablePhysics::DraggablePhysics::IsBeingDragged"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ""
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SourisSurObjet"
+                              },
+                              "parameters": [
+                                "Object",
+                                "",
+                                "",
+                                ""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "Physics2::AddMouseJoint"
+                              },
+                              "parameters": [
+                                "Object",
+                                "PhysicsBehavior",
+                                "MouseX(Object.Layer(),0)",
+                                "MouseY(Object.Layer(),0)",
+                                "Object.Behavior::PropertyMaxForce()",
+                                "Object.Behavior::PropertyFrequency()",
+                                "Object.Behavior::PropertyDamping()",
+                                "__DraggablePhysics.MouseJointID"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "Variable(__DraggablePhysics.MouseJointID)"
+                              ]
+                            }
                           ]
                         }
                       ]
@@ -214,6 +220,15 @@
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
+                    {
+                      "type": {
+                        "value": "DraggablePhysics::DraggablePhysics::PropertyEnableAutomaticDragging"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    },
                     {
                       "type": {
                         "value": "MouseButtonFromTextReleased"
@@ -281,6 +296,73 @@
                 }
               ],
               "parameters": []
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "DraggablePhysics::DraggablePhysics",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Start dragging the object.",
+          "fullName": "Start dragging object",
+          "functionType": "Action",
+          "name": "StartDragging",
+          "sentence": "Start dragging (physics) _PARAM0_ ",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "DraggablePhysics::DraggablePhysics::IsBeingDragged"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Physics2::AddMouseJoint"
+                  },
+                  "parameters": [
+                    "Object",
+                    "PhysicsBehavior",
+                    "MouseX(Object.Layer(),0)",
+                    "MouseY(Object.Layer(),0)",
+                    "Object.Behavior::PropertyMaxForce()",
+                    "Object.Behavior::PropertyFrequency()",
+                    "Object.Behavior::PropertyDamping()",
+                    "__DraggablePhysics.MouseJointID"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Variable(__DraggablePhysics.MouseJointID)"
+                  ]
+                }
+              ]
             }
           ],
           "parameters": [
@@ -772,40 +854,33 @@
           "objectGroups": []
         },
         {
-          "description": "Start dragging the object.  The \"Release drag\" action can be used if automatic dragging is disabled.",
-          "fullName": "Start dragging the object",
-          "functionType": "Action",
-          "name": "StartDragging",
-          "sentence": "Start dragging (physics) _PARAM0_ ",
+          "description": "Check if automatic dragging is enabled.",
+          "fullName": "Automatic dragging",
+          "functionType": "Condition",
+          "group": "Draggable (for physics objects) configuration",
+          "name": "IsAutomaticDraggingEnabled",
+          "sentence": "Automatic dragging is enabled on _PARAM0_ ",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "value": "DraggablePhysics::DraggablePhysics::PropertyEnableAutomaticDragging"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
-                    "value": "Physics2::AddMouseJoint"
+                    "value": "SetReturnBoolean"
                   },
                   "parameters": [
-                    "Object",
-                    "PhysicsBehavior",
-                    "MouseX(Object.Layer(),0)",
-                    "MouseY(Object.Layer(),0)",
-                    "Object.Behavior::PropertyMaxForce()",
-                    "Object.Behavior::PropertyFrequency()",
-                    "Object.Behavior::PropertyDamping()",
-                    "__DraggablePhysics.MouseJointID"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "DraggablePhysics::DraggablePhysics::SetPropertyMouseJointID"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "Variable(__DraggablePhysics.MouseJointID)"
+                    "True"
                   ]
                 }
               ]
@@ -822,6 +897,88 @@
               "name": "Behavior",
               "supplementaryInformation": "DraggablePhysics::DraggablePhysics",
               "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Enable (or disable) automatic dragging with the mouse or touch.",
+          "fullName": "Enable (or disable) automatic dragging",
+          "functionType": "Action",
+          "group": "Draggable (for physics objects) configuration",
+          "name": "SetEnableAutomaticDragging",
+          "sentence": "Enable automatic dragging on _PARAM0_: _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "DraggablePhysics::DraggablePhysics::SetPropertyEnableAutomaticDragging"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "DraggablePhysics::DraggablePhysics::SetPropertyEnableAutomaticDragging"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "DraggablePhysics::DraggablePhysics",
+              "type": "behavior"
+            },
+            {
+              "defaultValue": "yes",
+              "description": "EnableAutomaticDragging",
+              "name": "Value",
+              "optional": true,
+              "type": "yesorno"
             }
           ],
           "objectGroups": []
@@ -849,8 +1006,7 @@
           "extraInformation": [
             "Left",
             "Right",
-            "Middle",
-            "None (Disable automatic dragging)"
+            "Middle"
           ],
           "hidden": false,
           "name": "MouseButton"
@@ -895,6 +1051,16 @@
           "extraInformation": [],
           "hidden": true,
           "name": "MouseJointID"
+        },
+        {
+          "value": "true",
+          "type": "Boolean",
+          "label": "Enable automatic dragging",
+          "description": "If automatic dragging is disabled, use the \"Start drag\" and \"Release drag\" actions.",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "EnableAutomaticDragging"
         }
       ],
       "sharedPropertyDescriptors": []


### PR DESCRIPTION
Default dragging requires the cursor to be over an object. This is not great for fabrics of small objects, because there is a lot of space that will not trigger a drag to start.  This change adds a new action to manually start dragging, so game creators can choose when and which objects to grab.

To enable this logic, I added a new option to the Mouse Button property: "None (disable automatic dragging)".
Do you like this implementation, or should I make a separate property, such as: "Enable automatic dragging"?

![image](https://user-images.githubusercontent.com/8879811/236732667-7de8c521-ee20-44d9-ac00-51b9ee4ad065.png)

## Example game

https://gd.games/victrisgames/building-monsters