### PR TITLE
3D Movement on local axis

### DIFF
--- a/extensions/community/Movement3dOnLocalAxis.json
+++ b/extensions/community/Movement3dOnLocalAxis.json
@@ -1,0 +1,281 @@
+{
+  "author": "",
+  "category": "Movement",
+  "extensionNamespace": "",
+  "fullName": "3D Movement on local axis",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPHBhdGggZD0iTTI5LjksMTYuNGMwLjEtMC4yLDAuMS0wLjUsMC0wLjhjLTAuMS0wLjEtMC4xLTAuMi0wLjItMC4zbC00LTRjLTAuNC0wLjQtMS0wLjQtMS40LDBzLTAuNCwxLDAsMS40bDIuMywyLjNoLTUuNw0KCWMtMC40LTItMS45LTMuNS0zLjktMy45VjUuNGwyLjMsMi4zQzE5LjUsNy45LDE5LjcsOCwyMCw4czAuNS0wLjEsMC43LTAuM2MwLjQtMC40LDAuNC0xLDAtMS40bC00LTRjLTAuMS0wLjEtMC4yLTAuMi0wLjMtMC4yDQoJYy0wLjItMC4xLTAuNS0wLjEtMC44LDBjLTAuMSwwLjEtMC4yLDAuMS0wLjMsMC4ybC00LDRjLTAuNCwwLjQtMC40LDEsMCwxLjRzMSwwLjQsMS40LDBMMTUsNS40djUuN2MtMiwwLjQtMy41LDEuOS0zLjksMy45SDUuNA0KCWwyLjMtMi4zYzAuNC0wLjQsMC40LTEsMC0xLjRzLTEtMC40LTEuNCwwbC00LDRjLTAuMSwwLjEtMC4yLDAuMi0wLjIsMC4zYy0wLjEsMC4yLTAuMSwwLjUsMCwwLjhjMC4xLDAuMSwwLjEsMC4yLDAuMiwwLjNsNCw0DQoJQzYuNSwyMC45LDYuNywyMSw3LDIxczAuNS0wLjEsMC43LTAuM2MwLjQtMC40LDAuNC0xLDAtMS40TDUuNCwxN2g1LjdjMC40LDIsMS45LDMuNSwzLjksMy45djUuN2wtMi4zLTIuM2MtMC40LTAuNC0xLTAuNC0xLjQsMA0KCXMtMC40LDEsMCwxLjRsNCw0YzAuMSwwLjEsMC4yLDAuMiwwLjMsMC4yQzE1LjcsMzAsMTUuOSwzMCwxNiwzMHMwLjMsMCwwLjQtMC4xYzAuMS0wLjEsMC4yLTAuMSwwLjMtMC4ybDQtNGMwLjQtMC40LDAuNC0xLDAtMS40DQoJcy0xLTAuNC0xLjQsMEwxNywyNi42di01LjdjMi0wLjQsMy41LTEuOSwzLjktMy45aDUuN2wtMi4zLDIuM2MtMC40LDAuNC0wLjQsMSwwLDEuNGMwLjIsMC4yLDAuNSwwLjMsMC43LDAuM3MwLjUtMC4xLDAuNy0wLjNsNC00DQoJQzI5LjgsMTYuNiwyOS45LDE2LjUsMjkuOSwxNi40eiIvPg0KPC9zdmc+DQo=",
+  "name": "Movement3dOnLocalAxis",
+  "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/Glyphster Pack/Master/SVG/Maps and Navigation/0073161b63fcf00ad88178196958a47241bff982006653be8b99af956e1ca14f_Maps and Navigation_directions_arrows_cross.svg",
+  "shortDescription": "Translates or rotates a 3D object along a local axis.",
+  "version": "0.0.1",
+  "description": [
+    "This extension provides behaviors that allow you to translate and rotate 3D objects along local axes.",
+    "",
+    "Add the \"Movement 3D on local axis\" behavior to your 3D box or 3D model. The following actions will then be available:",
+    "- Translate by distance",
+    "- Translate by speed",
+    "- Rotate by angle",
+    "- Rotate by speed"
+  ],
+  "tags": [
+    "3d",
+    "movement",
+    "rotate"
+  ],
+  "authorIds": [
+    "Zu55H5hcb9YmZTltIVOTAFDJQyB2"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [],
+  "eventsBasedBehaviors": [
+    {
+      "description": "Translates or rotates a 3D object along a local axis.",
+      "fullName": "3D Movement on local axis",
+      "name": "Movement3dOnLocalAxis",
+      "objectType": "",
+      "eventsFunctions": [
+        {
+          "description": "Translates the 3D object along its local axis.",
+          "fullName": "Translate by distance",
+          "functionType": "Action",
+          "name": "TranslateDistance",
+          "sentence": "Translates _PARAM0_ by _PARAM3_ pixels along the local _PARAM2_ axis",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::JsCode",
+              "inlineCode": [
+                "const Object3D = objects[0].get3DRendererObject();",
+                "const Axis = eventsFunctionContext.getArgument(\"Axis\");",
+                "const Distance = eventsFunctionContext.getArgument(\"Distance\");",
+                "",
+                "Object3D.updateMatrixWorld(false);",
+                "const Elements = Object3D.matrixWorld.elements;",
+                "let WorldDirection = new THREE.Vector3();",
+                "if (Axis == \"X\") {",
+                "    WorldDirection.set(Elements[0], Elements[1], Elements[2]);",
+                "    WorldDirection = WorldDirection.normalize();",
+                "} else if (Axis == \"Y\") {",
+                "    WorldDirection.set(Elements[4], Elements[5], Elements[6]);",
+                "    WorldDirection = WorldDirection.normalize();",
+                "} else {",
+                "    Object3D.getWorldDirection(WorldDirection);",
+                "}",
+                "objects[0].setX(objects[0].getX() + (WorldDirection.x * Distance));",
+                "objects[0].setY(objects[0].getY() + (WorldDirection.y * Distance * -1));",
+                "objects[0].setZ(objects[0].getZ() + (WorldDirection.z * Distance));"
+              ],
+              "parameterObjects": "Object",
+              "useStrict": true,
+              "eventsSheetExpanded": true
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Movement3dOnLocalAxis::Movement3dOnLocalAxis",
+              "type": "behavior"
+            },
+            {
+              "description": "Axis",
+              "name": "Axis",
+              "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+              "type": "stringWithSelector"
+            },
+            {
+              "description": "Distance (in pixels)",
+              "name": "Distance",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Translates the 3D object along its local axis.",
+          "fullName": "Translate by speed",
+          "functionType": "Action",
+          "name": "TranslateSpeed",
+          "sentence": "Translates _PARAM0_ by _PARAM3_ pixels per second along the local _PARAM2_ axis",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Movement3dOnLocalAxis::Movement3dOnLocalAxis::TranslateDistance"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Axis",
+                    "Speed * TimeDelta()",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Movement3dOnLocalAxis::Movement3dOnLocalAxis",
+              "type": "behavior"
+            },
+            {
+              "description": "Axis",
+              "name": "Axis",
+              "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+              "type": "stringWithSelector"
+            },
+            {
+              "description": "Speed (in pixels per second)",
+              "name": "Speed",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Rotates the 3D object along its local axis.",
+          "fullName": "Rotate by angle",
+          "functionType": "Action",
+          "name": "RotateAngle",
+          "sentence": "Rotates _PARAM0_ by _PARAM3_ degrees along the local _PARAM2_ axis",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::JsCode",
+              "inlineCode": [
+                "const Object3D = objects[0].get3DRendererObject();",
+                "const Axis = eventsFunctionContext.getArgument(\"Axis\");",
+                "const Angle = eventsFunctionContext.getArgument(\"Angle\");",
+                "",
+                "if (Axis == \"X\") {",
+                "    Object3D.rotateX(gdjs.toRad(Angle));",
+                "} else if (Axis == \"Y\") {",
+                "    Object3D.rotateY(gdjs.toRad(Angle));",
+                "} else {",
+                "    Object3D.rotateZ(gdjs.toRad(Angle));",
+                "}",
+                "const DegreesX = gdjs.toDegrees(Object3D.rotation.x);",
+                "const DegreesY = gdjs.toDegrees(Object3D.rotation.y);",
+                "const DegreesZ = gdjs.toDegrees(Object3D.rotation.z);",
+                "objects[0].setRotationX(DegreesX);",
+                "objects[0].setRotationY(DegreesY);",
+                "objects[0].setAngle(DegreesZ);"
+              ],
+              "parameterObjects": "Object",
+              "useStrict": true,
+              "eventsSheetExpanded": true
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Movement3dOnLocalAxis::Movement3dOnLocalAxis",
+              "type": "behavior"
+            },
+            {
+              "description": "Axis",
+              "name": "Axis",
+              "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+              "type": "stringWithSelector"
+            },
+            {
+              "description": "Angle (in degrees)",
+              "name": "Angle",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Rotates the 3D object along its local axis.",
+          "fullName": "Rotate by speed",
+          "functionType": "Action",
+          "name": "RotateSpeed",
+          "sentence": "Rotates _PARAM0_ by _PARAM3_ degrees per second along the local _PARAM2_ axis",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "Movement3dOnLocalAxis::Movement3dOnLocalAxis::RotateAngle"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "Axis",
+                    "Speed * TimeDelta()",
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "type": "object"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "Movement3dOnLocalAxis::Movement3dOnLocalAxis",
+              "type": "behavior"
+            },
+            {
+              "description": "Axis",
+              "name": "Axis",
+              "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+              "type": "stringWithSelector"
+            },
+            {
+              "description": "Speed (in degrees per second)",
+              "name": "Speed",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": [
+        {
+          "value": "",
+          "type": "Behavior",
+          "label": "3D capability",
+          "description": "",
+          "group": "",
+          "extraInformation": [
+            "Scene3D::Base3DBehavior"
+          ],
+          "hidden": false,
+          "name": "Object3D"
+        }
+      ],
+      "sharedPropertyDescriptors": []
+    }
+  ],
+  "eventsBasedObjects": []
+}


### PR DESCRIPTION
This extension provides behaviors that allow you to translate and rotate 3D objects along local axes.

Add the "Movement 3D on local axis" behavior to your 3D box or 3D model. The following actions will then be available:
- Translate by distance
- Translate by speed
- Rotate by angle
- Rotate by speed

### Example
https://editor.gdevelop.io/?project=https://raw.githubusercontent.com/PANDAKO-GitHub/GDevelop-examples/3D-Movement-on-local-axis-Example/examples/3d-movement-on-local-axis/3d-movement-on-local-axis.json
