### PR TITLE
New extension SelectionTools.

### DIFF
--- a/extensions/community/SelectionTools.json
+++ b/extensions/community/SelectionTools.json
@@ -12,18 +12,17 @@
   "description": [
     "How to use:",
     "",
-    "- Create a shape painter object. It would be used to draw the selection on the screen.",
-    "- Add the `Setup selection tools` action to an event.",
-    "- Add the setup action for the required selection. Choose from: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.",
+    "- Activate SelectionTools using the `De/Activate selection tools` action.",
+    "- Create a shape painter object and add the `Selection painter` behavior to it. Create a single instance of this object in the scene.",
+    "- Set the type of selection using one of these actions: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.",
     "",
     "Tips:",
     "",
     "- The `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection` actions are used for both setting properties and changing the current selection type.",
-    "- Actions used to set things (i.e. \"Setup selection tools\" and the set action for each of the different selections) aren't required to be called each frame. They should ideally be added and triggered only once at the beginning of the scene. But they can be used again to modify specific properties or change the current selection type.",
+    "- None of the action require you to call them each frame, it's adviced that you use them with `At the beginning of the scene` condition or a `Triggred Once`.",
     "",
     "Actions:",
     "",
-    "- `Setup selection tools`",
     "- `De/Activate selection tools`",
     "- `Set rectangular selection`",
     "- `Set polygonal selection`",
@@ -34,7 +33,12 @@
     "",
     "- `Select`",
     "- `Selection activated`",
-    "- `Current selection type`"
+    "- `Current selection type`",
+    "",
+    "Behavior:",
+    "",
+    "- `Selection painter`",
+    ""
   ],
   "tags": [
     "select",
@@ -50,1221 +54,6 @@
   ],
   "dependencies": [],
   "eventsFunctions": [
-    {
-      "fullName": "",
-      "functionType": "Action",
-      "name": "onScenePreEvents",
-      "sentence": "",
-      "events": [
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "SceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__SelectionTools.Active",
-                "True"
-              ]
-            }
-          ],
-          "actions": [],
-          "events": [
-            {
-              "folded": true,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarSceneTxt"
-                  },
-                  "parameters": [
-                    "__SelectionTools.SelectionType",
-                    "=",
-                    "\"Rectangular\""
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Draw selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::JsCode",
-                      "inlineCode": [
-                        "const selectionTools = runtimeScene",
-                        "    .getVariables()",
-                        "    .get(\"__SelectionTools\")",
-                        "",
-                        "const vertex = selectionTools",
-                        "    .getChild(\"Vertex\")",
-                        "    .getAllChildrenArray();",
-                        "",
-                        "if (vertex.length == 4){",
-                        "    //get the painter object",
-                        "    const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
-                        "    painter.clear();",
-                        "    ",
-                        "    const originX = vertex[0].getAsNumber();",
-                        "    const originY = vertex[1].getAsNumber();",
-                        "    const cursorX = vertex[2].getAsNumber();",
-                        "    const cursorY = vertex[3].getAsNumber();",
-                        "",
-                        "    //begin fill path",
-                        "    painter.beginFillPath(originX, originY);",
-                        "    painter.drawPathLineTo(cursorX, originY);",
-                        "    painter.drawPathLineTo(cursorX,cursorY);",
-                        "    painter.drawPathLineTo(originX, cursorY);",
-                        "    painter.closePath();",
-                        "}"
-                      ],
-                      "parameterObjects": "",
-                      "useStrict": true,
-                      "eventsSheetExpanded": false
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "End selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "="
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Begin selection. Gain position of origin"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "False"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "VariableClearChildren"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Update position of free end (positioned at the cursor)"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "SceneVariableChildCount"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "=",
-                            "4"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::Or"
-                          },
-                          "parameters": [],
-                          "subInstructions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareNumbers"
-                              },
-                              "parameters": [
-                                "Variable(__SelectionTools.Vertex[2])",
-                                "!=",
-                                "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareNumbers"
-                              },
-                              "parameters": [
-                                "Variable(__SelectionTools.Vertex[3])",
-                                "!=",
-                                "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                              ]
-                            }
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SceneVariableRemoveAt"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "3"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariableRemoveAt"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "2"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "SceneVariableChildCount"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "=",
-                            "2"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
-                            ">",
-                            "0"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "folded": true,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarSceneTxt"
-                  },
-                  "parameters": [
-                    "__SelectionTools.SelectionType",
-                    "=",
-                    "\"Polygonal\""
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Draw selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::JsCode",
-                      "inlineCode": [
-                        "const selectionTools = runtimeScene",
-                        "    .getVariables()",
-                        "    .get(\"__SelectionTools\");",
-                        "",
-                        "const vertices = selectionTools",
-                        "    .getChild(\"Vertices\")",
-                        "    .getAllChildrenArray();",
-                        "",
-                        "//get the painter object",
-                        "const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
-                        "painter.clear();",
-                        "",
-                        "//begin fill path",
-                        "painter.beginFillPath(vertices[0].getAllChildrenArray()[0].getAsNumber(), vertices[0].getAllChildrenArray()[1].getAsNumber());",
-                        "",
-                        "const shapeClosed = selectionTools.getChild(\"CloseSelection\").getAsBoolean() && !gdjs.evtTools.input.isMouseButtonPressed(runtimeScene,\"Left\");",
-                        "",
-                        "//pop the last vertex",
-                        "//when the last vertex placed is within the merge proximity",
-                        "if (shapeClosed && selectionTools.getChild(\"PopLastVertex\").getAsBoolean()) {",
-                        "    vertices.pop();",
-                        "}",
-                        "",
-                        "//draw path lines",
-                        "for (let i = 1; i < vertices.length; i++) {",
-                        "    const vertex = vertices[i].getAllChildrenArray();",
-                        "    painter.drawPathLineTo(vertex[0].getAsNumber(), vertex[1].getAsNumber());",
-                        "}",
-                        "",
-                        "const cursorX = gdjs.evtTools.input.getCursorX(runtimeScene, selectionTools.getChild(\"Layer\"),0);",
-                        "const cursorY = gdjs.evtTools.input.getCursorY(runtimeScene, selectionTools.getChild(\"Layer\"),0);",
-                        "",
-                        "//close shape",
-                        "if (shapeClosed) {",
-                        "    painter.closePath();",
-                        "    runtimeScene.getVariables().get(\"__SelectionTools\").getChild(\"CanDrawSelection\").setValue(false);",
-                        "} else{",
-                        "    painter.drawPathLineTo(cursorX, cursorY);",
-                        "}"
-                      ],
-                      "parameterObjects": "",
-                      "useStrict": true,
-                      "eventsSheetExpanded": false
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Close selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonReleased"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        ">",
-                        "2"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::CompareNumbers"
-                      },
-                      "parameters": [
-                        "DistanceBetweenPositions(Variable(__SelectionTools.Vertices[0][0]), Variable(__SelectionTools.Vertices[0][1]), CursorX(VariableString(__SelectionTools.Layer),0), CursorY(VariableString(__SelectionTools.Layer),0))",
-                        "<",
-                        "Variable(__SelectionTools.MergeProximity)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CloseSelection",
-                        "True"
-                      ]
-                    }
-                  ],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][0])",
-                            "=",
-                            "round(CursorX(VariableString(__SelectionTools.Layer),0))"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][1])",
-                            "=",
-                            "round(CursorY(VariableString(__SelectionTools.Layer),0))"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__SelectionTools.PopLastVertex",
-                            "True"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "End selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "False"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "VariableClearChildren"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertices"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.PopLastVertex",
-                        "False"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CloseSelection",
-                        "False"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Add new vertex. Update vertices"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "<",
-                        "Variable(__SelectionTools.MaximumVertexCount)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Or"
-                      },
-                      "parameters": [],
-                      "subInstructions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
-                            ">=",
-                            "Variable(__SelectionTools.SideLength)"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            "=",
-                            "0"
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "VariableClearChildren"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePush"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertices",
-                        "__SelectionTools.Vertex"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "+",
-                        "1"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "folded": true,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarSceneTxt"
-                  },
-                  "parameters": [
-                    "__SelectionTools.SelectionType",
-                    "=",
-                    "\"Lasso\""
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Draw Selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::JsCode",
-                      "inlineCode": [
-                        "const selectionTools = runtimeScene",
-                        "    .getVariables()",
-                        "    .get(\"__SelectionTools\");",
-                        "",
-                        "const vertices = selectionTools",
-                        "    .getChild(\"Vertices\")",
-                        "    .getAllChildrenArray();",
-                        "",
-                        "if (vertices.length > 1){",
-                        "    //get the painter object",
-                        "    const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
-                        "    painter.clear();",
-                        "",
-                        "    //begin fill path",
-                        "    painter.beginFillPath(vertices[0].getAllChildrenArray()[0].getAsNumber(), vertices[0].getAllChildrenArray()[1].getAsNumber());",
-                        "",
-                        "    //draw path lines",
-                        "    for (let i = 1; i < vertices.length; i++) {",
-                        "    const vertex = vertices[i].getAllChildrenArray();",
-                        "    painter.drawPathLineTo(vertex[0].getAsNumber(), vertex[1].getAsNumber());",
-                        "    }",
-                        "",
-                        "    //close when mouse is not down",
-                        "    if (!gdjs.evtTools.input.isMouseButtonPressed(runtimeScene,\"Left\")) {",
-                        "        painter.closePath();",
-                        "    }",
-                        "}"
-                      ],
-                      "parameterObjects": "",
-                      "useStrict": true,
-                      "eventsSheetExpanded": false
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "End selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "="
-                      ]
-                    }
-                  ],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            "<",
-                            "3"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SelectionTools::ClearSelection"
-                          },
-                          "parameters": [
-                            "",
-                            ""
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Begin selection"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "False"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "VariableClearChildren"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertices"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SetSceneVariableAsBoolean"
-                      },
-                      "parameters": [
-                        "__SelectionTools.CanDrawSelection",
-                        "True"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Add new vertex. Update vertices"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "<",
-                        "Variable(__SelectionTools.MaximumVertexCount)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Or"
-                      },
-                      "parameters": [],
-                      "subInstructions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
-                            ">=",
-                            "Variable(__SelectionTools.SideLength)"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            "=",
-                            "0"
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "VariableClearChildren"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePushNumber"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertex",
-                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariablePush"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertices",
-                        "__SelectionTools.Vertex"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__SelectionTools.VertexCount",
-                        "+",
-                        "1"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "parameters": [],
-      "objectGroups": []
-    },
-    {
-      "description": "Set the shape painter object, the layer, and the z-order that will be used to draw the selection.",
-      "fullName": "Setup selection tools",
-      "functionType": "Action",
-      "name": "SetupSelectionTools",
-      "sentence": "Setup selection tools (painter: _PARAM1_, layer: _PARAM2_, z order: _PARAM3_)",
-      "events": [
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "SetSceneVariableAsBoolean"
-              },
-              "parameters": [
-                "__SelectionTools.Active",
-                "True"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarSceneTxt"
-              },
-              "parameters": [
-                "__SelectionTools.Layer",
-                "=",
-                "GetArgumentAsString(\"Layer\")"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__SelectionTools.VertexCount",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "VariableClearChildren"
-              },
-              "parameters": [
-                "__SelectionTools.Vertices"
-              ]
-            },
-            {
-              "type": {
-                "value": "VariableClearChildren"
-              },
-              "parameters": [
-                "__SelectionTools.Vertex"
-              ]
-            },
-            {
-              "type": {
-                "value": "Delete"
-              },
-              "parameters": [
-                "Painter",
-                ""
-              ]
-            },
-            {
-              "type": {
-                "value": "Create"
-              },
-              "parameters": [
-                "",
-                "Painter",
-                "0",
-                "0",
-                "GetArgumentAsString(\"Layer\")"
-              ]
-            },
-            {
-              "type": {
-                "value": "ChangePlan"
-              },
-              "parameters": [
-                "Painter",
-                "=",
-                "GetArgumentAsNumber(\"ZOrder\")"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarSceneTxt"
-              },
-              "parameters": [
-                "__SelectionTools.PainterObjectName",
-                "=",
-                "Painter.ObjectName()"
-              ]
-            }
-          ]
-        }
-      ],
-      "parameters": [
-        {
-          "description": "Shape painter object used to draw the selection",
-          "name": "Painter",
-          "supplementaryInformation": "PrimitiveDrawing::Drawer",
-          "type": "objectList"
-        },
-        {
-          "description": "The layer on which the selection would be drawn",
-          "name": "Layer",
-          "type": "layer"
-        },
-        {
-          "description": "Z Order of the selection",
-          "name": "ZOrder",
-          "type": "expression"
-        }
-      ],
-      "objectGroups": []
-    },
     {
       "description": "De/Activate selection tools.",
       "fullName": "De/Activate selection tools",
@@ -1333,8 +122,10 @@
       ],
       "parameters": [
         {
+          "defaultValue": "yes",
           "description": "Activate?",
           "name": "Choice",
+          "optional": true,
           "type": "yesorno"
         }
       ],
