### PR TITLE
[Flash object] Add ability to flash color tint, object effect, and opacity (fade)

### DIFF
--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -7,15 +7,15 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZsYXNoLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNywySDE3TDEzLjUsOUgxN0wxMCwyMlYxNEg3VjJNOSw0VjEySDEyVjE0LjY2TDE0LDExSDEwLjI0TDEzLjc2LDRIOVoiIC8+PC9zdmc+",
   "name": "Flash",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg",
-  "shortDescription": "Make an object flash visibility (blink), color tint, effect or opacity (fade) for a period of time.",
-  "version": "1.0.2",
+  "shortDescription": "Make an object flash visibility (blink), color tint, object effect, or opacity (fade)",
+  "version": "1.1.0",
   "description": [
     "Make an object flash for a period of time so that it alternates between two different states.",
-    "Includes flashing visibility (blink), color tint, object effect or opacity (fade).",
+    "Includes the ability to flash visibility (blink), color tint, object effect, or opacity (fade).",
     "",
     "After adding a behavior to an object, you **trigger the effect** by using the **Flash action**.",
     "",
-    "It can be used to:",
+    "This can be used to:",
     "- Let players know they are invincible after being hit",
     "- Catch player attention on the interface (for instance a \"press start\" text)",
     ""
@@ -26,7 +26,11 @@
     "visible",
     "invisible",
     "hit",
-    "damage"
+    "damage",
+    "fade",
+    "effect",
+    "color",
+    "tint"
   ],
   "authorIds": [
     "wWP8BSlAW0UP4NeaHa2LcmmDzmH2",
@@ -484,7 +488,7 @@
   ],
   "eventsBasedBehaviors": [
     {
-      "description": "Make the object flash (blink) for a period of time so that it alternates between visible and invisible.",
+      "description": "Make the object flash (blink) for a period of time so it alternates between visible and invisible.",
       "fullName": "Flash visibility (blink)",
       "name": "Flash",
       "objectType": "",
@@ -573,6 +577,17 @@
                       "conditions": [
                         {
                           "type": {
+                            "value": "Flash::Flash::PropertyFlashDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
                             "value": "CompareObjectTimer"
                           },
                           "parameters": [
@@ -629,70 +644,70 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareArgumentAsNumber"
+                    "inverted": true,
+                    "value": "Flash::Flash::IsFlashing"
                   },
                   "parameters": [
-                    "\"FlashDuration\"",
-                    ">",
-                    "0"
+                    "Object",
+                    "Behavior",
+                    ""
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Flash::ToggleVisibility"
-                      },
-                      "parameters": [
-                        "",
-                        "Object",
-                        ""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Visibility_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Visibility_Duration_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::Flash::SetPropertyFlashDuration"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsNumber(\"FlashDuration\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::Flash::SetPropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ]
-                    }
+                  "type": {
+                    "value": "Flash::ToggleVisibility"
+                  },
+                  "parameters": [
+                    "",
+                    "Object",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::Flash::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Visibility_Timer\""
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Visibility_Duration_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::Flash::SetPropertyFlashDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"FlashDuration\")"
                   ]
                 }
               ]
@@ -711,7 +726,8 @@
               "type": "behavior"
             },
             {
-              "description": "Duration of the blinking, in seconds",
+              "description": "Duration of the flashing, in seconds",
+              "longDescription": "Use \"0\" to keep flashing until stopped.",
               "name": "FlashDuration",
               "type": "expression"
             }
@@ -958,8 +974,8 @@
           "value": "0",
           "type": "Number",
           "unit": "Second",
-          "label": "",
-          "description": "",
+          "label": "Flash duration",
+          "description": "Use \"0\" to keep flashing until stopped",
           "group": "",
           "extraInformation": [],
           "hidden": true,
@@ -969,7 +985,7 @@
       "sharedPropertyDescriptors": []
     },
     {
-      "description": "Make the object flash a color tint for a period of time.",
+      "description": "Make an object flash a color tint for a period of time.",
       "fullName": "Flash color tint",
       "name": "FlashColor",
       "objectType": "Sprite",
@@ -1059,6 +1075,17 @@
                       "conditions": [
                         {
                           "type": {
+                            "value": "Flash::FlashColor::PropertyFlashDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
                             "value": "CompareObjectTimer"
                           },
                           "parameters": [
@@ -1116,122 +1143,92 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareArgumentAsNumber"
+                    "inverted": true,
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
                   },
                   "parameters": [
-                    "\"FlashDuration\"",
-                    ">",
-                    "0"
+                    "Object",
+                    "Behavior"
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
+                  "type": {
+                    "value": "ModVarObjetTxt"
                   },
-                  "comment": "Only save the tint if it is not currently flashing"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "Flash::FlashColor::PropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjetTxt"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashColor_StartingTint",
-                        "=",
-                        "Flash::ColorTint(Object)"
-                      ]
-                    }
+                  "parameters": [
+                    "Object",
+                    "__FlashColor_StartingTint",
+                    "=",
+                    "Flash::ColorTint(Object)"
                   ]
                 },
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Color_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Color_Duration_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashColor::SetPropertyFlashDuration"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsNumber(\"FlashDuration\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashColor::SetPropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashColor::SetPropertyTintColor"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsString(\"ColorTint\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::ToggleColorTint"
-                      },
-                      "parameters": [
-                        "",
-                        "Object",
-                        "Object.Behavior::PropertyTintColor()",
-                        ""
-                      ]
-                    }
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Color_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::ToggleColorTint"
+                  },
+                  "parameters": [
+                    "",
+                    "Object",
+                    "GetArgumentAsString(\"ColorTint\")",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Color_Duration_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::SetPropertyTintColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"ColorTint\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::SetPropertyFlashDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"FlashDuration\")"
                   ]
                 }
               ]
@@ -1251,7 +1248,8 @@
               "type": "behavior"
             },
             {
-              "description": "Duration of the blinking, in seconds",
+              "description": "Duration of the flashing, in seconds",
+              "longDescription": "Use \"0\" to keep flashing until stopped.",
               "name": "FlashDuration",
               "type": "expression"
             },
@@ -1264,7 +1262,7 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects are flashing a color tint.",
+          "description": "Check if an object is flashing a color tint.",
           "fullName": "Is object flashing a color tint",
           "functionType": "Condition",
           "name": "IsFlashing",
@@ -1485,7 +1483,8 @@
         {
           "value": "0.1",
           "type": "Number",
-          "label": "Half period (time between flashes), in seconds",
+          "unit": "Second",
+          "label": "Half period (time between flashes)",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -1505,8 +1504,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "",
-          "description": "",
+          "unit": "Second",
+          "label": "Flash duration",
+          "description": "Use \"0\" to keep flashing until stopped",
           "group": "",
           "extraInformation": [],
           "hidden": true,
@@ -1515,7 +1515,7 @@
         {
           "value": "\"255;255;255\"",
           "type": "String",
-          "label": "",
+          "label": "Tint color",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -1661,6 +1661,17 @@
                       "conditions": [
                         {
                           "type": {
+                            "value": "Flash::FlashOpacity::PropertyFlashDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
                             "value": "CompareObjectTimer"
                           },
                           "parameters": [
@@ -1718,111 +1729,86 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareArgumentAsNumber"
+                    "inverted": true,
+                    "value": "Flash::FlashOpacity::PropertyIsFlashing"
                   },
                   "parameters": [
-                    "\"FlashDuration\"",
-                    ">",
-                    "0"
+                    "Object",
+                    "Behavior"
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Opacity_Duration_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashOpacity::SetPropertyFlashDuration"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsNumber(\"FlashDuration\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashOpacity::SetPropertyTargetOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsNumber(\"TargetOpacity\")"
-                      ]
-                    }
+                  "type": {
+                    "value": "Flash::FlashOpacity::SetPropertyStartingOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Object.Opacity()"
                   ]
                 },
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "Flash::FlashOpacity::PropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "Flash::FlashOpacity::SetPropertyStartingOpacity"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "Object.Opacity()"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Tween::AddObjectOpacityTween"
-                          },
-                          "parameters": [
-                            "Object",
-                            "TweenBehavior",
-                            "\"__Flash.ToTargetOpacity\"",
-                            "Object.Behavior::PropertyTargetOpacity()",
-                            "\"easeInOutCubic\"",
-                            "1000 * Object.Behavior::PropertyHalfPeriodTime()",
-                            ""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ]
-                        }
-                      ]
-                    }
+                  "type": {
+                    "value": "Tween::AddObjectOpacityTween"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TweenBehavior",
+                    "\"__Flash.ToTargetOpacity\"",
+                    "GetArgumentAsNumber(\"TargetOpacity\")",
+                    "\"easeInOutCubic\"",
+                    "1000 * Object.Behavior::PropertyHalfPeriodTime()",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Opacity_Duration_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::SetPropertyFlashDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"FlashDuration\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::SetPropertyTargetOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"TargetOpacity\")"
                   ]
                 }
               ]
