### PR TITLE
Add behavior and object headers

### DIFF
--- a/scripts/generate-extensions-registry.js
+++ b/scripts/generate-extensions-registry.js
@@ -176,6 +176,25 @@ const readExtensionsFromFolder = async (folderPath, tier) => {
           previewIconUrl: extension.previewIconUrl,
           eventsBasedBehaviorsCount: extension.eventsBasedBehaviors.length,
           eventsFunctionsCount: extension.eventsFunctions.length,
+          behaviorHeaders: extension.eventsBasedBehaviors
+            .map((behavior) =>
+              behavior.private
+                ? null
+                : {
+                    name: behavior.name,
+                    fullName: behavior.fullName,
+                    description: behavior.description,
+                    objectType: behavior.objectType,
+                  }
+            )
+            .filter(Boolean),
+          objectHeaders: extension.eventsBasedObjects
+            ? extension.eventsBasedObjects.map((object) => ({
+                name: object.name,
+                fullName: object.fullName,
+                description: object.description,
+              }))
+            : [],
         };
 
         extensionShortHeaders.push(extensionShortHeader);

--- a/scripts/lib.es5.d.ts
+++ b/scripts/lib.es5.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Fixes https://github.com/microsoft/TypeScript/issues/16655 for `Array.prototype.filter()`
+ * For example, using the fix the type of `bar` is `string[]` in the below snippet as it should be.
+ *
+ *  const foo: (string | null | undefined)[] = [];
+ *  const bar = foo.filter(Boolean);
+ *
+ * For related definitions, see https://github.com/microsoft/TypeScript/blob/master/src/lib/es5.d.ts
+ *
+ * Original licenses apply, see
+ *  - https://github.com/microsoft/TypeScript/blob/master/LICENSE.txt
+ *  - https://stackoverflow.com/help/licensing
+ */
+
+/** See https://stackoverflow.com/a/51390763/1470607  */
+type Falsy = false | 0 | '' | null | undefined;
+
+interface Array<T> {
+  /**
+   * Returns the elements of an array that meet the condition specified in a callback function.
+   * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+   */
+  filter<S extends T>(
+    predicate: BooleanConstructor,
+    thisArg?: any
+  ): Exclude<S, Falsy>[];
+}

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -111,7 +111,7 @@ export interface EventsBasedBehaviors {
   fullName: string;
   name: string;
   objectType: string;
-  private: boolean;
+  private?: boolean;
   eventsFunctions: EventsFunction[];
 }
 

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -25,6 +25,22 @@ export interface ExtensionShortHeader extends ExtensionAndShortHeaderFields {
   headerUrl: string;
   eventsBasedBehaviorsCount: number;
   eventsFunctionsCount: number;
+  behaviorHeaders: Array<BehaviorHeaders>;
+  objectHeaders: Array<ObjectHeaders>;
+}
+
+export interface BehaviorHeaders {
+  name: string;
+  fullName: string;
+  description: string;
+  objectType: string;
+  private: boolean;
+}
+
+export interface ObjectHeaders {
+  name: string;
+  fullName: string;
+  description: string;
 }
 
 export interface ExtensionHeader
@@ -95,6 +111,7 @@ export interface EventsBasedBehaviors {
   fullName: string;
   name: string;
   objectType: string;
+  private: boolean;
   eventsFunctions: EventsFunction[];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["scripts", "__tests__"]
+  "include": ["scripts", "__tests__", "lib.es5.d.ts"]
 }


### PR DESCRIPTION
It add extension behavior and objet in the header to allow the IDE to list behaviors instead of extensions.