@@ -1620,25 +411,17 @@
               "parameters": [
                 "__SelectionTools.Vertex"
               ]
+            },
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.ClearPainter",
+                "True"
+              ]
             }
           ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": [
-            "const painterName = runtimeScene",
-            "    .getVariables()",
-            "    .get(\"__SelectionTools\")",
-            "    .getChild(\"PainterObjectName\")",
-            "    .getAsString()",
-            "",
-            "//get the painter object",
-            "const painter = runtimeScene.getObjects(painterName)[0];",
-            "painter.clear();"
-          ],
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": false
         }
       ],
       "parameters": [],
@@ -1978,6 +761,1357 @@
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": [],
+  "eventsBasedBehaviors": [
+    {
+      "description": "Draw selection (SelectionTools).",
+      "fullName": "Selection painter",
+      "name": "SelectionPainter",
+      "objectType": "PrimitiveDrawing::Drawer",
+      "eventsFunctions": [
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "doStepPreEvents",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__SelectionTools.ClearPainter",
+                    "True"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                  },
+                  "parameters": [
+                    "Object"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__SelectionTools.ClearPainter",
+                    ""
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "__SelectionTools.Active",
+                    "True"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "folded": true,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Rectangular\""
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableChildCount"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "=",
+                            "4"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::BeginFillPath"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertex[0])",
+                                "Variable(__SelectionTools.Vertex[1])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertex[2])",
+                                "Variable(__SelectionTools.Vertex[1])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertex[2])",
+                                "Variable(__SelectionTools.Vertex[3])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertex[0])",
+                                "Variable(__SelectionTools.Vertex[3])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::closePath"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "End selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "="
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Begin selection. Gain position of origin"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "False"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "VariableClearChildren"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorX())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorY())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Update position of free end (positioned at the cursor)"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableChildCount"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "=",
+                                "4"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                                  },
+                                  "parameters": [
+                                    "Variable(__SelectionTools.Vertex[2])",
+                                    "!=",
+                                    "round(CursorX())"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                                  },
+                                  "parameters": [
+                                    "Variable(__SelectionTools.Vertex[3])",
+                                    "!=",
+                                    "round(CursorY())"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableRemoveAt"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "3"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariableRemoveAt"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "2"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorX())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorY())"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableChildCount"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "=",
+                                "2"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX()), round(CursorY()))",
+                                ">",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorX())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorY())"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "folded": true,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Polygonal\""
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::BeginFillPath"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertices[0][0])",
+                                "Variable(__SelectionTools.Vertices[0][1])"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.CloseSelection",
+                                "True"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "MouseButtonPressed"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.PopLastVertex",
+                                "True"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableRemoveAt"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertices",
+                                "VariableChildCount(__SelectionTools.Vertices) - 1"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+                          "iterableVariableName": "__SelectionTools.Vertices",
+                          "valueIteratorVariableName": "__SelectionTools.ChildVertex",
+                          "keyIteratorVariableName": "",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.ChildVertex[0])",
+                                "Variable(__SelectionTools.ChildVertex[1])"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.CloseSelection",
+                                "True"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "MouseButtonPressed"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::closePath"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SetSceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.CanDrawSelection",
+                                ""
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Not"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__SelectionTools.CloseSelection",
+                                    "True"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "inverted": true,
+                                    "value": "MouseButtonPressed"
+                                  },
+                                  "parameters": [
+                                    "",
+                                    "Left"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "CursorX()",
+                                "CursorY()"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Close selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonReleased"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            ">",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertices[0][0]), Variable(__SelectionTools.Vertices[0][1]), CursorX(), CursorY())",
+                            "<",
+                            "Variable(__SelectionTools.MergeProximity)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CloseSelection",
+                            "True"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][0])",
+                                "=",
+                                "round(CursorX())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][1])",
+                                "=",
+                                "round(CursorY())"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetSceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.PopLastVertex",
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "End selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "False"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VariableClearChildren"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertices"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.PopLastVertex",
+                            "False"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CloseSelection",
+                            "False"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Add new vertex. Update vertices"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "<",
+                            "Variable(__SelectionTools.MaximumVertexCount)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX()), round(CursorY()))",
+                                ">=",
+                                "Variable(__SelectionTools.SideLength)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "VarScene"
+                              },
+                              "parameters": [
+                                "__SelectionTools.VertexCount",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "VariableClearChildren"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorX())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorY())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePush"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertices",
+                            "__SelectionTools.Vertex"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "+",
+                            "1"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "folded": true,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Lasso\""
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Draw Selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::BeginFillPath"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.Vertices[0][0])",
+                                "Variable(__SelectionTools.Vertices[0][1])"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+                          "iterableVariableName": "__SelectionTools.Vertices",
+                          "valueIteratorVariableName": "__SelectionTools.ChildVertex",
+                          "keyIteratorVariableName": "",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Variable(__SelectionTools.ChildVertex[0])",
+                                "Variable(__SelectionTools.ChildVertex[1])"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": true,
+                                "value": "MouseButtonPressed"
+                              },
+                              "parameters": [
+                                "",
+                                "Left"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::closePath"
+                              },
+                              "parameters": [
+                                "Object"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "End selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "inverted": true,
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "="
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "VarScene"
+                              },
+                              "parameters": [
+                                "__SelectionTools.VertexCount",
+                                "<",
+                                "3"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SelectionTools::ClearSelection"
+                              },
+                              "parameters": [
+                                "",
+                                ""
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Begin selection"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "False"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VariableClearChildren"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertices"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CanDrawSelection",
+                            "True"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Add new vertex. Update vertices"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonPressed"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "<",
+                            "Variable(__SelectionTools.MaximumVertexCount)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX()), round(CursorY()))",
+                                ">=",
+                                "Variable(__SelectionTools.SideLength)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "VarScene"
+                              },
+                              "parameters": [
+                                "__SelectionTools.VertexCount",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "VariableClearChildren"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorX())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorY())"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePush"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertices",
+                            "__SelectionTools.Vertex"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ModVarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "+",
+                            "1"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "PrimitiveDrawing::Drawer",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "SelectionTools::SelectionPainter",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [],
+      "sharedPropertyDescriptors": []
+    }
+  ],
   "eventsBasedObjects": []
 }