@@ -1848,7 +1834,8 @@
               "type": "behavior"
             },
             {
-              "description": "Duration of the blinking, in seconds",
+              "description": "Duration of the flashing, in seconds",
+              "longDescription": "Use \"0\" to keep flashing until stopped.",
               "name": "FlashDuration",
               "type": "expression"
             },
@@ -1861,7 +1848,7 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the object is flashing opacity.",
+          "description": "Check if an object is flashing opacity.",
           "fullName": "Is object flashing opacity",
           "functionType": "Condition",
           "name": "IsFlashing",
@@ -2107,6 +2094,7 @@
         {
           "value": "0.1",
           "type": "Number",
+          "unit": "Second",
           "label": "Half period (time between flashes), in seconds",
           "description": "",
           "group": "",
@@ -2127,8 +2115,9 @@
         {
           "value": "0",
           "type": "Number",
-          "label": "",
-          "description": "",
+          "unit": "Second",
+          "label": "Flash duration",
+          "description": "Use \"0\" to keep flashing until stopped",
           "group": "",
           "extraInformation": [],
           "hidden": true,
@@ -2251,6 +2240,17 @@
                       "conditions": [
                         {
                           "type": {
+                            "value": "Flash::FlashEffect::PropertyFlashDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
                             "value": "CompareObjectTimer"
                           },
                           "parameters": [
@@ -2304,251 +2304,197 @@
           "sentence": "Make _PARAM0_ flash the effect _PARAM3_ for _PARAM2_ seconds",
           "events": [
             {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Stop flashing existing effects if the effect name changed"
+            },
+            {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareArgumentAsNumber"
+                    "value": "Flash::FlashEffect::IsFlashing"
                   },
                   "parameters": [
-                    "\"FlashDuration\"",
-                    ">",
-                    "0"
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::PropertyEffectName"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "!=",
+                    "GetArgumentAsString(\"EffectName\")"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "Flash::FlashEffect::IsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
                   ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Stop flashing if the effect name has changed",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::IsFlashing"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::PropertyEffectName"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "!=",
-                            "GetArgumentAsString(\"EffectName\")"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::Stop"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ]
-                        }
+                      "type": {
+                        "value": "IsEffectEnabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "GetArgumentAsString(\"EffectName\")"
                       ]
                     }
                   ],
-                  "parameters": []
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetObjectVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__FlashColor_StartingState",
+                        "True"
+                      ]
+                    }
+                  ]
                 },
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Save starting state (only when not flashing)",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "Flash::FlashEffect::IsFlashing"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ]
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "IsEffectEnabled"
-                              },
-                              "parameters": [
-                                "Object",
-                                "GetArgumentAsString(\"EffectName\")"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetObjectVariableAsBoolean"
-                              },
-                              "parameters": [
-                                "Object",
-                                "__FlashColor_StartingState",
-                                "True"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "IsEffectEnabled"
-                              },
-                              "parameters": [
-                                "Object",
-                                "GetArgumentAsString(\"EffectName\")"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetObjectVariableAsBoolean"
-                              },
-                              "parameters": [
-                                "Object",
-                                "__FlashColor_StartingState",
-                                "False"
-                              ]
-                            }
-                          ]
-                        }
+                      "type": {
+                        "inverted": true,
+                        "value": "IsEffectEnabled"
+                      },
+                      "parameters": [
+                        "Object",
+                        "GetArgumentAsString(\"EffectName\")"
                       ]
                     }
                   ],
-                  "parameters": []
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetObjectVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__FlashColor_StartingState",
+                        "False"
+                      ]
+                    }
+                  ]
                 },
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Change to the opposite state",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
                     {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "Flash::ToggleEffect"
-                          },
-                          "parameters": [
-                            "",
-                            "Object",
-                            "GetArgumentAsString(\"EffectName\")",
-                            ""
-                          ]
-                        }
+                      "type": {
+                        "value": "Flash::ToggleEffect"
+                      },
+                      "parameters": [
+                        "",
+                        "Object",
+                        "GetArgumentAsString(\"EffectName\")",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Effect_Timer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::SetPropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
                       ]
                     }
-                  ],
-                  "parameters": []
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Effect_Duration_Timer\""
+                  ]
                 },
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Prepare for flashing",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "ResetObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Effect_Timer\""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "ResetObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Effect_Duration_Timer\""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::SetPropertyFlashDuration"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "GetArgumentAsNumber(\"FlashDuration\")"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::SetPropertyEffectName"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "GetArgumentAsString(\"EffectName\")"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashEffect::SetPropertyIsFlashing"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
+                  "type": {
+                    "value": "Flash::FlashEffect::SetPropertyFlashDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsNumber(\"FlashDuration\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::SetPropertyEffectName"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "GetArgumentAsString(\"EffectName\")"
+                  ]
                 }
               ]
             }
@@ -2567,7 +2513,8 @@
               "type": "behavior"
             },
             {
-              "description": "Duration of the blinking, in seconds",
+              "description": "Duration of the flashing, in seconds",
+              "longDescription": "Use \"0\" to keep flashing until stopped.",
               "name": "FlashDuration",
               "type": "expression"
             },
@@ -2580,7 +2527,7 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the object is flashing an effect.",
+          "description": "Check if an object is flashing an effect.",
           "fullName": "Is object flashing an effect",
           "functionType": "Condition",
           "name": "IsFlashing",
@@ -2870,8 +2817,8 @@
           "value": "0",
           "type": "Number",
           "unit": "Second",
-          "label": "",
-          "description": "",
+          "label": "Flash duration",
+          "description": "Use \"0\" to keep flashing until stopped",
           "group": "",
           "extraInformation": [],
           "hidden": true,

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -1580,16 +1580,6 @@
           "extraInformation": [],
           "hidden": true,
           "name": "TintColor"
-        },
-        {
-          "value": "",
-          "type": "Boolean",
-          "label": "Is tinted",
-          "description": "",
-          "group": "",
-          "extraInformation": [],
-          "hidden": true,
-          "name": "IsTinted"
         }
       ],
       "sharedPropertyDescriptors": []
@@ -2195,7 +2185,7 @@
           "type": "Number",
           "unit": "Dimensionless",
           "label": "Target opacity (Range: 0 - 255)",
-          "description": "Opacity will fade between the starting value and this target value",
+          "description": "Opacity will fade between the starting value and a target value",
           "group": "",
           "extraInformation": [],
           "hidden": true,
@@ -2206,7 +2196,7 @@
           "type": "Number",
           "unit": "Dimensionless",
           "label": "Starting opacity",
