### PR TITLE
fix: mouse acceleration on laptop

### DIFF
--- a/extensions/reviewed/MousePointerLock.json
+++ b/extensions/reviewed/MousePointerLock.json
@@ -132,7 +132,7 @@
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": [
             "const canvas = runtimeScene.getGame().getRenderer().getCanvas();\r",
-            "canvas.requestPointerLock();"
+            "canvas.requestPointerLock({ unadjustedMovement: true });"
           ],
           "parameterObjects": "",
           "useStrict": true,


### PR DESCRIPTION
On devices with a touchpad and a usb mouse connected, sometimes the mouse acceleration does not match on both devices. To prevent the mouse from jumping around, I disabled the default system acceleration

```js
canvas.requestPointerLock({
  unadjustedMovement: true
});
```
Example: https://youtu.be/AdXtAb_7_gg

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API