### PR TITLE
Ignore JS disallowed properties in issues

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -67,7 +67,7 @@ jobs:
               return;
             }
 
-            const { code, errors } = await verifyExtension(extensionName);
+            const { code, errors } = await verifyExtension(extensionName, /*preliminaryCheck=*/true);
 
             if(code === "invalid-file-name")
               github.rest.issues.createComment({

--- a/scripts/check-single-extension.js
+++ b/scripts/check-single-extension.js
@@ -6,11 +6,13 @@ const { validateExtension } = require('./lib/ExtensionValidator');
  * A function used by the CI to check for issues in a single extension.
  * @param {string} extensionName
  * @param {string} [extensionsFolder] The folder with the extensions.
+ * @param {boolean} preliminaryCheck True if we are to skip some checks meant for the reviewer, not the extension creator.
  * @returns {Promise<{code: "invalid-file-name" | "not-found" | "duplicated" | "invalid-json" | "success"} | {code: "rule-break", errors: string[]}>}
  */
 exports.verifyExtension = async function (
   extensionName,
-  extensionsFolder = `${__dirname}/../extensions`
+  extensionsFolder = `${__dirname}/../extensions`,
+  preliminaryCheck = false
 ) {
   // Make sure the name is valid, as dots are not allowed in the name
   // and could be used to do relative path shenanigans that could result in skipping automatic checks.
@@ -42,12 +44,15 @@ exports.verifyExtension = async function (
     return { code: 'invalid-json' };
   }
 
-  const validationDetails = await validateExtension({
-    state: 'success',
-    extension,
-    tier: community ? 'community' : 'reviewed',
-    filename: `${extensionName}.json`,
-  });
+  const validationDetails = await validateExtension(
+    {
+      state: 'success',
+      extension,
+      tier: community ? 'community' : 'reviewed',
+      filename: `${extensionName}.json`,
+    },
+    preliminaryCheck
+  );
 
   if (validationDetails.length > 0)
     return {

--- a/scripts/lib/ExtensionValidator.js
+++ b/scripts/lib/ExtensionValidator.js
@@ -23,9 +23,13 @@ const loadRules = (async function loadRules() {
 /**
  * Check the extension for any properties that are not on the allow list.
  * @param {ExtensionWithProperFileInfo} extensionWithFileInfo
+ * @param {boolean} preliminaryCheck True if we are to skip some checks meant for the reviewer, not the extension creator.
  * @returns {Promise<Error[]>}
  */
-async function validateExtension(extensionWithFileInfo) {
+async function validateExtension(
+  extensionWithFileInfo,
+  preliminaryCheck = false
+) {
   /** @type {Error[]} */
   const errors = [];
   const { eventsBasedBehaviors, eventsBasedObjects, eventsFunctions } =
@@ -59,6 +63,7 @@ async function validateExtension(extensionWithFileInfo) {
 
   const promises = [];
   for (const rule of rules) {
+    if (preliminaryCheck && rule.preliminary) continue;
     promises.push(
       rule.validate({
         allEventsFunctions,

--- a/scripts/lib/ExtensionValidator.js
+++ b/scripts/lib/ExtensionValidator.js
@@ -63,7 +63,7 @@ async function validateExtension(
 
   const promises = [];
   for (const rule of rules) {
-    if (preliminaryCheck && rule.preliminary) continue;
+    if (preliminaryCheck && rule.ignoreDuringPreliminaryChecks) continue;
     promises.push(
       rule.validate({
         allEventsFunctions,

--- a/scripts/lib/rules/JavascriptDisallowedProperties.js
+++ b/scripts/lib/rules/JavascriptDisallowedProperties.js
@@ -150,4 +150,5 @@ async function validate({ extension, onError }) {
 module.exports = {
   name: 'JavaScript disallowed properties',
   validate,
+  preliminary: true,
 };

--- a/scripts/lib/rules/JavascriptDisallowedProperties.js
+++ b/scripts/lib/rules/JavascriptDisallowedProperties.js
@@ -150,5 +150,5 @@ async function validate({ extension, onError }) {
 module.exports = {
   name: 'JavaScript disallowed properties',
   validate,
-  preliminary: true,
+  ignoreDuringPreliminaryChecks: true,
 };

--- a/scripts/lib/rules/rule.d.ts
+++ b/scripts/lib/rules/rule.d.ts
@@ -12,5 +12,5 @@ export interface RuleContext extends ExtensionWithProperFileInfo {
 export interface RuleModule {
   name: string;
   validate: Rule;
-  preliminary?: boolean;
+  ignoreDuringPreliminaryChecks?: boolean;
 }

--- a/scripts/lib/rules/rule.d.ts
+++ b/scripts/lib/rules/rule.d.ts
@@ -12,4 +12,5 @@ export interface RuleContext extends ExtensionWithProperFileInfo {
 export interface RuleModule {
   name: string;
   validate: Rule;
+  preliminary?: boolean;
 }


### PR DESCRIPTION
Adds a concept of "Preliminary checks" to the extension checker, where some rules can be ignored. By submitting an extension through an issue, the non-preliminary checks will no longer be ran, but will still be ran by the CI etc. and block a merge until a reviewer takes a look at it.

The rule "Disallowed JS properties" has been added as the single non-preliminary check, as to allow creating the PR for the reviewer to take a look at the disallowed properties in use and add them to the ignore list if appropriate.