### PR TITLE
[FPS] Update: Provide more accurate values for frames per second

### DIFF
--- a/extensions/reviewed/FPS.json
+++ b/extensions/reviewed/FPS.json
@@ -10,10 +10,12 @@
   "shortDescription": "Calculate and display the frames per second (FPS) of the game.",
   "version": "1.1.0",
   "description": [
-    "Provides an expression to get the current FPS and a behavior to simplify displaying the current FPS.",
+    "Provides an expression to get the current FPS and a text object behavior to display the current FPS.",
     "",
     "Frames Per Second (FPS) describes how many times in the last second your game logic was executed. ",
-    "This includes running behaviors and events, and then rendering the new game state into the game window. The higher the FPS, the more fluid and performant your game looks."
+    "This includes running behaviors and events, and then rendering the new game state into the game window. The higher the FPS, the more fluid and performant your game looks.",
+    "",
+    "Note: Use the Performance Profiler (inside in the Debugger) for detailed performance information about your game."
   ],
   "origin": {
     "identifier": "FPS",
@@ -40,39 +42,16 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save starting time and set default value"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "FPS::RestartFpsCounter"
+                "value": "SceneVariablePushNumber"
               },
               "parameters": [
-                "",
-                "",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FPS.UpdatePeriod",
-                "=",
-                "1"
+                "__FPS.FrameTimestamps",
+                "Time(\"timestamp\")"
               ]
             }
           ]
@@ -88,63 +67,128 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Keep timestamps for every frame inside the lookback period",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
             {
-              "type": {
-                "value": "ModVarScene"
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
               },
-              "parameters": [
-                "__FPS.FramesCounted",
-                "+",
-                "1"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
+              "comment": "Record how much time has elapsed"
+            },
             {
-              "type": {
-                "value": "BuiltinCommonInstructions::CompareNumbers"
-              },
-              "parameters": [
-                "Time(\"timestamp\") - Variable(__FPS.StartTime)",
-                ">",
-                "1000 * Variable(__FPS.UpdatePeriod) "
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FPS.FramesPerSecond",
-                "=",
-                "1000 * Variable(__FPS.FramesCounted) / (Time(\"timestamp\") - Variable(__FPS.StartTime))"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__FPS.TimeElapsed",
+                    "=",
+                    "Time(\"timestamp\") - Variable(__FPS.FrameTimestamps[0])"
+                  ]
+                }
               ]
             },
             {
-              "type": {
-                "value": "FPS::RestartFpsCounter"
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
               },
-              "parameters": [
-                "",
-                ""
+              "comment": "Remove any data before the last second from the beginning of the array"
+            },
+            {
+              "infiniteLoopWarning": true,
+              "type": "BuiltinCommonInstructions::While",
+              "whileConditions": [
+                {
+                  "type": {
+                    "value": "SceneVariableChildCount"
+                  },
+                  "parameters": [
+                    "__FPS.FrameTimestamps",
+                    ">",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "VarScene"
+                  },
+                  "parameters": [
+                    "__FPS.FrameTimestamps[0]",
+                    "<",
+                    "Time(\"timestamp\") - 1000"
+                  ]
+                }
+              ],
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SceneVariableRemoveAt"
+                  },
+                  "parameters": [
+                    "__FPS.FrameTimestamps",
+                    "0"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Add the current timestamp to the end of the array"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SceneVariablePushNumber"
+                  },
+                  "parameters": [
+                    "__FPS.FrameTimestamps",
+                    "Time(\"timestamp\")"
+                  ]
+                }
               ]
             }
-          ]
+          ],
+          "parameters": []
         }
       ],
       "parameters": [],
       "objectGroups": []
     },
     {
-      "description": "Average frames per second (FPS) during the last update period.",
+      "description": "Frames per second (FPS) during the last second.",
       "fullName": "Frames Per Second (FPS)",
       "functionType": "Expression",
       "name": "FPS",
@@ -159,7 +203,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__FPS.FramesPerSecond)"
+                "VariableChildCount(__FPS.FrameTimestamps) / (Variable(__FPS.TimeElapsed) / 1000)"
               ]
             }
           ]
