### PR TITLE
[Reviewed] [Mouse pointer lock] Avoid errors in Safari on iOS.

### DIFF
--- a/extensions/reviewed/MousePointerLock.json
+++ b/extensions/reviewed/MousePointerLock.json
@@ -8,7 +8,7 @@
   "name": "MousePointerLock",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Virtual Reality/Virtual Reality_360_rotate_vr_movement.svg",
   "shortDescription": "This behavior removes the limit on the distance the mouse can move and hides the cursor.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": [
     "This behavior removes the limit on the distance the mouse can move and hides the cursor.",
     "",
@@ -133,7 +133,9 @@
           "type": "BuiltinCommonInstructions::JsCode",
           "inlineCode": [
             "const canvas = runtimeScene.getGame().getRenderer().getCanvas();\r",
-            "canvas.requestPointerLock({ unadjustedMovement: true });"
+            "if (canvas.requestPointerLock) {\r",
+            "    canvas.requestPointerLock({ unadjustedMovement: true });\r",
+            "}"
           ],
           "parameterObjects": "",
           "useStrict": true,
@@ -152,7 +154,11 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "document.exitPointerLock();",
+          "inlineCode": [
+            "if (document.exitPointerLock) {\r",
+            "    document.exitPointerLock();\r",
+            "}"
+          ],
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false


### PR DESCRIPTION
Avoid errors when running the "Request Pointer Lock" and "Exit pointer lock" actions in Safari on iOS.