--- a/extensions/community/SelectionTools.json
+++ b/extensions/community/SelectionTools.json
@@ -10,18 +10,24 @@
   "shortDescription": "A set of tools that allow players to draw selections in order to select object instances.",
   "version": "1.0.0",
   "description": [
-    "How to use:",
+    "### How to use:",
     "",
     "- Activate SelectionTools using the `De/Activate selection tools` action.",
     "- Create a shape painter object and add the `Selection painter` behavior to it. Create a single instance of this object in the scene.",
     "- Set the type of selection using one of these actions: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.",
+    "- Use `Select` condition to check which object instances are inside the selection.",
     "",
-    "Tips:",
+    "---",
+    "",
+    "### Tips:",
     "",
     "- The `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection` actions are used for both setting properties and changing the current selection type.",
-    "- None of the action require you to call them each frame, it's adviced that you use them with `At the beginning of the scene` condition or a `Triggred Once`.",
+    "- None of the actions require you to call them each frame, it's advised that you use them with `At the beginning of the scene` condition or a `Triggred Once`.",
+    "- If you set `Pre select` to `Yes` in the `Select` condition. Make sure you don't add a `Triggred Once` to that event.",
     "",
-    "Actions:",
+    "---",
+    "",
+    "#### Actions:",
     "",
     "- `De/Activate selection tools`",
     "- `Set rectangular selection`",
@@ -29,16 +35,15 @@
     "- `Set lasso selection`",
     "- `Clear selection`",
     "",
-    "Condition:",
+    "#### Condition:",
     "",
     "- `Select`",
     "- `Selection activated`",
     "- `Current selection type`",
     "",
-    "Behavior:",
+    "#### Behavior:",
     "",
-    "- `Selection painter`",
-    ""
+    "- `Selection painter`"
   ],
   "tags": [
     "select",
@@ -432,7 +437,7 @@
       "fullName": "Select",
       "functionType": "Condition",
       "name": "Select",
-      "sentence": "Select all _PARAM1_ inside the selection boundary (invert selection: _PARAM2_)",
+      "sentence": "Select all _PARAM1_ inside the selection boundary (invert selection: _PARAM2_, pre select: _PARAM3_)",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -448,12 +453,28 @@
             },
             {
               "type": {
-                "inverted": true,
-                "value": "MouseButtonPressed"
+                "value": "BuiltinCommonInstructions::Or"
               },
-              "parameters": [
-                "",
-                "Left"
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "MouseButtonPressed"
+                  },
+                  "parameters": [
+                    "",
+                    "Left"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"PreSelect\""
+                  ]
+                }
               ]
             }
           ],
@@ -591,11 +612,27 @@
                         },
                         {
                           "type": {
-                            "value": "SceneVariableAsBoolean"
+                            "value": "BuiltinCommonInstructions::Or"
                           },
-                          "parameters": [
-                            "__SelectionTools.CloseSelection",
-                            "True"
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "GetArgumentAsBoolean"
+                              },
+                              "parameters": [
+                                "\"PreSelect\""
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.CloseSelection",
+                                "True"
+                              ]
+                            }
                           ]
                         }
                       ]
@@ -606,10 +643,90 @@
               "actions": [],
               "events": [
                 {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Polygonal\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"PreSelect\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableChildCount"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        ">",
+                        "1"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CloseSelection",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.ChildVertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.ChildVertex",
+                        "round(CursorX())"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.ChildVertex",
+                        "round(CursorY())"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePush"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        "__SelectionTools.ChildVertex"
+                      ]
+                    }
+                  ]
+                },
+                {
                   "type": "BuiltinCommonInstructions::JsCode",
                   "inlineCode": [
                     "const targets = eventsFunctionContext.getObjectsLists(\"Targets\").items;\r",
                     "const invertSelection = eventsFunctionContext.getArgument(\"InvertSelection\");\r",
+                    "const preSelect = eventsFunctionContext.getArgument(\"PreSelect\");\r",
                     "\r",
                     "const vertices = runtimeScene\r",
                     "    .getVariables()\r",
@@ -628,9 +745,11 @@
                     "    let inside = false;\r",
                     "\r",
                     "    for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {\r",
+                    "  \r",
                     "      const vi = [vertices[i].getAllChildrenArray()[0].getAsNumber(), vertices[i].getAllChildrenArray()[1].getAsNumber()];\r",
                     "      const vj = [vertices[j].getAllChildrenArray()[0].getAsNumber(), vertices[j].getAllChildrenArray()[1].getAsNumber()];\r",
-                    "      if (vi[1] > y != vj[1] > y && x < ((vj[0] - vi[0]) * (y - vi[1])) / (vj[1] - vi[1]) + vi[0]) {\r",
+                    "      \r",
+                    "      if (vi[1] > y != vj[1] > y && x < ((vj[0] - vi[0]) * (y - vi[1])) / (vj[1] - vi[1]) + vi[0]){\r",
                     "        inside = !inside;\r",
                     "      }\r",
                     "    }\r",
@@ -648,6 +767,59 @@
                   "parameterObjects": "",
                   "useStrict": true,
                   "eventsSheetExpanded": false
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Polygonal\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"PreSelect\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableChildCount"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        ">",
+                        "1"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CloseSelection",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SceneVariableRemoveAt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        "VariableChildCount(__SelectionTools.Vertices) - 1"
+                      ]
+                    }
+                  ]
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -676,7 +848,14 @@
         },
         {
           "description": "Invert selection?",
+          "longDescription": "Select all object instances outside the selection boundary.",
           "name": "InvertSelection",
+          "type": "yesorno"
+        },
+        {
+          "description": "Pre select?",
+          "longDescription": "Don't wait for the shape to be closed or the mouse button/touch to be released.",
+          "name": "PreSelect",
           "type": "yesorno"
         }
       ],

