### PR TITLE
[Reviewed] [Object Spawner] Added "Random Position" checkbox and deprecated "Offset" properties

### DIFF
--- a/extensions/reviewed/ObjectSpawner.json
+++ b/extensions/reviewed/ObjectSpawner.json
@@ -2,21 +2,25 @@
   "author": "",
   "category": "Game mechanic",
   "extensionNamespace": "",
-  "fullName": "Object spawner",
+  "fullName": "Object spawner area",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXBsdXMtb25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTEwLDhWMTJIMTRWMTRIMTBWMThIOFYxNEg0VjEySDhWOEgxME0xNC41LDYuMDhMMTksNVYxOEgxN1Y3LjRMMTQuNSw3LjlWNi4wOFoiIC8+PC9zdmc+",
   "name": "ObjectSpawner",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/plus-one.svg",
-  "shortDescription": "Spawn (create) objects periodically.",
-  "version": "0.5.0",
+  "shortDescription": "Spawn (create) objects periodically",
+  "version": "1.0.0",
   "description": [
-    "Spawn objects periodically and control their number.",
+    "Spawn objects periodically based on the location of the spawner.  ",
+    "",
+    "If \"random position\" is enabled, objects will spawn in a random position inside the spawner object. ",
+    "This allows the size of the spawner object to define an area that objects will spawn.",
     "",
     "It can be used to create:",
     "- Enemies",
     "- NPCs",
     "- Environmental objects",
-    ""
+    "",
+    "Note: Offset properties were deprecated in version 1.0.0."
   ],
   "origin": {
     "identifier": "ObjectSpawner",
@@ -428,28 +432,6 @@
                     },
                     {
                       "type": {
-                        "value": "Create"
-                      },
-                      "parameters": [
-                        "",
-                        "ObjectToSpawn",
-                        "Object.BoundingBoxCenterX() + Object.Behavior::PropertyOffsetX()",
-                        "Object.BoundingBoxCenterY() + Object.Behavior::PropertyOffsetY()",
-                        "Object.Layer()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "LinkedObjects::LinkObjects"
-                      },
-                      "parameters": [
-                        "",
-                        "ObjectToSpawn",
-                        "Object"
-                      ]
-                    },
-                    {
-                      "type": {
                         "value": "ObjectSpawner::ObjectSpawner::SetPropertySpawnerCapacity"
                       },
                       "parameters": [
@@ -467,6 +449,152 @@
                         "Object",
                         "Behavior",
                         "yes"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Spawn at Center Position"
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "Create"
+                          },
+                          "parameters": [
+                            "",
+                            "ObjectToSpawn",
+                            "Object.BoundingBoxCenterX()",
+                            "Object.BoundingBoxCenterY()",
+                            "Object.Layer()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "LinkedObjects::LinkObjects"
+                          },
+                          "parameters": [
+                            "",
+                            "ObjectToSpawn",
+                            "Object"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 205,
+                            "g": 211,
+                            "r": 33,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Legacy action that supports deprecated offsets"
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "ObjectSpawner::ObjectSpawner::PropertyOffsetX"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "!=",
+                                    "0"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "ObjectSpawner::ObjectSpawner::PropertyOffsetY"
+                                  },
+                                  "parameters": [
+                                    "Object",
+                                    "Behavior",
+                                    "!=",
+                                    "0"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCenter"
+                              },
+                              "parameters": [
+                                "ObjectToSpawn",
+                                "=",
+                                "Object.BoundingBoxCenterX() + Object.Behavior::PropertyOffsetX()",
+                                "=",
+                                "Object.BoundingBoxCenterY() + Object.Behavior::PropertyOffsetY()"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Move to a Random Position (if enabled)"
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "ObjectSpawner::ObjectSpawner::RandomPosition"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCenter"
+                              },
+                              "parameters": [
+                                "ObjectToSpawn",
+                                "=",
+                                "Object.BoundingBoxLeft() + Random(Object.Width())\n",
+                                "=",
+                                "Object.BoundingBoxTop() + Random(Object.Height())\n"
+                              ]
+                            }
+                          ]
+                        }
                       ]
                     }
                   ]
