### PR TITLE
[Reviewed] [Mouse pointer lock] Add handling of touches

### DIFF
--- a/extensions/reviewed/MousePointerLock.json
+++ b/extensions/reviewed/MousePointerLock.json
@@ -8,7 +8,7 @@
   "name": "MousePointerLock",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Virtual Reality/Virtual Reality_360_rotate_vr_movement.svg",
   "shortDescription": "This behavior removes the limit on the distance the mouse can move and hides the cursor.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": [
     "This behavior removes the limit on the distance the mouse can move and hides the cursor.",
     "",
@@ -17,7 +17,7 @@
     "",
     "Game players don't have to worry about leaving the gameplay area or accidentally clicking on another application that moves the mouse focus away from the game.",
     "",
-    "Locking the pointer locks `MouseX()` and `MouseY()` expressions.",
+    "Locking the pointer locks `CursorX()` and `CursorY()` expressions.",
     "Use `MovementX()` and `MovementY()` instead.",
     ""
   ],
@@ -49,7 +49,7 @@
             "gdjs._MousePointerLockExtension = {};",
             "gdjs._MousePointerLockExtension.movement = { x: 0, y: 0 };",
             "",
-            "canvas.addEventListener(\"mousemove\", (e) => {",
+            "canvas.addEventListener(\"pointermove\", (e) => {",
             "    gdjs._MousePointerLockExtension.movement.x += e.movementX || 0;",
             "    gdjs._MousePointerLockExtension.movement.y += e.movementY || 0;",
             "}, false);"


### PR DESCRIPTION
Listen `pointermove` instead of `mousemove` to make it work on with touch events too.