-          "description": "Opacity will fade between the starting value and this target value",
+          "description": "Opacity will fade between the starting value and a target value",
           "group": "",
           "extraInformation": [],
           "hidden": true,

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -1,27 +1,23 @@
 {
-  "author": "@4ian",
-  "category": "Visual effect",
+  "author": "@4ian, Entropy, VegeTato",
+  "category": "",
   "extensionNamespace": "",
   "fullName": "Flash (blink)",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZsYXNoLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNywySDE3TDEzLjUsOUgxN0wxMCwyMlYxNEg3VjJNOSw0VjEySDEyVjE0LjY2TDE0LDExSDEwLjI0TDEzLjc2LDRIOVoiIC8+PC9zdmc+",
   "name": "Flash",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg",
-  "shortDescription": "Make objects flash (alternately visible and invisible) for a period of time.",
-  "version": "1.0.1",
+  "shortDescription": "Make the object flash (blink) for a period of time, so that it is alternately visible and invisible.",
+  "version": "1.0.2",
   "description": [
-    "Make objects flash (alternately visible and invisible) for a period of time.",
+    "Make the object flash (blink) for a period of time, so that it is alternately visible and invisible.",
+    "After adding this behavior to an object, you **trigger the effect** by using the **Flash action**.",
     "",
     "It can be used to:",
     "- Let players know they are invincible after being hit",
     "- Catch player attention on the interface (for instance a \"press start\" text)",
-    "",
     ""
   ],
-  "origin": {
-    "identifier": "Flash",
-    "name": "gdevelop-extension-store"
-  },
   "tags": [
     "flash",
     "blink",
@@ -31,7 +27,8 @@
     "damage"
   ],
   "authorIds": [
-    "wWP8BSlAW0UP4NeaHa2LcmmDzmH2"
+    "wWP8BSlAW0UP4NeaHa2LcmmDzmH2",
+    "q8ubdigLvIRXLxsJDDTaokO41mc2"
   ],
   "dependencies": [],
   "eventsFunctions": [],
@@ -68,53 +65,12 @@
                   "conditions": [
                     {
                       "type": {
-                        "value": "ObjectTimer"
+                        "value": "CompareObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"FlashTimer\"",
-                        "Object.Behavior::PropertyHalfPeriodTime()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Cache"
-                      },
-                      "parameters": [
-                        "Object"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\""
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "ObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\"",
+                        ">",
                         "Object.Behavior::PropertyHalfPeriodTime()"
                       ]
                     },
@@ -154,11 +110,55 @@
                   "conditions": [
                     {
                       "type": {
-                        "value": "ObjectTimer"
+                        "value": "CompareObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"FlashTimer\"",
+                        ">",
+                        "Object.Behavior::PropertyHalfPeriodTime()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Visible"
+                      },
+                      "parameters": [
+                        "Object"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Cache"
+                      },
+                      "parameters": [
+                        "Object"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"FlashTimer\""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "CompareObjectTimer"
                       },
                       "parameters": [
                         "Object",
                         "\"FlashDurationTimer\"",
+                        ">",
                         "Object.Behavior::PropertyFlashDuration()"
                       ]
                     }
@@ -215,35 +215,59 @@
                   ]
                 }
               ],
-              "actions": [
+              "actions": [],
+              "events": [
                 {
-                  "type": {
-                    "value": "ResetObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"FlashDurationTimer\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "Flash::Flash::SetPropertyFlashDuration"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "GetArgumentAsNumber(\"FlashDuration\")"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "Flash::Flash::SetPropertyIsFlashing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "yes"
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"FlashTimer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"FlashDurationTimer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::Flash::SetPropertyFlashDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"FlashDuration\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::Flash::SetPropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Cache"
+                      },
+                      "parameters": [
+                        "Object"
+                      ]
+                    }
                   ]
                 }
               ]
@@ -407,7 +431,7 @@
           "objectGroups": []
         },
         {
-          "description": "Stop the flashing of the specified object.",
+          "description": "Stop flashing the object",
           "fullName": "Stop flashing",
           "functionType": "Action",
           "name": "Stop",
@@ -444,6 +468,24 @@
                     "Object",
                     "Behavior",
                     "no"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"FlashTimer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"FlashDurationTimer\""
                   ]
                 }
               ]
@@ -490,6 +532,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Second",
           "label": "",
           "description": "",
           "group": "",

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -2,16 +2,18 @@
   "author": "@4ian, Entropy, VegeTato",
   "category": "",
   "extensionNamespace": "",
-  "fullName": "Flash (blink)",
+  "fullName": "Flash object",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZsYXNoLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNywySDE3TDEzLjUsOUgxN0wxMCwyMlYxNEg3VjJNOSw0VjEySDEyVjE0LjY2TDE0LDExSDEwLjI0TDEzLjc2LDRIOVoiIC8+PC9zdmc+",
   "name": "Flash",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg",
-  "shortDescription": "Make the object flash (blink) for a period of time, so that it is alternately visible and invisible.",
+  "shortDescription": "Make an object flash visibility (blink), color tint, effect or opacity (fade) for a period of time.",
   "version": "1.0.2",
   "description": [
-    "Make the object flash (blink) for a period of time, so that it is alternately visible and invisible.",
-    "After adding this behavior to an object, you **trigger the effect** by using the **Flash action**.",
+    "Make an object flash for a period of time so that it alternates between two different states.",
+    "Includes flashing visibility (blink), color tint, object effect or opacity (fade).",
+    "",
+    "After adding a behavior to an object, you **trigger the effect** by using the **Flash action**.",
     "",
     "It can be used to:",
     "- Let players know they are invincible after being hit",
@@ -28,7 +30,8 @@
   ],
   "authorIds": [
     "wWP8BSlAW0UP4NeaHa2LcmmDzmH2",
-    "q8ubdigLvIRXLxsJDDTaokO41mc2"
+    "q8ubdigLvIRXLxsJDDTaokO41mc2",
+    "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
   "eventsFunctions": [
@@ -1571,17 +1574,6 @@
                             "TweenBehavior",
                             "\"__Flash.ToTargetOpacity\""
                           ]
-                        },
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "Tween::IsPlaying"
-                          },
-                          "parameters": [
-                            "Object",
-                            "TweenBehavior",
-                            "\"__Flash.ToStartingOpacity\""
-                          ]
                         }
                       ],
                       "actions": [
@@ -1622,17 +1614,6 @@
                             "Object",
                             "TweenBehavior",
                             "\"__Flash.ToStartingOpacity\""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "Tween::IsPlaying"
-                          },
-                          "parameters": [
-                            "Object",
-                            "TweenBehavior",
-                            "\"__Flash.ToTargetOpacity\""
                           ]
                         }
                       ],
@@ -1750,36 +1731,17 @@
               "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "Flash::FlashOpacity::PropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Flash::FlashOpacity::SetPropertyStartingOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Object.Opacity()"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Opacity_Duration_Timer\""
+                      ]
+                    },
                     {
                       "type": {
                         "value": "Flash::FlashOpacity::SetPropertyFlashDuration"
@@ -1801,38 +1763,64 @@
                         "=",
                         "GetArgumentAsNumber(\"TargetOpacity\")"
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
-                        "value": "Tween::AddObjectOpacityTween"
+                        "inverted": true,
+                        "value": "Flash::FlashOpacity::PropertyIsFlashing"
                       },
                       "parameters": [
                         "Object",
-                        "TweenBehavior",
-                        "\"__Flash.ToTargetOpacity\"",
-                        "Object.Behavior::PropertyTargetOpacity()",
-                        "\"easeInOutCubic\"",
-                        "1000 * Object.Behavior::PropertyHalfPeriodTime()",
-                        ""
+                        "Behavior"
                       ]
-                    },
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
                     {
-                      "type": {
-                        "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Opacity_Duration_Timer\""
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::FlashOpacity::SetPropertyStartingOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Opacity()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Tween::AddObjectOpacityTween"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToTargetOpacity\"",
+                            "Object.Behavior::PropertyTargetOpacity()",
+                            "\"easeInOutCubic\"",
+                            "1000 * Object.Behavior::PropertyHalfPeriodTime()",
+                            ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        }
                       ]
                     }
                   ]
