### PR TITLE
Upgrade in-app-purchase version for Google Play Billing v5

### DIFF
--- a/extensions/reviewed/InAppPurchase.json
+++ b/extensions/reviewed/InAppPurchase.json
@@ -9,24 +9,15 @@
   "name": "InAppPurchase",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Shopping and Ecommerce/Shopping and Ecommerce_wallet_money_cash.svg",
   "shortDescription": "Add items to buy directly in your game (\"In-App Purchase\"), for games published on Android or iOS.",
-  "version": "0.0.2",
-  "tags": [
-    "purchase",
-    "iap",
-    "android",
-    "ios",
-    "monetization"
-  ],
-  "authorIds": [
-    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1",
-    "wWP8BSlAW0UP4NeaHa2LcmmDzmH2"
-  ],
+  "version": "0.0.3",
+  "tags": ["purchase", "iap", "android", "ios", "monetization"],
+  "authorIds": ["ZgrsWuRTAkXgeuPV9bo0zuEcA2w1", "wWP8BSlAW0UP4NeaHa2LcmmDzmH2"],
   "dependencies": [
     {
       "exportName": "cordova-plugin-purchase",
       "name": "Purchase plugin",
       "type": "cordova",
-      "version": "11.0.0"
+      "version": "13.5.0"
     }
   ],
   "eventsFunctions": [


### PR DESCRIPTION
Not tested yet, should allow upgrading to Google Play Billing v5 (see https://github.com/j3k0/cordova-plugin-purchase/pull/1308)

Should test with example: https://github.com/GDevelopApp/GDevelop-examples/tree/main/examples/in-app-purchase