@@ -172,10 +216,11 @@
       "objectGroups": []
     },
     {
-      "description": "Return your game's current FPS count, with more control over rounding.",
-      "fullName": "Precise FPS (Frames per second) [Deprecated]",
+      "description": "Frames per second (FPS) during the last second. [Deprecated]",
+      "fullName": "Frames Per Second (FPS) [Deprecated]",
       "functionType": "Expression",
       "name": "PreciseFPS",
+      "private": true,
       "sentence": "",
       "events": [
         {
@@ -205,86 +250,6 @@
         }
       ],
       "objectGroups": []
-    },
-    {
-      "description": "Change time period between FPS updates. Default: 1 second.",
-      "fullName": "Change time period between FPS updates",
-      "functionType": "Action",
-      "name": "SetUpdatePeriod",
-      "sentence": "Change time period between FPS updates to _PARAM1_ seconds",
-      "events": [
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FPS.UpdatePeriod",
-                "=",
-                "max(0, GetArgumentAsNumber(\"UpdatePeriod\"))"
-              ]
-            },
-            {
-              "type": {
-                "value": "FPS::RestartFpsCounter"
-              },
-              "parameters": [
-                "",
-                ""
-              ]
-            }
-          ]
-        }
-      ],
-      "parameters": [
-        {
-          "description": "Update period (seconds)",
-          "name": "UpdatePeriod",
-          "type": "expression"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "Restart the FPS counter.",
-      "fullName": "Restart FPS counter",
-      "functionType": "Action",
-      "name": "RestartFpsCounter",
-      "private": true,
-      "sentence": "Restart the FPS counter",
-      "events": [
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FPS.FramesCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FPS.StartTime",
-                "=",
-                "Time(\"timestamp\")"
-              ]
-            }
-          ]
-        }
-      ],
-      "parameters": [],
-      "objectGroups": []
     }
   ],
   "eventsBasedBehaviors": [
@@ -301,6 +266,119 @@
           "sentence": "",
           "events": [
             {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Generate the raw FPS text"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarSceneTxt"
+                  },
+                  "parameters": [
+                    "__FPS.UnformattedFPS",
+                    "=",
+                    "ToString(roundTo(FPS::FPS(), Object.Behavior::PropertyDecimalDigits()))"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Add trailing zeroes, if needed"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "Object.Behavior::PropertyDecimalDigits()",
+                    ">",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "StrFind(VariableString(__FPS.UnformattedFPS),\".\")",
+                    "=",
+                    "-1"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__FPS.UnformattedFPS",
+                        "+",
+                        "\".\""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Repeat",
+                  "repeatExpression": "Object.Behavior::PropertyDecimalDigits()",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarSceneTxt"
+                      },
+                      "parameters": [
+                        "__FPS.UnformattedFPS",
+                        "+",
+                        "\"0\""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Show the formatted FPS text including the prefix"
+            },
+            {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
@@ -311,7 +389,7 @@
                   "parameters": [
                     "Object",
                     "=",
-                    "Object.Behavior::Propertyprefix() + ToString(FPS::FPS())"
+                    "Object.Behavior::Propertyprefix() + VariableString(__FPS.UnformattedFPS)"
                   ]
                 }
               ]
@@ -344,6 +422,17 @@
           "extraInformation": [],
           "hidden": false,
           "name": "prefix"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "unit": "Dimensionless",
+          "label": "Number of decimal digits to display",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "DecimalDigits"
         }
       ],
       "sharedPropertyDescriptors": []