--- a/extensions/community/SelectionTools.json
+++ b/extensions/community/SelectionTools.json
@@ -7,32 +7,31 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXNlbGVjdGlvbi1kcmFnIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE0LDE3SDE3VjE0SDE5VjE3SDIyVjE5SDE5VjIySDE3VjE5SDE0VjE3TTEyLDE3VjE5SDlWMTdIMTJNNywxN1YxOUgzVjE1SDVWMTdIN00zLDEzVjEwSDVWMTNIM00zLDhWNEg3VjZINVY4SDNNOSw0SDEyVjZIOVY0TTE1LDRIMTlWOEgxN1Y2SDE1VjRNMTksMTBWMTJIMTdWMTBIMTlaIiAvPjwvc3ZnPg==",
   "name": "SelectionTools",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/9183b1a2c466ffc831a749b3a2692200b070a88f807696d99caa662632c2ed73_selection-drag.svg",
-  "shortDescription": "A set of tools that allow players to draw selections in order to select object instances.",
+  "shortDescription": "Select object instances by drawing rectangular, polygonal or lasso selection.",
   "version": "1.0.0",
   "description": [
     "### How to use:",
     "",
     "- Activate SelectionTools using the `De/Activate selection tools` action.",
-    "- Create a shape painter object and add the `Selection painter` behavior to it. Create a single instance of this object in the scene.",
-    "- Set the type of selection using one of these actions: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.",
-    "- Use `Select` condition to check which object instances are inside the selection.",
+    "- Create a shape painter object and add the `Selection painter` behavior. Create a single instance of this object.",
+    "- Use `Activate rectangular selection`, `Activate polygonal selection`, or `Activate lasso selection` action to activate the type of selection you need.",
+    "- Use the `Select` condition to check which object instances are inside the selection.",
     "",
     "---",
     "",
     "### Tips:",
     "",
-    "- The `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection` actions are used for both setting properties and changing the current selection type.",
-    "- None of the actions require you to call them each frame, it's advised that you use them with `At the beginning of the scene` condition or a `Triggred Once`.",
-    "- If you set `Pre select` to `Yes` in the `Select` condition. Make sure you don't add a `Triggred Once` to that event.",
+    "- None of the actions require you to call them each frame. Use them with the `At the beginning of the scene` condition or `Triggred Once`.",
+    "- If you set `Pre-select?` to `Yes` in the `Select` condition, do not add a `Triggred Once` to that event.",
     "",
     "---",
     "",
     "#### Actions:",
     "",
     "- `De/Activate selection tools`",
-    "- `Set rectangular selection`",
-    "- `Set polygonal selection`",
-    "- `Set lasso selection`",
+    "- `Activate rectangular selection`",
+    "- `Activate polygonal selection`",
+    "- `Activate lasso selection`",
     "- `Clear selection`",
     "",
     "#### Condition:",
@@ -48,7 +47,7 @@
   "tags": [
     "select",
     "selection",
-    "tools",
+    "tool",
     "lasso",
     "marquee",
     "polygon",
@@ -138,10 +137,10 @@
     },
     {
       "description": "Change the current selection type to rectangular selection.",
-      "fullName": "Set rectangular selection",
+      "fullName": "Activate rectangular selection",
       "functionType": "Action",
-      "name": "SetRectangularSelection",
-      "sentence": "Set selection type to rectangular selection",
+      "name": "ActivateRectangularSelection",
+      "sentence": "Activate rectangular selection",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -173,11 +172,11 @@
       "objectGroups": []
     },
     {
-      "description": "Setup and change the current selection type to polygonal selection.",
-      "fullName": "Set polygonal selection",
+      "description": "Change the current selection type to polygonal selection.",
+      "fullName": "Activate polygonal selection",
       "functionType": "Action",
-      "name": "SetPolygonalSelection",
-      "sentence": "Set selection type to polygonal selection (minimum side length: _PARAM1_, maximum vertex count: _PARAM2_, merge proximity: _PARAM3_)",
+      "name": "ActivatePolygonalSelection",
+      "sentence": "Activate polygonal selection (true polygon: _PARAM4_, minimum side length: _PARAM1_, maximum vertex count: _PARAM2_, merge proximity: _PARAM3_)",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -233,6 +232,136 @@
               ]
             }
           ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"TruePolygon\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.TruePolygon",
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"TruePolygon\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.TruePolygon",
+                "False"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "CompareArgumentAsNumber"
+              },
+              "parameters": [
+                "\"MaximumVertexCount\"",
+                "<",
+                "3"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MaximumVertexCount",
+                "=",
+                "3"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "CompareArgumentAsNumber"
+              },
+              "parameters": [
+                "\"SideLength\"",
+                "<",
+                "1"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.SideLength",
+                "=",
+                "1"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "CompareArgumentAsNumber"
+              },
+              "parameters": [
+                "\"MergeProximity\"",
+                "<",
+                "1"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MergeProximity",
+                "=",
+                "1"
+              ]
+            }
+          ]
         }
       ],
       "parameters": [
@@ -249,19 +378,25 @@
         },
         {
           "description": "Merge proximity",
-          "longDescription": "When clicked, how far (at maximum, in pixels) the cursor needs to be from the first vertex to close the shape. (Default: minimum side length).",
+          "longDescription": "When clicked, how far (at maximum, in pixels) the cursor needs to be from the first vertex to close the shape.",
           "name": "MergeProximity",
           "type": "expression"
+        },
+        {
+          "description": "True polygon?",
+          "longDescription": "If the selection is a true polygon, dragging while the mouse button or touch is down will not place new vertices.",
+          "name": "TruePolygon",
+          "type": "yesorno"
         }
       ],
       "objectGroups": []
     },
     {
-      "description": "Setup and change the current selection type to lasso selection.",
-      "fullName": "Set lasso selection",
+      "description": "Change the current selection type to lasso selection.",
+      "fullName": "Activate lasso selection",
       "functionType": "Action",
-      "name": "SetLassoSelection",
-      "sentence": "Set selection type to lasso selection (side length: _PARAM1_, maximum vertex count: _PARAM2_)",
+      "name": "ActivateLassoSelection",
+      "sentence": "Activate lasso selection (side length: _PARAM1_, maximum vertex count: _PARAM2_)",
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -306,60 +441,58 @@
                 ""
               ]
             }
-          ],
-          "events": [
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "CompareArgumentAsNumber"
-                  },
-                  "parameters": [
-                    "\"MaximumVertexCount\"",
-                    "<",
-                    "3"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__SelectionTools.MaximumVertexCount",
-                    "=",
-                    "3"
-                  ]
-                }
+              "type": {
+                "value": "CompareArgumentAsNumber"
+              },
+              "parameters": [
+                "\"MaximumVertexCount\"",
+                "<",
+                "3"
               ]
-            },
+            }
+          ],
+          "actions": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "CompareArgumentAsNumber"
-                  },
-                  "parameters": [
-                    "\"SideLength\"",
-                    "<",
-                    "1"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__SelectionTools.SideLength",
-                    "=",
-                    "1"
-                  ]
-                }
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MaximumVertexCount",
+                "=",
+                "3"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "CompareArgumentAsNumber"
+              },
+              "parameters": [
+                "\"SideLength\"",
+                "<",
+                "1"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.SideLength",
+                "=",
+                "1"
               ]
             }
           ]