@@ -2055,24 +2043,22 @@
                 },
                 {
                   "type": {
-                    "value": "Tween::StopTween"
+                    "value": "Tween::RemoveTween"
                   },
                   "parameters": [
                     "Object",
                     "TweenBehavior",
-                    "\"__Flash.ToTargetOpacity\"",
-                    "yes"
+                    "\"__Flash.ToTargetOpacity\""
                   ]
                 },
                 {
                   "type": {
-                    "value": "Tween::StopTween"
+                    "value": "Tween::RemoveTween"
                   },
                   "parameters": [
                     "Object",
                     "TweenBehavior",
-                    "\"__Flash.ToStartingOpacity\"",
-                    "yes"
+                    "\"__Flash.ToStartingOpacity\""
                   ]
                 },
                 {

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -1323,68 +1323,6 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects is tinted",
-          "fullName": "Is object tinted",
-          "functionType": "Condition",
-          "name": "IsTinted",
-          "sentence": "_PARAM0_ is flashing",
-          "events": [
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "False"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "Flash::FlashColor::PropertyIsFlashing"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "True"
-                  ]
-                }
-              ]
-            }
-          ],
-          "parameters": [
-            {
-              "description": "Object",
-              "name": "Object",
-              "supplementaryInformation": "Sprite",
-              "type": "object"
-            },
-            {
-              "description": "Behavior",
-              "name": "Behavior",
-              "supplementaryInformation": "Flash::FlashColor",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
           "fullName": "",
           "functionType": "Action",
           "name": "onOwnerRemovedFromScene",
@@ -1636,9 +1574,14 @@
                         },
                         {
                           "type": {
-                            "value": "BuiltinCommonInstructions::Once"
+                            "inverted": true,
+                            "value": "Tween::IsPlaying"
                           },
-                          "parameters": []
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToStartingOpacity\""
+                          ]
                         }
                       ],
                       "actions": [
@@ -1654,6 +1597,16 @@
                             "\"easeInOutCubic\"",
                             "1000 * Object.Behavior::PropertyHalfPeriodTime()",
                             ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Tween::RemoveTween"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToTargetOpacity\""
                           ]
                         }
                       ]
@@ -1673,9 +1626,14 @@
                         },
                         {
                           "type": {
-                            "value": "BuiltinCommonInstructions::Once"
+                            "inverted": true,
+                            "value": "Tween::IsPlaying"
                           },
-                          "parameters": []
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToTargetOpacity\""
+                          ]
                         }
                       ],
                       "actions": [
@@ -1691,6 +1649,16 @@
                             "\"easeInOutCubic\"",
                             "1000 * Object.Behavior::PropertyHalfPeriodTime()",
                             ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Tween::RemoveTween"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToStartingOpacity\""
                           ]
                         }
                       ]

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -141,22 +141,22 @@
           "conditions": [
             {
               "type": {
-                "inverted": true,
-                "value": "IsEffectEnabled"
-              },
-              "parameters": [
-                "Object",
-                "GetArgumentAsString(\"EffectName\")"
-              ]
-            },
-            {
-              "type": {
                 "value": "ObjectVariableAsBoolean"
               },
               "parameters": [
                 "Object",
                 "__Flash_EffectToggled",
                 "False"
+              ]
+            },
+            {
+              "type": {
+                "inverted": true,
+                "value": "IsEffectEnabled"
+              },
+              "parameters": [
+                "Object",
+                "GetArgumentAsString(\"EffectName\")"
               ]
             }
           ],
@@ -218,120 +218,144 @@
               "actions": [],
               "events": [
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Alternate states",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
                     {
-                      "type": {
-                        "value": "CompareObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\"",
-                        ">",
-                        "Object.Behavior::PropertyHalfPeriodTime()"
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Visibility_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyHalfPeriodTime()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "Visible"
+                          },
+                          "parameters": [
+                            "Object"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Montre"
+                          },
+                          "parameters": [
+                            "Object",
+                            ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Visibility_Timer\""
+                          ]
+                        }
                       ]
                     },
                     {
-                      "type": {
-                        "inverted": true,
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Visibility_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyHalfPeriodTime()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Visible"
+                          },
+                          "parameters": [
+                            "Object"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Cache"
+                          },
+                          "parameters": [
+                            "Object"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Visibility_Timer\""
+                          ]
+                        }
                       ]
                     }
                   ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Montre"
-                      },
-                      "parameters": [
-                        "Object",
-                        ""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\""
-                      ]
-                    }
-                  ]
+                  "parameters": []
                 },
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Stop flashing",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
                     {
-                      "type": {
-                        "value": "CompareObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\"",
-                        ">",
-                        "Object.Behavior::PropertyHalfPeriodTime()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Visible"
-                      },
-                      "parameters": [
-                        "Object"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Cache"
-                      },
-                      "parameters": [
-                        "Object"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashTimer\""
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "CompareObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"FlashDurationTimer\"",
-                        ">",
-                        "Object.Behavior::PropertyFlashDuration()"
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Visibility_Duration_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyFlashDuration()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::Flash::Stop"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
                       ]
                     }
                   ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Flash::Flash::Stop"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    }
-                  ]
+                  "parameters": []
                 }
               ]
             }
@@ -363,10 +387,10 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "Egal"
+                    "value": "CompareArgumentAsNumber"
                   },
                   "parameters": [
-                    "GetArgumentAsNumber(\"FlashDuration\")",
+                    "\"FlashDuration\"",
                     ">",
                     "0"
                   ]
@@ -384,7 +408,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "\"FlashTimer\""
+                        "\"Flash_Visibility_Timer\""
                       ]
                     },
                     {
@@ -393,7 +417,7 @@
                       },
                       "parameters": [
                         "Object",
-                        "\"FlashDurationTimer\""
+                        "\"Flash_Visibility_Duration_Timer\""
                       ]
                     },
                     {
@@ -633,7 +657,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"FlashTimer\""
+                    "\"Flash_Visibility_Timer\""
                   ]
                 },
                 {
@@ -642,7 +666,7 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"FlashDurationTimer\""
+                    "\"Flash_Visibility_Duration_Timer\""
                   ]
                 }
               ]