--- a/extensions/reviewed/FPS.json
+++ b/extensions/reviewed/FPS.json
@@ -1,15 +1,24 @@
 {
   "author": "Ahnaf30e",
   "category": "Advanced",
-  "description": "Adds expressions to get the current FPS and a behavior to display the current FPS easily.\n\nThe FPS, Frames Per Second, describes how many times in the last second your game got updated. An update consists in running all the behaviors, objects, and events sheet code, before rendering the new game state into the game window. The higher the FPS, the more it manages to update in a second, influencing how fluid and performant your game looks.",
   "extensionNamespace": "",
-  "fullName": "FPS",
+  "fullName": "Frames per second (FPS)",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8cGF0aCBkPSJNMzAsM2gtMkg0SDJDMS40LDMsMSwzLjQsMSw0czAuNCwxLDEsMWgxdjE2YzAsMC42LDAuNCwxLDEsMWg5LjhsLTUuNSw2LjNjLTAuNCwwLjQtMC4zLDEsMC4xLDEuNEM4LjUsMjkuOSw4LjgsMzAsOSwzMA0KCWMwLjMsMCwwLjYtMC4xLDAuOC0wLjNsNS4yLTZWMjhjMCwwLjYsMC40LDEsMSwxczEtMC40LDEtMXYtNC4zbDUuMiw2YzAuMiwwLjIsMC41LDAuMywwLjgsMC4zYzAuMiwwLDAuNS0wLjEsMC43LTAuMg0KCWMwLjQtMC40LDAuNS0xLDAuMS0xLjRMMTguMiwyMkgyOGMwLjYsMCwxLTAuNCwxLTFWNWgxYzAuNiwwLDEtMC40LDEtMVMzMC42LDMsMzAsM3ogTTI0LjgsOC42bC00LDZjLTAuMywwLjQtMC44LDAuNi0xLjMsMC4zDQoJTDE1LjgsMTNoLTMuNGwtMy43LDMuN0M4LjUsMTYuOSw4LjMsMTcsOCwxN3MtMC41LTAuMS0wLjctMC4zYy0wLjQtMC40LTAuNC0xLDAtMS40bDQtNGMwLjItMC4yLDAuNC0wLjMsMC43LTAuM2g0DQoJYzAuMiwwLDAuMywwLDAuNCwwLjFsMy4yLDEuNmwzLjUtNS4zYzAuMy0wLjUsMC45LTAuNiwxLjQtMC4zQzI1LDcuNSwyNS4xLDguMSwyNC44LDguNnoiLz4NCjwvc3ZnPg0K",
   "name": "FPS",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/SEO/SEO_board_performance_profit.svg",
-  "shortDescription": "Adds expressions and a behavior to get and display the game FPS.",
-  "version": "1.0.0",
+  "shortDescription": "Calculate and display the frames per second (FPS) of the game.",
+  "version": "1.1.0",
+  "description": [
+    "Provides an expression to get the current FPS and a behavior to simplify displaying the current FPS.",
+    "",
+    "Frames Per Second (FPS) describes how many times in the last second your game logic was executed. ",
+    "This includes running behaviors and events, and then rendering the new game state into the game window. The higher the FPS, the more fluid and performant your game looks."
+  ],
+  "origin": {
+    "identifier": "FPS",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "fps",
     "frames",
@@ -19,81 +28,262 @@
     "speed"
   ],
   "authorIds": [
-    "onPsboRtDkUHNOsx7OPr8R8G1oj2"
+    "onPsboRtDkUHNOsx7OPr8R8G1oj2",
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Return your game's current FPS count.",
-      "fullName": "FPS (Frames per second)",
-      "functionType": "Expression",
-      "name": "FPS",
-      "private": false,
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onSceneLoaded",
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Save starting time and set default value"
+        },
+        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "SetReturnNumber"
+                "value": "FPS::RestartFpsCounter"
               },
               "parameters": [
-                "ceil(1/TimeDelta())"
-              ],
-              "subInstructions": []
+                "",
+                "",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.UpdatePeriod",
+                "=",
+                "1"
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [],
       "objectGroups": []
     },
     {
-      "description": "Return your game's current FPS count, with more control over rounding.",
-      "fullName": "Precise FPS (Frames per second)",
-      "functionType": "Expression",
-      "name": "PreciseFPS",
-      "private": false,
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onScenePostEvents",
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.FramesCounted",
+                "+",
+                "1"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareNumbers"
+              },
+              "parameters": [
+                "Time(\"timestamp\") - Variable(__FPS.StartTime)",
+                ">",
+                "1000 * Variable(__FPS.UpdatePeriod) "
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.FramesPerSecond",
+                "=",
+                "1000 * Variable(__FPS.FramesCounted) / (Time(\"timestamp\") - Variable(__FPS.StartTime))"
+              ]
+            },
+            {
+              "type": {
+                "value": "FPS::RestartFpsCounter"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Average frames per second (FPS) during the last update period.",
+      "fullName": "Frames Per Second (FPS)",
+      "functionType": "Expression",
+      "name": "FPS",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "(ceil(1/TimeDelta()*(GetArgumentAsNumber(\"accuracy\") * 10))) / (GetArgumentAsNumber(\"accuracy\") * 10)"
-              ],
-              "subInstructions": []
+                "Variable(__FPS.FramesPerSecond)"
+              ]
             }
-          ],
-          "events": []
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Return your game's current FPS count, with more control over rounding.",
+      "fullName": "Precise FPS (Frames per second) [Deprecated]",
+      "functionType": "Expression",
+      "name": "PreciseFPS",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "FPS::FPS()"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "The accuracy of the FPS",
+          "longDescription": "This tells how many numbers after the period should be shown.",
+          "name": "accuracy",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change time period between FPS updates. Default: 1 second.",
+      "fullName": "Change time period between FPS updates",
+      "functionType": "Action",
+      "name": "SetUpdatePeriod",
+      "sentence": "Change time period between FPS updates to _PARAM1_ seconds",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.UpdatePeriod",
+                "=",
+                "max(0, GetArgumentAsNumber(\"UpdatePeriod\"))"
+              ]
+            },
+            {
+              "type": {
+                "value": "FPS::RestartFpsCounter"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "The accuracy of the FPS",
-          "longDescription": "This tells how many numbers after the period should be shown.",
-          "name": "accuracy",
-          "optional": false,
-          "supplementaryInformation": "",
+          "description": "Update period (seconds)",
+          "name": "UpdatePeriod",
           "type": "expression"
         }
       ],
+      "objectGroups": []
+    },
+    {
+      "description": "Restart the FPS counter.",
+      "fullName": "Restart FPS counter",
+      "functionType": "Action",
+      "name": "RestartFpsCounter",
+      "private": true,
+      "sentence": "Restart the FPS counter",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.FramesCounted",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__FPS.StartTime",
+                "=",
+                "Time(\"timestamp\")"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
       "objectGroups": []
     }
   ],
@@ -105,53 +295,38 @@
       "objectType": "TextObject::Text",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "doStepPreEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "TextObject::String"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "Object.Behavior::Propertyprefix() + ToString(FPS::FPS())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "TextObject::Text",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FPS::FPSDisplayer",
               "type": "behavior"
             }
@@ -165,11 +340,14 @@
           "type": "String",
           "label": "The prefix before the FPS count",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": false,
           "name": "prefix"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
- Uses a sliding window to show exactly the number of frames in the previous second
- Backwards compatible with the previous extension

## Playable game

https://gd.games/victrisgames/load-testing

## Game example

https://github.com/GDevelopApp/GDevelop-examples/pull/544

## Video

https://github.com/GDevelopApp/GDevelop-extensions/assets/8879811/fb5d5953-b3fe-48f2-887b-047cbada839d