@@ -381,7 +514,7 @@
       "objectGroups": []
     },
     {
-      "description": "Clear the selection.",
+      "description": "Clear the selection (Note: This action does not deslect selected objects).",
       "fullName": "Clear selection",
       "functionType": "Action",
       "name": "ClearSelection",
@@ -526,7 +659,7 @@
                     "\r",
                     "const tempDict = {};\r",
                     "\r",
-                    "//filter the targets whose center lie inside the polygon\r",
+                    "//filter the targets whose center lie inside the rectangle\r",
                     "for (const targetName in targets){\r",
                     "  tempDict[targetName] = targets[targetName].filter(object => {\r",
                     "    const objectX = object.getCenterXInScene();\r",
@@ -643,6 +776,18 @@
               "actions": [],
               "events": [
                 {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Add the cursor position to the end of the vertices array if \"PreSelect\" is true. Thus pre-selecting the objects that get selected if a new vertex gets created at that position."
+                },
+                {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -718,8 +863,29 @@
                         "__SelectionTools.Vertices",
                         "__SelectionTools.ChildVertex"
                       ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.PopVertex",
+                        "True"
+                      ]
                     }
                   ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Check if object's center lies inside the polygon"
                 },
                 {
                   "type": "BuiltinCommonInstructions::JsCode",
@@ -734,11 +900,11 @@
                     "    .getChild(\"Vertices\")\r",
                     "    .getAllChildrenArray();\r",
                     "\r",
-                    "const tempDict = {};\r",
+                    "const temporaryDictionary = {};\r",
                     "\r",
                     "//filter the targets whose center lie inside the polygon\r",
                     "for (const targetName in targets){\r",
-                    "  tempDict[targetName] = targets[targetName].filter(object => {\r",
+                    "  temporaryDictionary[targetName] = targets[targetName].filter(object => {\r",
                     "    const x = object.getCenterXInScene();\r",
                     "    const y = object.getCenterYInScene();\r",
                     "\r",
@@ -758,8 +924,8 @@
                     "  targets[targetName].length = 0;\r",
                     "}\r",
                     "\r",
-                    "for (const targetName in tempDict){\r",
-                    "  for (const value of tempDict[targetName]){\r",
+                    "for (const targetName in temporaryDictionary){\r",
+                    "  for (const value of temporaryDictionary[targetName]){\r",
                     "    targets[targetName].push(value);\r",
                     "  }\r",
                     "}"
@@ -769,43 +935,27 @@
                   "eventsSheetExpanded": false
                 },
                 {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Pop the last element in vertices array (cursor position) since it is not an actual vertex."
+                },
+                {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
-                    {
-                      "type": {
-                        "value": "VarSceneTxt"
-                      },
-                      "parameters": [
-                        "__SelectionTools.SelectionType",
-                        "=",
-                        "\"Polygonal\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "GetArgumentAsBoolean"
-                      },
-                      "parameters": [
-                        "\"PreSelect\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "SceneVariableChildCount"
-                      },
-                      "parameters": [
-                        "__SelectionTools.Vertices",
-                        ">",
-                        "1"
-                      ]
-                    },
                     {
                       "type": {
                         "value": "SceneVariableAsBoolean"
                       },
                       "parameters": [
-                        "__SelectionTools.CloseSelection",
-                        "False"
+                        "__SelectionTools.PopVertex",
+                        "True"
                       ]
                     }
                   ],
@@ -817,6 +967,15 @@
                       "parameters": [
                         "__SelectionTools.Vertices",
                         "VariableChildCount(__SelectionTools.Vertices) - 1"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.PopVertex",
+                        "False"
                       ]
                     }
                   ]
@@ -853,7 +1012,7 @@
           "type": "yesorno"
         },
         {
-          "description": "Pre select?",
+          "description": "Pre-select?",
           "longDescription": "Don't wait for the shape to be closed or the mouse button/touch to be released.",
           "name": "PreSelect",
           "type": "yesorno"
@@ -1387,7 +1546,6 @@
                   ]
                 },
                 {
-                  "folded": true,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
@@ -1413,9 +1571,112 @@
                         "textG": 0,
                         "textR": 0
                       },
+                      "comment": "Close selection"
+                    },
+                    {
+                      "folded": true,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "MouseButtonReleased"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            ">",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertices[0][0]), Variable(__SelectionTools.Vertices[0][1]), CursorX(), CursorY())",
+                            "<",
+                            "Variable(__SelectionTools.MergeProximity)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Once"
+                          },
+                          "parameters": []
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CloseSelection",
+                            "True"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][0])",
+                                "=",
+                                "round(CursorX())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][1])",
+                                "=",
+                                "round(CursorY())"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetSceneVariableAsBoolean"
+                              },
+                              "parameters": [
+                                "__SelectionTools.PopLastVertex",
+                                "True"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
                       "comment": "Draw selection"
                     },
                     {
+                      "folded": true,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
@@ -1616,107 +1877,6 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Close selection"
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "MouseButtonReleased"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            ">",
-                            "2"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::CompareNumbers"
-                          },
-                          "parameters": [
-                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertices[0][0]), Variable(__SelectionTools.Vertices[0][1]), CursorX(), CursorY())",
-                            "<",
-                            "Variable(__SelectionTools.MergeProximity)"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::Once"
-                          },
-                          "parameters": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SetSceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__SelectionTools.CloseSelection",
-                            "True"
-                          ]
-                        }
-                      ],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareNumbers"
-                              },
-                              "parameters": [
-                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][0])",
-                                "=",
-                                "round(CursorX())"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "BuiltinCommonInstructions::CompareNumbers"
-                              },
-                              "parameters": [
-                                "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][1])",
-                                "=",
-                                "round(CursorY())"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "SetSceneVariableAsBoolean"
-                              },
-                              "parameters": [
-                                "__SelectionTools.PopLastVertex",
-                                "True"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
                       "comment": "End selection"
                     },
                     {
@@ -1799,39 +1959,11 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Add new vertex. Update vertices"
+                      "comment": "If the shape is a true polygon, dragging while the mouse button or touch is down will not place new vertices."
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
-                        {
-                          "type": {
-                            "value": "MouseButtonPressed"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariableAsBoolean"
-                          },
-                          "parameters": [
-                            "__SelectionTools.CanDrawSelection",
-                            "True"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            "<",
-                            "Variable(__SelectionTools.MaximumVertexCount)"
-                          ]
-                        },
                         {
                           "type": {
                             "value": "BuiltinCommonInstructions::Or"
@@ -1840,12 +1972,136 @@
                           "subInstructions": [
                             {
                               "type": {
-                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                                "value": "BuiltinCommonInstructions::And"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__SelectionTools.TruePolygon",
+                                    "False"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "MouseButtonPressed"
+                                  },
+                                  "parameters": [
+                                    "",
+                                    "Left"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::And"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "SceneVariableAsBoolean"
+                                  },
+                                  "parameters": [
+                                    "__SelectionTools.TruePolygon",
+                                    "True"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::Or"
+                                  },
+                                  "parameters": [],
+                                  "subInstructions": [
+                                    {
+                                      "type": {
+                                        "value": "BuiltinCommonInstructions::And"
+                                      },
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseButtonReleased"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "Left"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "VarScene"
+                                          },
+                                          "parameters": [
+                                            "__SelectionTools.VertexCount",
+                                            "!=",
+                                            "0"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "BuiltinCommonInstructions::And"
+                                      },
+                                      "parameters": [],
+                                      "subInstructions": [
+                                        {
+                                          "type": {
+                                            "value": "MouseButtonPressed"
+                                          },
+                                          "parameters": [
+                                            "",
+                                            "Left"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "VarScene"
+                                          },
+                                          "parameters": [
+                                            "__SelectionTools.VertexCount",
+                                            "=",
+                                            "0"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Add new vertex. Update vertices"
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SceneVariableAsBoolean"
                               },
                               "parameters": [
-                                "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX()), round(CursorY()))",
-                                ">=",
-                                "Variable(__SelectionTools.SideLength)"
+                                "__SelectionTools.CanDrawSelection",
+                                "True"
                               ]
                             },
                             {
@@ -1854,57 +2110,85 @@
                               },
                               "parameters": [
                                 "__SelectionTools.VertexCount",
-                                "=",
-                                "0"
+                                "<",
+                                "Variable(__SelectionTools.MaximumVertexCount)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                                  },
+                                  "parameters": [
+                                    "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX()), round(CursorY()))",
+                                    ">=",
+                                    "Variable(__SelectionTools.SideLength)"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "VarScene"
+                                  },
+                                  "parameters": [
+                                    "__SelectionTools.VertexCount",
+                                    "=",
+                                    "0"
+                                  ]
+                                }
                               ]
                             }
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "VariableClearChildren"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorX())"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePushNumber"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertex",
-                            "round(CursorY())"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "SceneVariablePush"
-                          },
-                          "parameters": [
-                            "__SelectionTools.Vertices",
-                            "__SelectionTools.Vertex"
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "__SelectionTools.VertexCount",
-                            "+",
-                            "1"
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "VariableClearChildren"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorX())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePushNumber"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertex",
+                                "round(CursorY())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SceneVariablePush"
+                              },
+                              "parameters": [
+                                "__SelectionTools.Vertices",
+                                "__SelectionTools.Vertex"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "ModVarScene"
+                              },
+                              "parameters": [
+                                "__SelectionTools.VertexCount",
+                                "+",
+                                "1"
+                              ]
+                            }
                           ]
                         }
                       ]