@@ -497,9 +625,10 @@
         },
         {
           "description": "Change the offset X relative to the center of spawner (in pixels).",
-          "fullName": "Offset on X axis",
+          "fullName": "Offset on X axis (deprecated)",
           "functionType": "Action",
           "name": "SetOffsetX",
+          "private": true,
           "sentence": "Change the offset X of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
@@ -542,9 +671,10 @@
         },
         {
           "description": "Change the offset Y relative to the center of spawner (in pixels).",
-          "fullName": "Offset on Y axis",
+          "fullName": "Offset on Y axis (deprecated)",
           "functionType": "Action",
           "name": "SetOffsetY",
+          "private": true,
           "sentence": "Change the offset Y of _PARAM0_ to _PARAM2_ pixels",
           "events": [
             {
@@ -632,9 +762,10 @@
         },
         {
           "description": "Return the offset X relative to the center of spawner (in pixels).",
-          "fullName": "Offset X",
+          "fullName": "Offset X (deprecated)",
           "functionType": "Expression",
           "name": "OffsetX",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -677,9 +808,10 @@
         },
         {
           "description": "Return the offset Y relative to the center of spawner (in pixels).",
-          "fullName": "Offset Y",
+          "fullName": "Offset Y (deprecated)",
           "functionType": "Expression",
           "name": "OffsetY",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -1241,6 +1373,136 @@
             }
           ],
           "objectGroups": []
+        },
+        {
+          "description": "Check if use random positions inside the spawner. Useful for making large spawner areas.",
+          "fullName": "Use random positions inside the spawner",
+          "functionType": "Condition",
+          "group": "Object spawner configuration",
+          "name": "RandomPosition",
+          "sentence": "_PARAM0_ use random positions inside the spawner",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectSpawner::ObjectSpawner::PropertyRandomPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "ObjectSpawner::ObjectSpawner",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Change if use random positions inside the spawner. Useful for making large spawner areas.",
+          "fullName": "Use random positions inside the spawner",
+          "functionType": "Action",
+          "group": "Object spawner configuration",
+          "name": "SetRandomPosition",
+          "sentence": "_PARAM0_ use random positions inside the spawner: _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ObjectSpawner::ObjectSpawner::SetPropertyRandomPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "no"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"Value\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ObjectSpawner::ObjectSpawner::SetPropertyRandomPosition"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "yes"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "ObjectSpawner::ObjectSpawner",
+              "type": "behavior"
+            },
+            {
+              "defaultValue": "yes",
+              "description": "RandomPosition",
+              "name": "Value",
+              "optional": true,
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
         }
       ],
       "propertyDescriptors": [
@@ -1263,7 +1525,7 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
+          "hidden": true,
           "name": "OffsetX"
         },
         {
@@ -1274,7 +1536,7 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
+          "hidden": true,
           "name": "OffsetY"
         },
         {
@@ -1326,6 +1588,16 @@
           "extraInformation": [],
           "hidden": false,
           "name": "UnlimitedCapacity"
+        },
+        {
+          "value": "false",
+          "type": "Boolean",
+          "label": "Use random positions inside the spawner",
+          "description": "Useful for making large spawner areas",
+          "group": "",
+          "extraInformation": [],
+          "hidden": false,
+          "name": "RandomPosition"
         }
       ],
       "sharedPropertyDescriptors": []

--- a/extensions/reviewed/ObjectSpawner.json
+++ b/extensions/reviewed/ObjectSpawner.json
@@ -7,7 +7,7 @@
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXBsdXMtb25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTEwLDhWMTJIMTRWMTRIMTBWMThIOFYxNEg0VjEySDhWOEgxME0xNC41LDYuMDhMMTksNVYxOEgxN1Y3LjRMMTQuNSw3LjlWNi4wOFoiIC8+PC9zdmc+",
   "name": "ObjectSpawner",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/plus-one.svg",
-  "shortDescription": "Spawn (create) objects periodically",
+  "shortDescription": "Spawn (create) objects periodically.",
   "version": "1.0.0",
   "description": [
     "Spawn objects periodically based on the location of the spawner.  ",

--- a/extensions/reviewed/ObjectSpawner.json
+++ b/extensions/reviewed/ObjectSpawner.json
@@ -1375,12 +1375,12 @@
           "objectGroups": []
         },
         {
-          "description": "Check if use random positions inside the spawner. Useful for making large spawner areas.",
-          "fullName": "Use random positions inside the spawner",
+          "description": "Check if using random positions. Useful for making large spawner areas.",
+          "fullName": "Use random positions",
           "functionType": "Condition",
           "group": "Object spawner configuration",
           "name": "RandomPosition",
-          "sentence": "_PARAM0_ use random positions inside the spawner",
+          "sentence": "Use random positions inside _PARAM0_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1423,12 +1423,12 @@
           "objectGroups": []
         },
         {
-          "description": "Change if use random positions inside the spawner. Useful for making large spawner areas.",
-          "fullName": "Use random positions inside the spawner",
+          "description": "Enable (or disable) random positions. Useful for making large spawner areas.",
+          "fullName": "Use random positions",
           "functionType": "Action",
           "group": "Object spawner configuration",
           "name": "SetRandomPosition",
-          "sentence": "_PARAM0_ use random positions inside the spawner: _PARAM2_",
+          "sentence": "Use random positions inside _PARAM0_: _PARAM2_",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1592,8 +1592,8 @@
         {
           "value": "false",
           "type": "Boolean",
-          "label": "Use random positions inside the spawner",
-          "description": "Useful for making large spawner areas",
+          "label": "Use random positions",
+          "description": "Objects will be created at a random position inside the spawner. Useful for making large spawner areas.",
           "group": "",
           "extraInformation": [],
           "hidden": false,


### PR DESCRIPTION
Offsets were originally designed to enable random positions, but this new implementation is much cleaner. The offset method can still be used by adding a value to the position of objects as a subevent to the "Periodically spawn objects".  This was not possible before GDevelop started picking objects created by extensions.

Playable game:
https://gd.games/instant-builds/cbf53f3e-449a-45e2-b7c1-011f257c7343

Project file:
[ObjectSpawnerRandomPositions.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/13540079/ObjectSpawnerRandomPositions.zip)