@@ -1349,6 +1373,631 @@
       "sharedPropertyDescriptors": []
     },
     {
+      "description": "Flash opacity in a looping tween",
+      "fullName": "Flash opacity in a looping tween",
+      "name": "FlashOpacity",
+      "objectType": "Sprite",
+      "eventsFunctions": [
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::IsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Alternate states",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "Tween::HasFinished"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToTargetOpacity\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Tween::AddObjectOpacityTween"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToStartingOpacity\"",
+                            "Object.Behavior::PropertyStartingOpacity()",
+                            "\"easeInOutCubic\"",
+                            "1000 * Object.Behavior::PropertyHalfPeriodTime()",
+                            ""
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "Tween::HasFinished"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToStartingOpacity\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Tween::AddObjectOpacityTween"
+                          },
+                          "parameters": [
+                            "Object",
+                            "TweenBehavior",
+                            "\"__Flash.ToTargetOpacity\"",
+                            "Object.Behavior::PropertyTargetOpacity()",
+                            "\"easeInOutCubic\"",
+                            "1000 * Object.Behavior::PropertyHalfPeriodTime()",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Stop flashing",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Opacity_Duration_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyFlashDuration()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::FlashOpacity::Stop"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make the object fade opacity in a loop.",
+          "fullName": "Fade opacity in a loop",
+          "functionType": "Action",
+          "name": "Flash",
+          "sentence": "Make _PARAM0_ fade opacity to _PARAM4_ in a loop for _PARAM3_ seconds",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareArgumentAsNumber"
+                  },
+                  "parameters": [
+                    "\"FlashDuration\"",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "Flash::FlashColor::PropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Flash::FlashOpacity::SetPropertyStartingOpacity"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Opacity()"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Flash::FlashColor::SetPropertyFlashDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"FlashDuration\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashOpacity::SetPropertyTargetOpacity"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"TargetOpacity\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Tween::AddObjectOpacityTween"
+                      },
+                      "parameters": [
+                        "Object",
+                        "TweenBehavior",
+                        "\"__Flash.ToTargetOpacity\"",
+                        "Object.Behavior::PropertyTargetOpacity()",
+                        "\"easeInOutCubic\"",
+                        "1000 * Object.Behavior::PropertyHalfPeriodTime()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Opacity_Duration_Timer\""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            },
+            {
+              "description": "Tween behavior (required)",
+              "name": "TweenBehavior",
+              "supplementaryInformation": "Tween::TweenBehavior",
+              "type": "behavior"
+            },
+            {
+              "description": "Duration of the blinking, in seconds",
+              "name": "FlashDuration",
+              "type": "expression"
+            },
+            {
+              "description": "Target opacity",
+              "name": "TargetOpacity",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the specified objects are flashing.",
+          "fullName": "Is object flashing",
+          "functionType": "Condition",
+          "name": "IsFlashing",
+          "sentence": "_PARAM0_ is flashing",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onOwnerRemovedFromScene",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onDeActivate",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Stop flashing the object",
+          "fullName": "Stop flashing",
+          "functionType": "Action",
+          "name": "Stop",
+          "sentence": "Stop flashing _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::IsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashOpacity::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Color_Duration_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Tween::RemoveTween"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TweenBehavior",
+                    "\"__Flash.ToTargetOpacity\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Tween::RemoveTween"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TweenBehavior",
+                    "\"__Flash.ToStartingOpacity\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "Opacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "=",
+                    "Object.Behavior::PropertyStartingOpacity()"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashOpacity",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "Tween Behavior (required)",
+          "description": "",
+          "group": "",
+          "extraInformation": [
+            "Tween::TweenBehavior"
+          ],
+          "hidden": false,
+          "name": "TweenBehavior"
+        },
+        {
+          "value": "0.1",
+          "type": "Number",
+          "label": "Half period (time between flashes), in seconds",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HalfPeriodTime"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsFlashing"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "FlashDuration"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "unit": "Dimensionless",
+          "label": "Target opacity (Range: 0 - 255)",
+          "description": "Opacity will fade between the starting value and this target value",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TargetOpacity"
+        },
+        {
+          "value": "",
+          "type": "Number",
+          "unit": "Dimensionless",
+          "label": "Starting opacity",
+          "description": "Opacity will fade between the starting value and this target value",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "StartingOpacity"
+        }
+      ],
+      "sharedPropertyDescriptors": []
+    },
+    {
       "description": "Make the object flash an effect for a period of time.",
       "fullName": "Flash effect",
       "name": "FlashEffect",
@@ -1381,7 +2030,7 @@
                   "colorG": 176,
                   "colorR": 74,
                   "creationTime": 0,
-                  "name": "Altenate states",
+                  "name": "Alternate states",
                   "source": "",
                   "type": "BuiltinCommonInstructions::Group",
                   "events": [
@@ -1509,93 +2158,35 @@
               "actions": [],
               "events": [
                 {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Stop any previous flashing if the effect name has changed"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::IsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::PropertyEffectName"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "!=",
-                        "GetArgumentAsString(\"EffectName\")"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::Stop"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Only save the starting state if it is not currently flashing"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "Flash::FlashEffect::IsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    }
-                  ],
-                  "actions": [],
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Stop flashing if the effect name has changed",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
                   "events": [
                     {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "value": "IsEffectEnabled"
+                            "value": "Flash::FlashEffect::IsFlashing"
                           },
                           "parameters": [
                             "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashEffect::PropertyEffectName"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "!=",
                             "GetArgumentAsString(\"EffectName\")"
                           ]
                         }
@@ -1603,112 +2194,199 @@
                       "actions": [
                         {
                           "type": {
-                            "value": "SetObjectVariableAsBoolean"
+                            "value": "Flash::FlashEffect::Stop"
                           },
                           "parameters": [
                             "Object",
-                            "__FlashColor_StartingState",
-                            "True"
+                            "Behavior",
+                            ""
                           ]
                         }
                       ]
-                    },
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Save starting state (only when not flashing)",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
                     {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
                             "inverted": true,
-                            "value": "IsEffectEnabled"
+                            "value": "Flash::FlashEffect::IsFlashing"
                           },
                           "parameters": [
                             "Object",
-                            "GetArgumentAsString(\"EffectName\")"
+                            "Behavior",
+                            ""
                           ]
                         }
                       ],
-                      "actions": [
+                      "actions": [],
+                      "events": [
                         {
-                          "type": {
-                            "value": "SetObjectVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "Object",
-                            "__FlashColor_StartingState",
-                            "False"
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "IsEffectEnabled"
+                              },
+                              "parameters": [
+                                "Object",
+                                "GetArgumentAsString(\"EffectName\")"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetObjectVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "Object",
+                                "__FlashColor_StartingState",
+                                "True"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "IsEffectEnabled"
+                              },
+                              "parameters": [
+                                "Object",
+                                "GetArgumentAsString(\"EffectName\")"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetObjectVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "Object",
+                                "__FlashColor_StartingState",
+                                "False"
+                              ]
+                            }
                           ]
                         }
                       ]
                     }
-                  ]
+                  ],
+                  "parameters": []
                 },
                 {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Start flashing"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Change to the opposite state",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
                     {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Effect_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResetObjectTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "\"Flash_Effect_Duration_Timer\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::SetPropertyFlashDuration"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsNumber(\"FlashDuration\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::SetPropertyEffectName"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "GetArgumentAsString(\"EffectName\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashEffect::SetPropertyIsFlashing"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::ToggleEffect"
+                          },
+                          "parameters": [
+                            "",
+                            "Object",
+                            "GetArgumentAsString(\"EffectName\")",
+                            ""
+                          ]
+                        }
                       ]
                     }
-                  ]
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Prepare for flashing",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Effect_Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Effect_Duration_Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashEffect::SetPropertyFlashDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "GetArgumentAsNumber(\"FlashDuration\")"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashEffect::SetPropertyEffectName"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "GetArgumentAsString(\"EffectName\")"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashEffect::SetPropertyIsFlashing"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
                 }
               ]
             }

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -7,7 +7,7 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZsYXNoLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNywySDE3TDEzLjUsOUgxN0wxMCwyMlYxNEg3VjJNOSw0VjEySDEyVjE0LjY2TDE0LDExSDEwLjI0TDEzLjc2LDRIOVoiIC8+PC9zdmc+",
   "name": "Flash",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg",
-  "shortDescription": "Make an object flash visibility (blink), color tint, object effect, or opacity (fade)",
+  "shortDescription": "Make an object flash visibility (blink), color tint, object effect, or opacity (fade).",
   "version": "1.1.0",
   "description": [
     "Make an object flash for a period of time so that it alternates between two different states.",

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -2001,7 +2001,7 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing opacity of an object",
+          "description": "Stop flashing opacity of an object.",
           "fullName": "Stop flashing opacity",
           "functionType": "Action",
           "name": "Stop",

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -33,11 +33,11 @@
   "dependencies": [],
   "eventsFunctions": [
     {
-      "description": "Color tint that is currently applied to the object. \"255;255;255\" is used when there is no tint applied.",
-      "fullName": "Color tint applied to object",
-      "functionType": "StringExpression",
-      "name": "Tint",
-      "sentence": "",
+      "description": "Color tint applied to an object.",
+      "fullName": "Color tint applied to an object",
+      "functionType": "ExpressionAndCondition",
+      "name": "ColorTint",
+      "sentence": "Color tint applied to _PARAM1_",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Comment",
@@ -62,6 +62,55 @@
           "parameterObjects": "Object",
           "useStrict": true,
           "eventsSheetExpanded": false
+        }
+      ],
+      "expressionType": {
+        "type": "color"
+      },
+      "parameters": [
+        {
+          "description": "Object",
+          "name": "Object",
+          "supplementaryInformation": "Sprite",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Check if a color tint is applied to an object.",
+      "fullName": "Is a color tint applied to an object",
+      "functionType": "StringExpression",
+      "name": "IsTinted",
+      "sentence": "_PARAM1_ is color tinted",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "Flash::ColorTint"
+              },
+              "parameters": [
+                "",
+                "=",
+                "\"255;255;255\"",
+                "Object",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
         }
       ],
       "expressionType": {
@@ -187,6 +236,247 @@
         }
       ],
       "objectGroups": []