--- a/extensions/community/SelectionTools.json
+++ b/extensions/community/SelectionTools.json
@@ -1,0 +1,1983 @@
+{
+  "author": "",
+  "category": "Advanced",
+  "extensionNamespace": "",
+  "fullName": "Selection tools",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXNlbGVjdGlvbi1kcmFnIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE0LDE3SDE3VjE0SDE5VjE3SDIyVjE5SDE5VjIySDE3VjE5SDE0VjE3TTEyLDE3VjE5SDlWMTdIMTJNNywxN1YxOUgzVjE1SDVWMTdIN00zLDEzVjEwSDVWMTNIM00zLDhWNEg3VjZINVY4SDNNOSw0SDEyVjZIOVY0TTE1LDRIMTlWOEgxN1Y2SDE1VjRNMTksMTBWMTJIMTdWMTBIMTlaIiAvPjwvc3ZnPg==",
+  "name": "SelectionTools",
+  "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/9183b1a2c466ffc831a749b3a2692200b070a88f807696d99caa662632c2ed73_selection-drag.svg",
+  "shortDescription": "A set of tools that allow players to draw selections in order to select object instances.",
+  "version": "1.0.0",
+  "description": [
+    "How to use:",
+    "",
+    "- Create a shape painter object. It would be used to draw the selection on the screen.",
+    "- Add the `Setup selection tools` action to an event.",
+    "- Add the setup action for the required selection. Choose from: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.",
+    "",
+    "Tips:",
+    "",
+    "- The `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection` actions are used for both setting properties and changing the current selection type.",
+    "- Actions used to set things (i.e. \"Setup selection tools\" and the set action for each of the different selections) aren't required to be called each frame. They should ideally be added and triggered only once at the beginning of the scene. But they can be used again to modify specific properties or change the current selection type.",
+    "",
+    "Actions:",
+    "",
+    "- `Setup selection tools`",
+    "- `De/Activate selection tools`",
+    "- `Set rectangular selection`",
+    "- `Set polygonal selection`",
+    "- `Set lasso selection`",
+    "- `Clear selection`",
+    "",
+    "Condition:",
+    "",
+    "- `Select`",
+    "- `Selection activated`",
+    "- `Current selection type`"
+  ],
+  "tags": [
+    "select",
+    "selection",
+    "tools",
+    "lasso",
+    "marquee",
+    "polygon",
+    "rectangle"
+  ],
+  "authorIds": [
+    "TJLmS4MUFJSWNNietFUWDxVSKnB3"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "fullName": "",
+      "functionType": "Action",
+      "name": "onScenePreEvents",
+      "sentence": "",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "True"
+              ]
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "folded": true,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarSceneTxt"
+                  },
+                  "parameters": [
+                    "__SelectionTools.SelectionType",
+                    "=",
+                    "\"Rectangular\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Draw selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::JsCode",
+                      "inlineCode": [
+                        "const selectionTools = runtimeScene",
+                        "    .getVariables()",
+                        "    .get(\"__SelectionTools\")",
+                        "",
+                        "const vertex = selectionTools",
+                        "    .getChild(\"Vertex\")",
+                        "    .getAllChildrenArray();",
+                        "",
+                        "if (vertex.length == 4){",
+                        "    //get the painter object",
+                        "    const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
+                        "    painter.clear();",
+                        "    ",
+                        "    const originX = vertex[0].getAsNumber();",
+                        "    const originY = vertex[1].getAsNumber();",
+                        "    const cursorX = vertex[2].getAsNumber();",
+                        "    const cursorY = vertex[3].getAsNumber();",
+                        "",
+                        "    //begin fill path",
+                        "    painter.beginFillPath(originX, originY);",
+                        "    painter.drawPathLineTo(cursorX, originY);",
+                        "    painter.drawPathLineTo(cursorX,cursorY);",
+                        "    painter.drawPathLineTo(originX, cursorY);",
+                        "    painter.closePath();",
+                        "}"
+                      ],
+                      "parameterObjects": "",
+                      "useStrict": true,
+                      "eventsSheetExpanded": false
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "End selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "="
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Begin selection. Gain position of origin"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Update position of free end (positioned at the cursor)"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableChildCount"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "=",
+                            "4"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertex[2])",
+                                "!=",
+                                "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::CompareNumbers"
+                              },
+                              "parameters": [
+                                "Variable(__SelectionTools.Vertex[3])",
+                                "!=",
+                                "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "3"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "SceneVariableChildCount"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "=",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
+                            ">",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariablePushNumber"
+                          },
+                          "parameters": [
+                            "__SelectionTools.Vertex",
+                            "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "folded": true,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarSceneTxt"
+                  },
+                  "parameters": [
+                    "__SelectionTools.SelectionType",
+                    "=",
+                    "\"Polygonal\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Draw selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::JsCode",
+                      "inlineCode": [
+                        "const selectionTools = runtimeScene",
+                        "    .getVariables()",
+                        "    .get(\"__SelectionTools\");",
+                        "",
+                        "const vertices = selectionTools",
+                        "    .getChild(\"Vertices\")",
+                        "    .getAllChildrenArray();",
+                        "",
+                        "//get the painter object",
+                        "const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
+                        "painter.clear();",
+                        "",
+                        "//begin fill path",
+                        "painter.beginFillPath(vertices[0].getAllChildrenArray()[0].getAsNumber(), vertices[0].getAllChildrenArray()[1].getAsNumber());",
+                        "",
+                        "const shapeClosed = selectionTools.getChild(\"CloseSelection\").getAsBoolean() && !gdjs.evtTools.input.isMouseButtonPressed(runtimeScene,\"Left\");",
+                        "",
+                        "//pop the last vertex",
+                        "//when the last vertex placed is within the merge proximity",
+                        "if (shapeClosed && selectionTools.getChild(\"PopLastVertex\").getAsBoolean()) {",
+                        "    vertices.pop();",
+                        "}",
+                        "",
+                        "//draw path lines",
+                        "for (let i = 1; i < vertices.length; i++) {",
+                        "    const vertex = vertices[i].getAllChildrenArray();",
+                        "    painter.drawPathLineTo(vertex[0].getAsNumber(), vertex[1].getAsNumber());",
+                        "}",
+                        "",
+                        "const cursorX = gdjs.evtTools.input.getCursorX(runtimeScene, selectionTools.getChild(\"Layer\"),0);",
+                        "const cursorY = gdjs.evtTools.input.getCursorY(runtimeScene, selectionTools.getChild(\"Layer\"),0);",
+                        "",
+                        "//close shape",
+                        "if (shapeClosed) {",
+                        "    painter.closePath();",
+                        "    runtimeScene.getVariables().get(\"__SelectionTools\").getChild(\"CanDrawSelection\").setValue(false);",
+                        "} else{",
+                        "    painter.drawPathLineTo(cursorX, cursorY);",
+                        "}"
+                      ],
+                      "parameterObjects": "",
+                      "useStrict": true,
+                      "eventsSheetExpanded": false
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Close selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonReleased"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        ">",
+                        "2"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "DistanceBetweenPositions(Variable(__SelectionTools.Vertices[0][0]), Variable(__SelectionTools.Vertices[0][1]), CursorX(VariableString(__SelectionTools.Layer),0), CursorY(VariableString(__SelectionTools.Layer),0))",
+                        "<",
+                        "Variable(__SelectionTools.MergeProximity)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CloseSelection",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][0])",
+                            "=",
+                            "round(CursorX(VariableString(__SelectionTools.Layer),0))"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "Variable(__SelectionTools.Vertices[VariableChildCount(__SelectionTools.Vertices)-1][1])",
+                            "=",
+                            "round(CursorY(VariableString(__SelectionTools.Layer),0))"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetSceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.PopLastVertex",
+                            "True"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "End selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.PopLastVertex",
+                        "False"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CloseSelection",
+                        "False"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Add new vertex. Update vertices"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "<",
+                        "Variable(__SelectionTools.MaximumVertexCount)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
+                            ">=",
+                            "Variable(__SelectionTools.SideLength)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePush"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        "__SelectionTools.Vertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "+",
+                        "1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "folded": true,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarSceneTxt"
+                  },
+                  "parameters": [
+                    "__SelectionTools.SelectionType",
+                    "=",
+                    "\"Lasso\""
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Draw Selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::JsCode",
+                      "inlineCode": [
+                        "const selectionTools = runtimeScene",
+                        "    .getVariables()",
+                        "    .get(\"__SelectionTools\");",
+                        "",
+                        "const vertices = selectionTools",
+                        "    .getChild(\"Vertices\")",
+                        "    .getAllChildrenArray();",
+                        "",
+                        "if (vertices.length > 1){",
+                        "    //get the painter object",
+                        "    const painter = runtimeScene.getObjects(selectionTools.getChild(\"PainterObjectName\").getAsString())[0];",
+                        "    painter.clear();",
+                        "",
+                        "    //begin fill path",
+                        "    painter.beginFillPath(vertices[0].getAllChildrenArray()[0].getAsNumber(), vertices[0].getAllChildrenArray()[1].getAsNumber());",
+                        "",
+                        "    //draw path lines",
+                        "    for (let i = 1; i < vertices.length; i++) {",
+                        "    const vertex = vertices[i].getAllChildrenArray();",
+                        "    painter.drawPathLineTo(vertex[0].getAsNumber(), vertex[1].getAsNumber());",
+                        "    }",
+                        "",
+                        "    //close when mouse is not down",
+                        "    if (!gdjs.evtTools.input.isMouseButtonPressed(runtimeScene,\"Left\")) {",
+                        "        painter.closePath();",
+                        "    }",
+                        "}"
+                      ],
+                      "parameterObjects": "",
+                      "useStrict": true,
+                      "eventsSheetExpanded": false
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "End selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "="
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "<",
+                            "3"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SelectionTools::ClearSelection"
+                          },
+                          "parameters": [
+                            "",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Begin selection"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "False"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "=",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SetSceneVariableAsBoolean"
+                      },
+                      "parameters": [
+                        "__SelectionTools.CanDrawSelection",
+                        "True"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Add new vertex. Update vertices"
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "MouseButtonPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "VarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "<",
+                        "Variable(__SelectionTools.MaximumVertexCount)"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::CompareNumbers"
+                          },
+                          "parameters": [
+                            "DistanceBetweenPositions(Variable(__SelectionTools.Vertex[0]), Variable(__SelectionTools.Vertex[1]), round(CursorX(VariableString(__SelectionTools.Layer),0)), round(CursorY(VariableString(__SelectionTools.Layer),0)))",
+                            ">=",
+                            "Variable(__SelectionTools.SideLength)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarScene"
+                          },
+                          "parameters": [
+                            "__SelectionTools.VertexCount",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "VariableClearChildren"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorX(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePushNumber"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertex",
+                        "round(CursorY(VariableString(__SelectionTools.Layer), 0))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SceneVariablePush"
+                      },
+                      "parameters": [
+                        "__SelectionTools.Vertices",
+                        "__SelectionTools.Vertex"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ModVarScene"
+                      },
+                      "parameters": [
+                        "__SelectionTools.VertexCount",
+                        "+",
+                        "1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Set the shape painter object, the layer, and the z-order that will be used to draw the selection.",
+      "fullName": "Setup selection tools",
+      "functionType": "Action",
+      "name": "SetupSelectionTools",
+      "sentence": "Setup selection tools (painter: _PARAM1_, layer: _PARAM2_, z order: _PARAM3_)",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "True"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.Layer",
+                "=",
+                "GetArgumentAsString(\"Layer\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.VertexCount",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "VariableClearChildren"
+              },
+              "parameters": [
+                "__SelectionTools.Vertices"
+              ]
+            },
+            {
+              "type": {
+                "value": "VariableClearChildren"
+              },
+              "parameters": [
+                "__SelectionTools.Vertex"
+              ]
+            },
+            {
+              "type": {
+                "value": "Delete"
+              },
+              "parameters": [
+                "Painter",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "Create"
+              },
+              "parameters": [
+                "",
+                "Painter",
+                "0",
+                "0",
+                "GetArgumentAsString(\"Layer\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ChangePlan"
+              },
+              "parameters": [
+                "Painter",
+                "=",
+                "GetArgumentAsNumber(\"ZOrder\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.PainterObjectName",
+                "=",
+                "Painter.ObjectName()"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Shape painter object used to draw the selection",
+          "name": "Painter",
+          "supplementaryInformation": "PrimitiveDrawing::Drawer",
+          "type": "objectList"
+        },
+        {
+          "description": "The layer on which the selection would be drawn",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Z Order of the selection",
+          "name": "ZOrder",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "De/Activate selection tools.",
+      "fullName": "De/Activate selection tools",
+      "functionType": "Action",
+      "name": "De_ActivateSelectionTools",
+      "sentence": "Activate selection tools: _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"Choice\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "True"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "GetArgumentAsBoolean"
+              },
+              "parameters": [
+                "\"Choice\""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetSceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "False"
+              ]
+            },
+            {
+              "type": {
+                "value": "SelectionTools::ClearSelection"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Activate?",
+          "name": "Choice",
+          "type": "yesorno"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Change the current selection type to rectangular selection.",
+      "fullName": "Set rectangular selection",
+      "functionType": "Action",
+      "name": "SetRectangularSelection",
+      "sentence": "Set selection type to rectangular selection",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.SelectionType",
+                "=",
+                "\"Rectangular\""
+              ]
+            },
+            {
+              "type": {
+                "value": "SelectionTools::ClearSelection"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Setup and change the current selection type to polygonal selection.",
+      "fullName": "Set polygonal selection",
+      "functionType": "Action",
+      "name": "SetPolygonalSelection",
+      "sentence": "Set selection type to polygonal selection (minimum side length: _PARAM1_, maximum vertex count: _PARAM2_, merge proximity: _PARAM3_)",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.SelectionType",
+                "=",
+                "\"Polygonal\""
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.SideLength",
+                "=",
+                "GetArgumentAsNumber(\"SideLength\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MaximumVertexCount",
+                "=",
+                "GetArgumentAsNumber(\"MaximumVertexCount\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MergeProximity",
+                "=",
+                "GetArgumentAsNumber(\"MergeProximity\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "SelectionTools::ClearSelection"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Minimum length of each side of the shape/polygon (in pixels)",
+          "name": "SideLength",
+          "type": "expression"
+        },
+        {
+          "description": "Maximum number of vertices that the shape/polygon can have",
+          "longDescription": "Too many vertices can affect the performance. A limit on the vertex count ensures that doesn't happen.",
+          "name": "MaximumVertexCount",
+          "type": "expression"
+        },
+        {
+          "description": "Merge proximity",
+          "longDescription": "When clicked, how far (at maximum, in pixels) the cursor needs to be from the first vertex to close the shape. (Default: minimum side length).",
+          "name": "MergeProximity",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Setup and change the current selection type to lasso selection.",
+      "fullName": "Set lasso selection",
+      "functionType": "Action",
+      "name": "SetLassoSelection",
+      "sentence": "Set selection type to lasso selection (side length: _PARAM1_, maximum vertex count: _PARAM2_)",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.SelectionType",
+                "=",
+                "\"Lasso\""
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.MaximumVertexCount",
+                "=",
+                "GetArgumentAsNumber(\"MaximumVertexCount\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.SideLength",
+                "=",
+                "GetArgumentAsNumber(\"SideLength\")"
+              ]
+            },
+            {
+              "type": {
+                "value": "SelectionTools::ClearSelection"
+              },
+              "parameters": [
+                "",
+                ""
+              ]
+            }
+          ],
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareArgumentAsNumber"
+                  },
+                  "parameters": [
+                    "\"MaximumVertexCount\"",
+                    "<",
+                    "3"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__SelectionTools.MaximumVertexCount",
+                    "=",
+                    "3"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareArgumentAsNumber"
+                  },
+                  "parameters": [
+                    "\"SideLength\"",
+                    "<",
+                    "1"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarScene"
+                  },
+                  "parameters": [
+                    "__SelectionTools.SideLength",
+                    "=",
+                    "1"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Length of each side of the shape representing the lasso (in pixels)",
+          "name": "SideLength",
+          "type": "expression"
+        },
+        {
+          "description": "Maximum number of vertices that the shape representing the lasso can have",
+          "longDescription": "Too many vertices can affect the performance. A limit on the vertex count ensures that doesn't happen.",
+          "name": "MaximumVertexCount",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Clear the selection.",
+      "fullName": "Clear selection",
+      "functionType": "Action",
+      "name": "ClearSelection",
+      "sentence": "Clear the selection",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__SelectionTools.VertexCount",
+                "=",
+                "0"
+              ]
+            },
+            {
+              "type": {
+                "value": "VariableClearChildren"
+              },
+              "parameters": [
+                "__SelectionTools.Vertices"
+              ]
+            },
+            {
+              "type": {
+                "value": "VariableClearChildren"
+              },
+              "parameters": [
+                "__SelectionTools.Vertex"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "const painterName = runtimeScene",
+            "    .getVariables()",
+            "    .get(\"__SelectionTools\")",
+            "    .getChild(\"PainterObjectName\")",
+            "    .getAsString()",
+            "",
+            "//get the painter object",
+            "const painter = runtimeScene.getObjects(painterName)[0];",
+            "painter.clear();"
+          ],
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Select objects inside the selection boundary.",
+      "fullName": "Select",
+      "functionType": "Condition",
+      "name": "Select",
+      "sentence": "Select all _PARAM1_ inside the selection boundary (invert selection: _PARAM2_)",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "True"
+              ]
+            },
+            {
+              "type": {
+                "inverted": true,
+                "value": "MouseButtonPressed"
+              },
+              "parameters": [
+                "",
+                "Left"
+              ]
+            }
+          ],
+          "actions": [],
+          "events": [
+            {
+              "folded": true,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarSceneTxt"
+                  },
+                  "parameters": [
+                    "__SelectionTools.SelectionType",
+                    "=",
+                    "\"Rectangular\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SceneVariableChildCount"
+                  },
+                  "parameters": [
+                    "__SelectionTools.Vertex",
+                    "=",
+                    "4"
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": [
+                    "const targets = eventsFunctionContext.getObjectsLists(\"Targets\").items;\r",
+                    "const invertSelection = eventsFunctionContext.getArgument(\"InvertSelection\");\r",
+                    "\r",
+                    "const vertex = runtimeScene\r",
+                    "  .getVariables()\r",
+                    "  .get(\"__SelectionTools\")\r",
+                    "  .getChild(\"Vertex\")\r",
+                    "  .getAllChildrenArray();\r",
+                    "\r",
+                    "const vertexMinX = vertex[0].getAsNumber() < vertex[2].getAsNumber() ? vertex[0].getAsNumber() : vertex[2].getAsNumber();\r",
+                    "const vertexMaxX = vertex[0].getAsNumber() > vertex[2].getAsNumber() ? vertex[0].getAsNumber() : vertex[2].getAsNumber();\r",
+                    "const vertexMinY = vertex[1].getAsNumber() < vertex[3].getAsNumber() ? vertex[1].getAsNumber() : vertex[3].getAsNumber();\r",
+                    "const vertexMaxY = vertex[1].getAsNumber() > vertex[3].getAsNumber() ? vertex[1].getAsNumber() : vertex[3].getAsNumber();\r",
+                    "\r",
+                    "const tempDict = {};\r",
+                    "\r",
+                    "//filter the targets whose center lie inside the polygon\r",
+                    "for (const targetName in targets){\r",
+                    "  tempDict[targetName] = targets[targetName].filter(object => {\r",
+                    "    const objectX = object.getCenterXInScene();\r",
+                    "    const objectY = object.getCenterYInScene();\r",
+                    "\r",
+                    "    const result = objectX > vertexMinX && objectX < vertexMaxX && objectY > vertexMinY && objectY < vertexMaxY;\r",
+                    "    return invertSelection ? !result : result;\r",
+                    "  });\r",
+                    "  targets[targetName].length = 0;\r",
+                    "}\r",
+                    "\r",
+                    "for (const targetName in tempDict){\r",
+                    "  for (const value of tempDict[targetName]){\r",
+                    "    targets[targetName].push(value);\r",
+                    "  }\r",
+                    "}"
+                  ],
+                  "parameterObjects": "",
+                  "useStrict": true,
+                  "eventsSheetExpanded": false
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnBoolean"
+                      },
+                      "parameters": [
+                        "True"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "folded": true,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarScene"
+                  },
+                  "parameters": [
+                    "__SelectionTools.VertexCount",
+                    "!=",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
+                        "value": "VarSceneTxt"
+                      },
+                      "parameters": [
+                        "__SelectionTools.SelectionType",
+                        "=",
+                        "\"Lasso\""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::And"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "VarSceneTxt"
+                          },
+                          "parameters": [
+                            "__SelectionTools.SelectionType",
+                            "=",
+                            "\"Polygonal\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SceneVariableAsBoolean"
+                          },
+                          "parameters": [
+                            "__SelectionTools.CloseSelection",
+                            "True"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": [
+                    "const targets = eventsFunctionContext.getObjectsLists(\"Targets\").items;\r",
+                    "const invertSelection = eventsFunctionContext.getArgument(\"InvertSelection\");\r",
+                    "\r",
+                    "const vertices = runtimeScene\r",
+                    "    .getVariables()\r",
+                    "    .get(\"__SelectionTools\")\r",
+                    "    .getChild(\"Vertices\")\r",
+                    "    .getAllChildrenArray();\r",
+                    "\r",
+                    "const tempDict = {};\r",
+                    "\r",
+                    "//filter the targets whose center lie inside the polygon\r",
+                    "for (const targetName in targets){\r",
+                    "  tempDict[targetName] = targets[targetName].filter(object => {\r",
+                    "    const x = object.getCenterXInScene();\r",
+                    "    const y = object.getCenterYInScene();\r",
+                    "\r",
+                    "    let inside = false;\r",
+                    "\r",
+                    "    for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {\r",
+                    "      const vi = [vertices[i].getAllChildrenArray()[0].getAsNumber(), vertices[i].getAllChildrenArray()[1].getAsNumber()];\r",
+                    "      const vj = [vertices[j].getAllChildrenArray()[0].getAsNumber(), vertices[j].getAllChildrenArray()[1].getAsNumber()];\r",
+                    "      if (vi[1] > y != vj[1] > y && x < ((vj[0] - vi[0]) * (y - vi[1])) / (vj[1] - vi[1]) + vi[0]) {\r",
+                    "        inside = !inside;\r",
+                    "      }\r",
+                    "    }\r",
+                    "    return invertSelection ? !inside : inside;\r",
+                    "  });\r",
+                    "  targets[targetName].length = 0;\r",
+                    "}\r",
+                    "\r",
+                    "for (const targetName in tempDict){\r",
+                    "  for (const value of tempDict[targetName]){\r",
+                    "    targets[targetName].push(value);\r",
+                    "  }\r",
+                    "}"
+                  ],
+                  "parameterObjects": "",
+                  "useStrict": true,
+                  "eventsSheetExpanded": false
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnBoolean"
+                      },
+                      "parameters": [
+                        "True"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Object or group that is to be selected",
+          "name": "Targets",
+          "type": "objectList"
+        },
+        {
+          "description": "Invert selection?",
+          "name": "InvertSelection",
+          "type": "yesorno"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Selection tools is activated.",
+      "fullName": "Selection activated",
+      "functionType": "Condition",
+      "name": "SelectionActivated",
+      "sentence": "Selection tools is activated",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "SceneVariableAsBoolean"
+              },
+              "parameters": [
+                "__SelectionTools.Active",
+                "True"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [],
+      "objectGroups": []
+    },
+    {
+      "description": "Current selection type.",
+      "fullName": "Current selection type",
+      "functionType": "Condition",
+      "name": "CurrentSelectionType",
+      "sentence": "Current selection type: _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "VarSceneTxt"
+              },
+              "parameters": [
+                "__SelectionTools.SelectionType",
+                "=",
+                "GetArgumentAsString(\"Type\")"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Selection type",
+          "name": "Type",
+          "supplementaryInformation": "[\"Rectangular\",\"Polygonal\",\"Lasso\"]",
+          "type": "stringWithSelector"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
+}


### PR DESCRIPTION
The extension provides functionality to draw different types of selections in order to select object instances present on the scene. 

#### How to use:

- Create a shape painter object. It would be used to draw the selection on the screen.
- Add the `Setup selection tools` action to an event.
- Add the setup action for the required selection. Choose from: `Set rectangular selection`, `Set polygonal selection`, and `Set lasso selection`.

---

#### Example

- Project: [SelectionTools Example.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/12333279/SelectionTools.Example.zip)
- Build: https://gd.games/instant-builds/008aa4fb-a228-4eeb-9543-e4004d96d04b