### PR TITLE
Added TweenGroup extension exceptions

### DIFF
--- a/scripts/lib/ExtensionsValidatorExceptions.js
+++ b/scripts/lib/ExtensionsValidatorExceptions.js
@@ -412,6 +412,12 @@ const extensionsAllowedProperties = {
       runtimeSceneAllowedProperties: [],
       javaScriptObjectAllowedProperties: [],
     },
+    TweenGroup: {
+      gdjsAllowedProperties: ['TweenRuntimeBehavior'],
+      gdjsEvtToolsAllowedProperties: [],
+      runtimeSceneAllowedProperties: ['getObjects'],
+      javaScriptObjectAllowedProperties: [],
+    },
     VoiceRecognition: {
       gdjsAllowedProperties: ['_extensionVoiceRecognition'],
       gdjsEvtToolsAllowedProperties: [],


### PR DESCRIPTION
Added TweenGroup extension (#774) `gdjsAllowedProperties` and `runtimeSceneAllowedProperties` exceptions