+    },
+    {
+      "description": "Toggle color tint between the starting tint and a given value.",
+      "fullName": "Toggle a color tint",
+      "functionType": "Action",
+      "name": "ToggleColorTint",
+      "private": true,
+      "sentence": "Toggle color tint _PARAM2_ on _PARAM1_",
+      "events": [
+        {
+          "colorB": 35,
+          "colorG": 166,
+          "colorR": 245,
+          "creationTime": 0,
+          "name": "Note: This function cannot be \"public\" until it properly handles objects without a starting color tint variable (NULL)",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "name": "Swap between the starting tint and the given value",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetObjectVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__Flash_ColorTintToggled",
+                    "False"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::ColorTint"
+                  },
+                  "parameters": [
+                    "",
+                    "=",
+                    "Object.VariableString(__FlashColor_StartingTint)",
+                    "Object",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ChangeColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "GetArgumentAsString(\"ColorTint\")"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetObjectVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__Flash_ColorTintToggled",
+                    "True"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__Flash_ColorTintToggled",
+                    "False"
+                  ]
+                },
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "Flash::ColorTint"
+                  },
+                  "parameters": [
+                    "",
+                    "=",
+                    "Object.VariableString(__FlashColor_StartingTint)",
+                    "Object",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ChangeColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Object.VariableString(__FlashColor_StartingTint)"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": []
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Object",
+          "name": "Object",
+          "supplementaryInformation": "Sprite",
+          "type": "objectList"
+        },
+        {
+          "description": "Color tint",
+          "name": "ColorTint",
+          "type": "color"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Toggle object visibility.",
+      "fullName": "Toggle object visibility",
+      "functionType": "Action",
+      "name": "ToggleVisibility",
+      "sentence": "Toggle visibility of _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_VisibilityToggled",
+                "False"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "Visible"
+              },
+              "parameters": [
+                "Object"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "Cache"
+              },
+              "parameters": [
+                "Object"
+              ]
+            },
+            {
+              "type": {
+                "value": "SetObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_VisibilityToggled",
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "ObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_VisibilityToggled",
+                "False"
+              ]
+            },
+            {
+              "type": {
+                "inverted": true,
+                "value": "Visible"
+              },
+              "parameters": [
+                "Object"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "Montre"
+              },
+              "parameters": [
+                "Object",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Object",
+          "name": "Object",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
     }
   ],
   "eventsBasedBehaviors": [
@@ -239,68 +529,17 @@
                             ">",
                             "Object.Behavior::PropertyHalfPeriodTime()"
                           ]
-                        },
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "Visible"
-                          },
-                          "parameters": [
-                            "Object"
-                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "value": "Montre"
+                            "value": "Flash::ToggleVisibility"
                           },
                           "parameters": [
+                            "",
                             "Object",
                             ""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "ResetObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Visibility_Timer\""
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "CompareObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Visibility_Timer\"",
-                            ">",
-                            "Object.Behavior::PropertyHalfPeriodTime()"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Visible"
-                          },
-                          "parameters": [
-                            "Object"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "Cache"
-                          },
-                          "parameters": [
-                            "Object"
                           ]
                         },
                         {
@@ -376,11 +615,11 @@
           "objectGroups": []
         },
         {
-          "description": "Make object blink visibility for a period of time.",
+          "description": "Make an object flash (blink) visibility for a period of time.",
           "fullName": "Flash visibility (blink)",
           "functionType": "Action",
           "name": "Flash",
-          "sentence": "Make _PARAM0_ blink for _PARAM2_ seconds",
+          "sentence": "Make _PARAM0_ flash (blink) for _PARAM2_ seconds",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -402,6 +641,16 @@
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
+                    {
+                      "type": {
+                        "value": "Flash::ToggleVisibility"
+                      },
+                      "parameters": [
+                        "",
+                        "Object",
+                        ""
+                      ]
+                    },
                     {
                       "type": {
                         "value": "ResetObjectTimer"
@@ -440,14 +689,6 @@
                         "Behavior",
                         "yes"
                       ]
-                    },
-                    {
-                      "type": {
-                        "value": "Cache"
-                      },
-                      "parameters": [
-                        "Object"
-                      ]
                     }
                   ]
                 }
@@ -475,8 +716,8 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects are flashing.",
-          "fullName": "Is object flashing",
+          "description": "Check if an object is flashing visibility.",
+          "fullName": "Is object flashing visibility",
           "functionType": "Condition",
           "name": "IsFlashing",
           "sentence": "_PARAM0_ is flashing",
@@ -612,11 +853,11 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing visibility (blink) of the object.",
+          "description": "Stop flashing visibility (blink) of an object.",
           "fullName": "Stop flashing visibility (blink)",
           "functionType": "Action",
           "name": "Stop",
-          "sentence": "Stop flashing _PARAM0_",
+          "sentence": "Stop flashing visibility of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -773,27 +1014,9 @@
                             ">",
                             "Object.Behavior::PropertyHalfPeriodTime()"
                           ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashColor::PropertyIsTinted"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ]
                         }
                       ],
                       "actions": [
-                        {
-                          "type": {
-                            "value": "ChangeColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.VariableString(__FlashColor_StartingTint)"
-                          ]
-                        },
                         {
                           "type": {
                             "value": "ResetObjectTimer"
@@ -805,68 +1028,13 @@
                         },
                         {
                           "type": {
-                            "value": "Flash::FlashColor::SetPropertyIsTinted"
+                            "value": "Flash::ToggleColorTint"
                           },
                           "parameters": [
+                            "",
                             "Object",
-                            "Behavior",
-                            "no"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "CompareObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Color_Timer\"",
-                            ">",
-                            "Object.Behavior::PropertyHalfPeriodTime()"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "inverted": true,
-                            "value": "Flash::FlashColor::PropertyIsTinted"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "ChangeColor"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Object.Behavior::PropertyTintColor()"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "ResetObjectTimer"
-                          },
-                          "parameters": [
-                            "Object",
-                            "\"Flash_Color_Timer\""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Flash::FlashColor::SetPropertyIsTinted"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "yes"
+                            "Object.Behavior::PropertyTintColor()",
+                            ""
                           ]
                         }
                       ]
@@ -934,11 +1102,11 @@
           "objectGroups": []
         },
         {
-          "description": "Make the specified object(s) change color for the given duration.",
-          "fullName": "Flash color",
+          "description": "Make an object flash a color tint for a period of time.",
+          "fullName": "Flash color tint",
           "functionType": "Action",
           "name": "Flash",
-          "sentence": "Make _PARAM0_ flash the color _PARAM3_ for _PARAM2_ seconds",
+          "sentence": "Make _PARAM0_ flash the color tint _PARAM3_ for _PARAM2_ seconds",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -991,7 +1159,7 @@
                         "Object",
                         "__FlashColor_StartingTint",
                         "=",
-                        "Flash::Tint(Object)"
+                        "Flash::ColorTint(Object)"
                       ]
                     }
                   ]
@@ -1052,21 +1220,13 @@
                     },
                     {
                       "type": {
-                        "value": "ChangeColor"
+                        "value": "Flash::ToggleColorTint"
                       },
                       "parameters": [
+                        "",
                         "Object",
-                        "GetArgumentAsString(\"ColorTint\")"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "Flash::FlashColor::SetPropertyIsTinted"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
+                        "Object.Behavior::PropertyTintColor()",
+                        ""
                       ]
                     }
                   ]
@@ -1101,10 +1261,72 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects are flashing.",
-          "fullName": "Is object flashing",
+          "description": "Check if the specified objects are flashing a color tint.",
+          "fullName": "Is object flashing a color tint",
           "functionType": "Condition",
           "name": "IsFlashing",
