### PR TITLE
3D Movement on local axis of camera

### DIFF
--- a/extensions/community/Movement3dOnLocalAxisOfCamera.json
+++ b/extensions/community/Movement3dOnLocalAxisOfCamera.json
@@ -1,0 +1,256 @@
+{
+  "author": "",
+  "category": "Camera",
+  "extensionNamespace": "",
+  "fullName": "3D Movement on local axis of camera",
+  "helpPath": "",
+  "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXZpZGVvLTNkLXZhcmlhbnQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTQsMTBWMTRBMC41LDAuNSAwIDAsMSAxMy41LDE0LjVIMTIuNVY5LjVIMTMuNUEwLjUsMC41IDAgMCwxIDE0LDEwTTIxLDYuNVYxNy41TDE3LDEzLjVWMTdBMSwxIDAgMCwxIDE2LDE4SDRBMSwxIDAgMCwxIDMsMTdWN0ExLDEgMCAwLDEgNCw2SDE2QTEsMSAwIDAsMSAxNyw3VjEwLjVNOS41LDkuNUExLjUsMS41IDAgMCwwIDgsOEg0LjVWOS41SDhWMTEuMjVINS41VjEyLjc1SDhWMTQuNUg0LjVWMTZIOEExLjUsMS41IDAgMCwwIDkuNSwxNC41TTE1LjUsOS41QTEuNSwxLjUgMCAwLDAgMTQsOEgxMVYxNkgxNEExLjUsMS41IDAgMCwwIDE1LjUsMTQuNSIgLz48L3N2Zz4=",
+  "name": "Movement3dOnLocalAxisOfCamera",
+  "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/6760f151bd8288f69b1628449a3984abc9ad4e056851c4dc188be579d35dee10_video-3d-variant.svg",
+  "shortDescription": "Translates or rotates a camera along a local axis.",
+  "version": "0.0.1",
+  "description": [
+    "This extension provides actions that allow you to move and rotate the camera along local axes.",
+    "",
+    "The following actions are added to the camera category.",
+    "- Translate camera by distance",
+    "- Translate camera by speed",
+    "- Rotate camera by angle",
+    "- Rotate camera by speed",
+    ""
+  ],
+  "tags": [
+    "3d",
+    "camera",
+    "movement",
+    "rotate"
+  ],
+  "authorIds": [
+    "Zu55H5hcb9YmZTltIVOTAFDJQyB2"
+  ],
+  "dependencies": [],
+  "eventsFunctions": [
+    {
+      "description": "Translates the camera along its local axis.",
+      "fullName": "Translate camera by distance",
+      "functionType": "Action",
+      "name": "TranslateCameraDistance",
+      "sentence": "Translates the camera (Layer: _PARAM3_; _PARAM4_) by _PARAM2_ pixels along the local _PARAM1_ axis",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "const Axis = eventsFunctionContext.getArgument(\"Axis\");",
+            "const Distance = eventsFunctionContext.getArgument(\"Distance\");",
+            "const Layer = eventsFunctionContext.getArgument(\"Layer\");",
+            "// const CameraNumber = eventsFunctionContext.getArgument(\"CameraNumber\");",
+            "",
+            "const Camera3D = runtimeScene.getLayer(Layer).getRenderer().getThreeCamera();",
+            "if (!Camera3D) {",
+            "    return;",
+            "}",
+            "if (Axis == \"X\") {",
+            "    Camera3D.translateX(Distance);",
+            "} else if (Axis == \"Y\") {",
+            "    Camera3D.translateY(Distance * -1);",
+            "} else {",
+            "    Camera3D.translateZ(Distance);",
+            "}"
+          ],
+          "parameterObjects": "Object",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Axis",
+          "name": "Axis",
+          "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "description": "Distance (in pixels)",
+          "name": "Distance",
+          "type": "expression"
+        },
+        {
+          "description": "Layer",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Camera number (default: 0)",
+          "name": "CameraNumber",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Translates the camera along its local axis.",
+      "fullName": "Translate camera by speed",
+      "functionType": "Action",
+      "name": "TranslateCameraSpeed",
+      "sentence": "Translates the camera (Layer: _PARAM3_; _PARAM4_) by _PARAM2_ pixels per second along the local _PARAM1_ axis",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "Movement3dOnLocalAxisOfCamera::TranslateCameraDistance"
+              },
+              "parameters": [
+                "",
+                "Axis",
+                "Speed * TimeDelta()",
+                "Layer",
+                "CameraNumber",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Axis",
+          "name": "Axis",
+          "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "description": "Speed (in pixels per second)",
+          "name": "Speed",
+          "type": "expression"
+        },
+        {
+          "description": "Layer",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Camera number (default: 0)",
+          "name": "CameraNumber",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Rotates the camera along its local axis.",
+      "fullName": "Rotate camera by angle",
+      "functionType": "Action",
+      "name": "RotateCameraAngle",
+      "sentence": "Rotates the camera (Layer: _PARAM3_; _PARAM4_) by _PARAM2_ degrees along the local _PARAM1_ axis",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "const Axis = eventsFunctionContext.getArgument(\"Axis\");",
+            "const Angle = eventsFunctionContext.getArgument(\"Angle\");",
+            "const Layer = eventsFunctionContext.getArgument(\"Layer\");",
+            "// const CameraNumber = eventsFunctionContext.getArgument(\"CameraNumber\");",
+            "",
+            "const Camera3D = runtimeScene.getLayer(Layer).getRenderer().getThreeCamera();",
+            "if (!Camera3D) {",
+            "    return;",
+            "}",
+            "if (Axis == \"X\") {",
+            "    // const CameraRotationX = gdjs.scene3d.camera.getCameraRotationX(runtimeScene, Layer, CameraNumber);",
+            "    // gdjs.scene3d.camera.setCameraRotationX(runtimeScene, CameraRotationX + SpeedPerSecond, Layer, CameraNumber);",
+            "    Camera3D.rotateX(gdjs.toRad(Angle * -1));",
+            "} else if (Axis == \"Y\") {",
+            "    Camera3D.rotateY(gdjs.toRad(Angle));",
+            "} else {",
+            "    Camera3D.rotateZ(gdjs.toRad(Angle * -1));",
+            "}"
+          ],
+          "parameterObjects": "Object",
+          "useStrict": true,
+          "eventsSheetExpanded": true
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Axis",
+          "name": "Axis",
+          "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "description": "Angle (in degrees)",
+          "name": "Angle",
+          "type": "expression"
+        },
+        {
+          "description": "Layer",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Camera number (default: 0)",
+          "name": "CameraNumber",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Rotates the camera along its local axis.",
+      "fullName": "Rotate camera by speed",
+      "functionType": "Action",
+      "name": "RotateCameraSpeed",
+      "sentence": "Rotates the camera (Layer: _PARAM3_; _PARAM4_) by _PARAM2_ degrees per second along the local _PARAM1_ axis",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "Movement3dOnLocalAxisOfCamera::RotateCameraAngle"
+              },
+              "parameters": [
+                "",
+                "Axis",
+                "Speed * TimeDelta()",
+                "Layer",
+                "CameraNumber",
+                ""
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Axis",
+          "name": "Axis",
+          "supplementaryInformation": "[\"X\",\"Y\",\"Z\"]",
+          "type": "stringWithSelector"
+        },
+        {
+          "description": "Speed (in degrees per second)",
+          "name": "Speed",
+          "type": "expression"
+        },
+        {
+          "description": "Layer",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Camera number (default: 0)",
+          "name": "CameraNumber",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
+}


### PR DESCRIPTION
This extension provides actions that allow you to move and rotate the camera along local axes.

The following actions are added to the camera category.
- Translate camera by distance
- Translate camera by speed
- Rotate camera by angle
- Rotate camera by speed

### Example
https://editor.gdevelop.io/?project=https://raw.githubusercontent.com/PANDAKO-GitHub/GDevelop-examples/3D-Movement-on-local-axis-Example/examples/3d-movement-on-local-axis/3d-movement-on-local-axis.json