+          "sentence": "_PARAM0_ is flashing a color tint",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the specified objects is tinted",
+          "fullName": "Is object tinted",
+          "functionType": "Condition",
+          "name": "IsTinted",
           "sentence": "_PARAM0_ is flashing",
           "events": [
             {
@@ -1241,11 +1463,11 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing the object",
-          "fullName": "Stop flashing",
+          "description": "Stop flashing a color tint on an object.",
+          "fullName": "Stop flashing color tint",
           "functionType": "Action",
           "name": "Stop",
-          "sentence": "Stop flashing _PARAM0_",
+          "sentence": "Stop flashing color tint _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1546,11 +1768,11 @@
           "objectGroups": []
         },
         {
-          "description": "Make the object fade opacity in a loop.",
-          "fullName": "Fade opacity in a loop",
+          "description": "Make an object flash opacity smoothly in a loop for a period of time.",
+          "fullName": "Flash opacity smoothly in a loop",
           "functionType": "Action",
           "name": "Flash",
-          "sentence": "Make _PARAM0_ fade opacity to _PARAM4_ in a loop for _PARAM3_ seconds",
+          "sentence": "Make _PARAM0_ flash opacity smoothly to _PARAM4_ in a loop for _PARAM3_ seconds",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1574,7 +1796,7 @@
                     {
                       "type": {
                         "inverted": true,
-                        "value": "Flash::FlashColor::PropertyIsFlashing"
+                        "value": "Flash::FlashOpacity::PropertyIsFlashing"
                       },
                       "parameters": [
                         "Object",
@@ -1602,7 +1824,7 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "Flash::FlashColor::SetPropertyFlashDuration"
+                        "value": "Flash::FlashOpacity::SetPropertyFlashDuration"
                       },
                       "parameters": [
                         "Object",
@@ -1621,13 +1843,7 @@
                         "=",
                         "GetArgumentAsNumber(\"TargetOpacity\")"
                       ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
+                    },
                     {
                       "type": {
                         "value": "Tween::AddObjectOpacityTween"
@@ -1699,11 +1915,11 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects are flashing.",
-          "fullName": "Is object flashing",
+          "description": "Check if the object is flashing opacity.",
+          "fullName": "Is object flashing opacity",
           "functionType": "Condition",
           "name": "IsFlashing",
-          "sentence": "_PARAM0_ is flashing",
+          "sentence": "_PARAM0_ is flashing opacity",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1839,11 +2055,11 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing the object",
-          "fullName": "Stop flashing",
+          "description": "Stop flashing opacity of an object",
+          "fullName": "Stop flashing opacity",
           "functionType": "Action",
           "name": "Stop",
-          "sentence": "Stop flashing _PARAM0_",
+          "sentence": "Stop flashing opacity of _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1881,22 +2097,24 @@
                 },
                 {
                   "type": {
-                    "value": "Tween::RemoveTween"
+                    "value": "Tween::StopTween"
                   },
                   "parameters": [
                     "Object",
                     "TweenBehavior",
-                    "\"__Flash.ToTargetOpacity\""
+                    "\"__Flash.ToTargetOpacity\"",
+                    "yes"
                   ]
                 },
                 {
                   "type": {
-                    "value": "Tween::RemoveTween"
+                    "value": "Tween::StopTween"
                   },
                   "parameters": [
                     "Object",
                     "TweenBehavior",
-                    "\"__Flash.ToStartingOpacity\""
+                    "\"__Flash.ToStartingOpacity\"",
+                    "yes"
                   ]
                 },
                 {
@@ -2135,7 +2353,7 @@
           "objectGroups": []
         },
         {
-          "description": "Make the object flash an effect for a period of time.",
+          "description": "Make an object flash an effect for a period of time.",
           "fullName": "Flash effect",
           "functionType": "Action",
           "name": "Flash",
@@ -2418,11 +2636,11 @@
           "objectGroups": []
         },
         {
-          "description": "Check if the specified objects are flashing.",
-          "fullName": "Is object flashing",
+          "description": "Check if the object is flashing an effect.",
+          "fullName": "Is object flashing an effect",
           "functionType": "Condition",
           "name": "IsFlashing",
-          "sentence": "_PARAM0_ is flashing",
+          "sentence": "_PARAM0_ is flashing an effect",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2558,7 +2776,7 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing an effect of the object.",
+          "description": "Stop flashing an effect of an object.",
           "fullName": "Stop flashing an effect",
           "functionType": "Action",
           "name": "Stop",

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -31,11 +31,168 @@
     "q8ubdigLvIRXLxsJDDTaokO41mc2"
   ],
   "dependencies": [],
-  "eventsFunctions": [],
+  "eventsFunctions": [
+    {
+      "description": "Color tint that is currently applied to the object. \"255;255;255\" is used when there is no tint applied.",
+      "fullName": "Color tint applied to object",
+      "functionType": "StringExpression",
+      "name": "Tint",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Return the color string for the tint applied to the object"
+        },
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "/** @type {gdjs.SpriteRuntimeObject} */\r",
+            "const tintedObject = objects[0];\r",
+            "const tint = tintedObject.getColor();\r",
+            "eventsFunctionContext.returnValue = tint;"
+          ],
+          "parameterObjects": "Object",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "expressionType": {
+        "type": "color"
+      },
+      "parameters": [
+        {
+          "description": "Object",
+          "name": "Object",
+          "supplementaryInformation": "Sprite",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Toggle an object effect.",
+      "fullName": "Toggle an object effect",
+      "functionType": "Action",
+      "name": "ToggleEffect",
+      "sentence": "Toggle effect _PARAM2_ on _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_EffectToggled",
+                "False"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "IsEffectEnabled"
+              },
+              "parameters": [
+                "Object",
+                "GetArgumentAsString(\"EffectName\")"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "EnableEffect"
+              },
+              "parameters": [
+                "Object",
+                "GetArgumentAsString(\"EffectName\")",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "SetObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_EffectToggled",
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "IsEffectEnabled"
+              },
+              "parameters": [
+                "Object",
+                "GetArgumentAsString(\"EffectName\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ObjectVariableAsBoolean"
+              },
+              "parameters": [
+                "Object",
+                "__Flash_EffectToggled",
+                "False"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "EnableEffect"
+              },
+              "parameters": [
+                "Object",
+                "GetArgumentAsString(\"EffectName\")",
+                "yes"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Object",
+          "name": "Object",
+          "type": "objectList"
+        },
+        {
+          "description": "Effect name to toggle",
+          "name": "EffectName",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
   "eventsBasedBehaviors": [
     {
-      "description": "Make the object flash (blink) for a period of time, so that it is alternately visible and invisible.\nTrigger the effect by using the Flash action.",
-      "fullName": "Flash (blink)",
+      "description": "Make the object flash (blink) for a period of time so that it alternates between visible and invisible.",
+      "fullName": "Flash visibility (blink)",
       "name": "Flash",
       "objectType": "",
       "eventsFunctions": [
@@ -195,8 +352,8 @@
           "objectGroups": []
         },
         {
-          "description": "Make the specified object(s) blink for the given duration.",
-          "fullName": "Flash (blink)",
+          "description": "Make object blink visibility for a period of time.",
+          "fullName": "Flash visibility (blink)",
           "functionType": "Action",
           "name": "Flash",
           "sentence": "Make _PARAM0_ blink for _PARAM2_ seconds",
@@ -431,8 +588,8 @@
           "objectGroups": []
         },
         {
-          "description": "Stop flashing the object",
-          "fullName": "Stop flashing",
+          "description": "Stop flashing visibility (blink) of the object.",
+          "fullName": "Stop flashing visibility (blink)",
           "functionType": "Action",
           "name": "Stop",
           "sentence": "Stop flashing _PARAM0_",
@@ -539,6 +696,1356 @@
           "extraInformation": [],
           "hidden": true,
           "name": "FlashDuration"
+        }
+      ],
+      "sharedPropertyDescriptors": []
+    },
+    {
+      "description": "Make the object flash a color tint for a period of time.",
+      "fullName": "Flash color tint",
+      "name": "FlashColor",
+      "objectType": "Sprite",
+      "eventsFunctions": [
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Alternate states",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Color_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyHalfPeriodTime()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashColor::PropertyIsTinted"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ChangeColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.VariableString(__FlashColor_StartingTint)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Color_Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashColor::SetPropertyIsTinted"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "no"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Color_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyHalfPeriodTime()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "Flash::FlashColor::PropertyIsTinted"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ChangeColor"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Object.Behavior::PropertyTintColor()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Color_Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::FlashColor::SetPropertyIsTinted"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "yes"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Stop flashing",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Color_Duration_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyFlashDuration()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::FlashColor::Stop"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make the specified object(s) change color for the given duration.",
+          "fullName": "Flash color",
+          "functionType": "Action",
+          "name": "Flash",
+          "sentence": "Make _PARAM0_ flash the color _PARAM3_ for _PARAM2_ seconds",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareArgumentAsNumber"
+                  },
+                  "parameters": [
+                    "\"FlashDuration\"",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Only save the tint if it is not currently flashing"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "Flash::FlashColor::PropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarObjetTxt"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__FlashColor_StartingTint",
+                        "=",
+                        "Flash::Tint(Object)"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Color_Timer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Color_Duration_Timer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashColor::SetPropertyFlashDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"FlashDuration\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashColor::SetPropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashColor::SetPropertyTintColor"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsString(\"ColorTint\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ChangeColor"
+                      },
+                      "parameters": [
+                        "Object",
+                        "GetArgumentAsString(\"ColorTint\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashColor::SetPropertyIsTinted"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            },
+            {
+              "description": "Duration of the blinking, in seconds",
+              "name": "FlashDuration",
+              "type": "expression"
+            },
+            {
+              "description": "Color tint",
+              "name": "ColorTint",
+              "type": "color"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the specified objects are flashing.",
+          "fullName": "Is object flashing",
+          "functionType": "Condition",
+          "name": "IsFlashing",
+          "sentence": "_PARAM0_ is flashing",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onOwnerRemovedFromScene",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onDeActivate",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Stop flashing the object",
+          "fullName": "Stop flashing",
+          "functionType": "Action",
+          "name": "Stop",
+          "sentence": "Stop flashing _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ChangeColor"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Object.VariableString(__FlashColor_StartingTint)"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Color_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Color_Duration_Timer\""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashColor",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "0.1",
+          "type": "Number",
+          "label": "Half period (time between flashes), in seconds",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HalfPeriodTime"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsFlashing"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "FlashDuration"
+        },
+        {
+          "value": "\"255;255;255\"",
+          "type": "String",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "TintColor"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "Is tinted",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsTinted"
+        }
+      ],
+      "sharedPropertyDescriptors": []
+    },
+    {
+      "description": "Make the object flash an effect for a period of time.",
+      "fullName": "Flash effect",
+      "name": "FlashEffect",
+      "objectType": "Sprite",
+      "eventsFunctions": [
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::IsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Altenate states",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Effect_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyHalfPeriodTime()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ResetObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Effect_Timer\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "Flash::ToggleEffect"
+                          },
+                          "parameters": [
+                            "",
+                            "Object",
+                            "Object.Behavior::PropertyEffectName()",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Stop flashing",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CompareObjectTimer"
+                          },
+                          "parameters": [
+                            "Object",
+                            "\"Flash_Effect_Duration_Timer\"",
+                            ">",
+                            "Object.Behavior::PropertyFlashDuration()"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Flash::FlashEffect::Stop"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Make the object flash an effect for a period of time.",
+          "fullName": "Flash effect",
+          "functionType": "Action",
+          "name": "Flash",
+          "sentence": "Make _PARAM0_ flash the effect _PARAM3_ for _PARAM2_ seconds",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareArgumentAsNumber"
+                  },
+                  "parameters": [
+                    "\"FlashDuration\"",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Stop any previous flashing if the effect name has changed"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::IsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::PropertyEffectName"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "!=",
+                        "GetArgumentAsString(\"EffectName\")"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::Stop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Only save the starting state if it is not currently flashing"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "Flash::FlashEffect::IsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "IsEffectEnabled"
+                          },
+                          "parameters": [
+                            "Object",
+                            "GetArgumentAsString(\"EffectName\")"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__FlashColor_StartingState",
+                            "True"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "IsEffectEnabled"
+                          },
+                          "parameters": [
+                            "Object",
+                            "GetArgumentAsString(\"EffectName\")"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetObjectVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__FlashColor_StartingState",
+                            "False"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Start flashing"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Effect_Timer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ResetObjectTimer"
+                      },
+                      "parameters": [
+                        "Object",
+                        "\"Flash_Effect_Duration_Timer\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::SetPropertyFlashDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"FlashDuration\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::SetPropertyEffectName"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsString(\"EffectName\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Flash::FlashEffect::SetPropertyIsFlashing"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            },
+            {
+              "description": "Duration of the blinking, in seconds",
+              "name": "FlashDuration",
+              "type": "expression"
+            },
+            {
+              "description": "Name of effect",
+              "name": "EffectName",
+              "type": "string"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Check if the specified objects are flashing.",
+          "fullName": "Is object flashing",
+          "functionType": "Condition",
+          "name": "IsFlashing",
+          "sentence": "_PARAM0_ is flashing",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "False"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onOwnerRemovedFromScene",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onDeActivate",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::Stop"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Stop flashing an effect of the object.",
+          "fullName": "Stop flashing an effect",
+          "functionType": "Action",
+          "name": "Stop",
+          "sentence": "Stop flashing an effect on _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashColor::PropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Flash::FlashEffect::SetPropertyIsFlashing"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Effect_Timer\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"Flash_Effect_Duration_Timer\""
+                  ]
+                }
+              ],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__FlashEffect_StartingState",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "EnableEffect"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Object.Behavior::PropertyEffectName()",
+                        "yes"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__FlashEffect_StartingState",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "EnableEffect"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Object.Behavior::PropertyEffectName()",
+                        ""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "Sprite",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Flash::FlashEffect",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "0.1",
+          "type": "Number",
+          "unit": "Second",
+          "label": "Half period (time between flashes), in seconds",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "HalfPeriodTime"
+        },
+        {
+          "value": "",
+          "type": "Boolean",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "IsFlashing"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "unit": "Second",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "FlashDuration"
+        },
+        {
+          "value": "",
+          "type": "String",
+          "label": "Name of effect",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "EffectName"
         }
       ],
       "sharedPropertyDescriptors": []

--- a/extensions/reviewed/Flash.json
+++ b/extensions/reviewed/Flash.json
@@ -1526,8 +1526,8 @@
       "sharedPropertyDescriptors": []
     },
     {
-      "description": "Flash opacity in a looping tween",
-      "fullName": "Flash opacity in a looping tween",
+      "description": "Flash opacity smoothly (fade) in a repeating loop.",
+      "fullName": "Flash opacity smothly (fade)",
       "name": "FlashOpacity",
       "objectType": "Sprite",
       "eventsFunctions": [
@@ -1707,8 +1707,8 @@
           "objectGroups": []
         },
         {
-          "description": "Make an object flash opacity smoothly in a loop for a period of time.",
-          "fullName": "Flash opacity smoothly in a loop",
+          "description": "Make an object flash opacity smoothly (fade) in a repeating loop.",
+          "fullName": "Flash opacity (fade)",
           "functionType": "Action",
           "name": "Flash",
           "sentence": "Make _PARAM0_ flash opacity smoothly to _PARAM4_ in a loop for _PARAM3_ seconds",

--- a/scripts/lib/ExtensionsValidatorExceptions.js
+++ b/scripts/lib/ExtensionsValidatorExceptions.js
@@ -442,6 +442,12 @@ const extensionsAllowedProperties = {
       runtimeSceneAllowedProperties: [],
       javaScriptObjectAllowedProperties: [],
     },
+    Flash: {
+      gdjsAllowedProperties: ['SpriteRuntimeObject'],
+      gdjsEvtToolsAllowedProperties: [],
+      runtimeSceneAllowedProperties: [],
+      javaScriptObjectAllowedProperties: [],
+    },
   },
 };
 


### PR DESCRIPTION
## New features
- Flash color tint
- Flash effect
- Flash opacity (fade)

## Improvements
- When "Flash object" action is used during an pre-existing flash, simply extend the duration of the flashing 
  - Previously, it always started with "hide object", potentially causing the object to be hidden too much

## Playable game

https://gd.games/victrisgames/flash-object-extension-example

## Project files

https://github.com/GDevelopApp/GDevelop-examples/pull/554

## Video

https://github.com/GDevelopApp/GDevelop-extensions/assets/8879811/401d5d73-c13f-4e94-96be-05afb6ff7b55



