### PR TITLE
[Reviewed] [Repeat every X seconds] Allow to use several object timers

### DIFF
--- a/extensions/reviewed/RepeatEveryXSeconds.json
+++ b/extensions/reviewed/RepeatEveryXSeconds.json
@@ -455,9 +455,9 @@
           ],
           "parameters": [
             {
-              "description": "",
+              "description": "Object",
               "name": "Object",
-              "type": "objectList"
+              "type": "object"
             },
             {
               "description": "Behavior",
@@ -506,9 +506,9 @@
           },
           "parameters": [
             {
-              "description": "",
+              "description": "Object",
               "name": "Object",
-              "type": "objectList"
+              "type": "object"
             },
             {
               "description": "Behavior",
@@ -593,9 +593,9 @@
           ],
           "parameters": [
             {
-              "description": "",
+              "description": "Object",
               "name": "Object",
-              "type": "objectList"
+              "type": "object"
             },
             {
               "description": "Behavior",
@@ -658,9 +658,9 @@
           ],
           "parameters": [
             {
-              "description": "",
+              "description": "Object",
               "name": "Object",
-              "type": "objectList"
+              "type": "object"
             },
             {
               "description": "Behavior",

--- a/extensions/reviewed/RepeatEveryXSeconds.json
+++ b/extensions/reviewed/RepeatEveryXSeconds.json
@@ -1,300 +1,303 @@
 {
   "author": "VegeTato, arthuro555",
   "category": "General",
-  "description": "Convenience conditions, actions and behaviors for timers to trigger a condition every X seconds.",
   "extensionNamespace": "",
   "fullName": "Repeat every X seconds",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLXJlcGVhdCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xNywxN0g3VjE0TDMsMThMNywyMlYxOUgxOVYxM0gxN003LDdIMTdWMTBMMjEsNkwxNywyVjVINVYxMUg3VjdaIiAvPjwvc3ZnPg==",
   "name": "RepeatEveryXSeconds",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/repeat.svg",
-  "shortDescription": "This allows to trigger an event every X seconds.",
-  "version": "0.1.0",
+  "shortDescription": "Trigger an event every X seconds.",
+  "version": "0.1.1",
+  "description": "Convenience conditions, actions and behaviors for timers to trigger a condition every X seconds.",
+  "origin": {
+    "identifier": "RepeatEveryXSeconds",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "repeat",
     "timer",
-    "time",
-    "convenience"
+    "time"
   ],
   "authorIds": [
     "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1",
-    "IRIhkkTTl2UHhfjrLTTH5GYwkYu1"
+    "IRIhkkTTl2UHhfjrLTTH5GYwkYu1",
+    "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
   "eventsFunctions": [
     {
       "description": "Triggers every X seconds.",
-      "fullName": "Repeat every X seconds",
+      "fullName": "Repeat with a scene timer",
       "functionType": "Condition",
       "name": "Repeat",
-      "private": false,
-      "sentence": "Repeat timer _PARAM1_ every _PARAM2_ seconds",
+      "sentence": "Repeat every _PARAM2_ seconds using timer _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Once"
-              },
-              "parameters": [],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ResetTimer"
+                "inverted": true,
+                "value": "CompareTimer"
               },
               "parameters": [
-                "player",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "Timer"
-              },
-              "parameters": [
-                "player",
-                "GetArgumentAsNumber(\"time\")",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ResetTimer"
-              },
-              "parameters": [
-                "player",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "SetReturnBoolean"
-              },
-              "parameters": [
-                "True"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "The name of the timer to loop",
-          "longDescription": "",
-          "name": "timerName",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "The time in seconds between each trigger",
-          "longDescription": "",
-          "name": "time",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "Triggers every X seconds X amount of times.",
-      "fullName": "Repeat every X seconds in X number",
-      "functionType": "Condition",
-      "name": "RepeatXTimes",
-      "private": false,
-      "sentence": "Repeat timer _PARAM1_ every _PARAM2_ seconds _PARAM3_ times",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Once"
-              },
-              "parameters": [],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ResetTimer"
-              },
-              "parameters": [
-                "player",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__RepeatEveryXSeconds_.Counter[GetArgumentAsString(\"timerName\")]",
-                "=",
+                "",
+                "TimerName",
+                ">=",
                 "0"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "Timer"
-              },
-              "parameters": [
-                "player",
-                "GetArgumentAsNumber(\"time\")",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Or"
-              },
-              "parameters": [],
-              "subInstructions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Egal"
-                  },
-                  "parameters": [
-                    "GetArgumentAsNumber(\"limit\")",
-                    "=",
-                    "-1"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "VarScene"
-                  },
-                  "parameters": [
-                    "__RepeatEveryXSeconds_.Counter[GetArgumentAsString(\"timerName\")]",
-                    "<",
-                    "GetArgumentAsNumber(\"limit\")"
-                  ],
-                  "subInstructions": []
-                }
               ]
             }
           ],
           "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ResetTimer"
               },
               "parameters": [
                 "player",
-                "GetArgumentAsString(\"timerName\")"
-              ],
-              "subInstructions": []
+                "TimerName"
+              ]
             },
             {
               "type": {
-                "inverted": false,
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__RepeatEveryXSeconds_.Counter[GetArgumentAsString(\"timerName\")]",
-                "+",
-                "1"
-              ],
-              "subInstructions": []
+                "__RepeatEveryXSeconds.Repetitions[TimerName]",
+                "=",
+                "0"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "TODO: It should keep the overflowing time to be more precise (it would need JavaScript)"
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "CompareTimer"
+              },
+              "parameters": [
+                "player",
+                "TimerName",
+                ">=",
+                "LoopDuration"
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "ResetTimer"
+              },
+              "parameters": [
+                "player",
+                "TimerName"
+              ]
             },
             {
               "type": {
-                "inverted": false,
+                "value": "ModVarScene"
+              },
+              "parameters": [
+                "__RepeatEveryXSeconds.Repetitions[TimerName]",
+                "+",
+                "1"
+              ]
+            },
+            {
+              "type": {
                 "value": "SetReturnBoolean"
               },
               "parameters": [
                 "True"
-              ],
-              "subInstructions": []
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "The name of the timer to loop",
-          "longDescription": "",
-          "name": "timerName",
-          "optional": false,
-          "supplementaryInformation": "",
+          "description": "Timer name used to loop",
+          "name": "TimerName",
           "type": "string"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "The time in seconds between each trigger",
-          "longDescription": "",
-          "name": "time",
-          "optional": false,
-          "supplementaryInformation": "",
+          "description": "Duration in seconds between each repetition",
+          "name": "LoopDuration",
+          "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "the number of times the timer has repeated.",
+      "fullName": "Repetition number of a scene timer",
+      "functionType": "ExpressionAndCondition",
+      "name": "Repetition",
+      "sentence": "Repetition number of timer _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnNumber"
+              },
+              "parameters": [
+                "Variable(__RepeatEveryXSeconds.Repetitions[TimerName])"
+              ]
+            }
+          ]
+        }
+      ],
+      "expressionType": {
+        "type": "expression"
+      },
+      "parameters": [
+        {
+          "description": "Timer name used to loop",
+          "name": "TimerName",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Triggers every X seconds X amount of times.",
+      "fullName": "Repeat with a scene timer X times",
+      "functionType": "Condition",
+      "name": "RepeatXTimes",
+      "sentence": "Repeat every _PARAM2_ seconds _PARAM3_ times using timer _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Or"
+              },
+              "parameters": [],
+              "subInstructions": [
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
+                  },
+                  "parameters": [
+                    "MaxLoop",
+                    "<",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RepeatEveryXSeconds::Repetition"
+                  },
+                  "parameters": [
+                    "",
+                    "<",
+                    "MaxLoop",
+                    "TimerName",
+                    ""
+                  ]
+                }
+              ]
+            },
+            {
+              "type": {
+                "value": "RepeatEveryXSeconds::Repeat"
+              },
+              "parameters": [
+                "",
+                "TimerName",
+                "LoopDuration",
+                ""
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": {
+                "value": "SetReturnBoolean"
+              },
+              "parameters": [
+                "True"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Timer name used to loop",
+          "name": "TimerName",
+          "type": "string"
+        },
+        {
+          "description": "Duration in seconds between each repetition",
+          "name": "LoopDuration",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "The limit of loops",
-          "longDescription": "The condition will trigger at most this amount of times. Make it -1 for looping forever.",
-          "name": "limit",
-          "optional": false,
-          "supplementaryInformation": "",
+          "longDescription": "Maximum nuber of repetition (-1 to repeat forever).",
+          "name": "MaxLoop",
           "type": "expression"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
+      "description": "Reset repetition count of a scene timer.",
+      "fullName": "Reset repetition count of a scene timer",
+      "functionType": "Action",
+      "name": "DeleteTimer",
+      "sentence": "Reset repetition count for timer _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "RemoveTimer"
+              },
+              "parameters": [
+                "player",
+                "TimerName"
+              ]
+            },
+            {
+              "type": {
+                "value": "VariableRemoveChild"
+              },
+              "parameters": [
+                "__RepeatEveryXSeconds.Repetitions",
+                "TimerName"
+              ]
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "description": "Timer name used to loop",
+          "name": "TimerName",
+          "type": "string"
         }
       ],
       "objectGroups": []
@@ -308,52 +311,36 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "onCreated",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTimerName()"
-                  ],
-                  "subInstructions": []
+                    "TimerName"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
               "type": "behavior"
             }
@@ -361,40 +348,363 @@
           "objectGroups": []
         },
         {
-          "description": "Triggers every X seconds, where X is defined in the behavior properties.",
-          "fullName": "Repeat every X seconds",
+          "description": "Triggers every X seconds.",
+          "fullName": "Repeat with an object timer",
           "functionType": "Condition",
-          "name": "Repeat",
-          "private": false,
-          "sentence": "Recurring timer _PARAM1_ of _PARAM0_ has triggered",
+          "group": "Timers",
+          "name": "Repeat2",
+          "sentence": "Repeat every _PARAM3_ seconds using timer _PARAM2_ of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "ObjectTimer"
+                    "inverted": true,
+                    "value": "CompareObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTimerName()",
-                    "Object.Behavior::PropertyTimerLength()"
-                  ],
-                  "subInstructions": []
+                    "TimerName",
+                    ">=",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TimerName"
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__RepeatEveryXSeconds.Repetitions[TimerName]",
+                    "=",
+                    "0"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "TODO: It should keep the overflowing time to be more precise (it would need JavaScript)"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "CompareObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TimerName",
+                    ">=",
+                    "LoopDuration"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TimerName"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__RepeatEveryXSeconds.Repetitions[TimerName]",
+                    "+",
+                    "1"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "",
+              "name": "Object",
+              "type": "objectList"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
+              "type": "behavior"
+            },
+            {
+              "description": "Timer name used to loop",
+              "name": "TimerName",
+              "type": "string"
+            },
+            {
+              "description": "Duration in seconds between each repetition",
+              "name": "LoopDuration",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "the number of times the timer has repeated.",
+          "fullName": "Repetition number of an object timer",
+          "functionType": "ExpressionAndCondition",
+          "group": "Timers",
+          "name": "Repetition",
+          "sentence": "Repetition number of timer _PARAM2_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "Object.Variable(__RepeatEveryXSeconds.Repetitions[TimerName])"
+                  ]
+                }
+              ]
+            }
+          ],
+          "expressionType": {
+            "type": "expression"
+          },
+          "parameters": [
+            {
+              "description": "",
+              "name": "Object",
+              "type": "objectList"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
+              "type": "behavior"
+            },
+            {
+              "description": "Timer name used to loop",
+              "name": "TimerName",
+              "type": "string"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Triggers every X seconds X amount of times.",
+          "fullName": "Repeat with an object timer X times",
+          "functionType": "Condition",
+          "group": "Timers",
+          "name": "RepeatXTimes",
+          "sentence": "Repeat every _PARAM3_ seconds _PARAM4_ times using timer _PARAM2_ of _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
+                      },
+                      "parameters": [
+                        "MaxLoop",
+                        "<",
+                        "0"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "RepeatEveryXSeconds::RepeatTimer::Repetition"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "<",
+                        "MaxLoop",
+                        "TimerName",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "RepeatEveryXSeconds::RepeatTimer::Repeat2"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "TimerName",
+                    "LoopDuration",
+                    ""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnBoolean"
+                  },
+                  "parameters": [
+                    "True"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "",
+              "name": "Object",
+              "type": "objectList"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
+              "type": "behavior"
+            },
+            {
+              "description": "Timer name used to loop",
+              "name": "TimerName",
+              "type": "string"
+            },
+            {
+              "description": "Duration in seconds between each repetition",
+              "name": "LoopDuration",
+              "type": "expression"
+            },
+            {
+              "description": "The limit of loops",
+              "longDescription": "Maximum nuber of repetition (-1 to repeat forever).",
+              "name": "MaxLoop",
+              "type": "expression"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Reset repetition count of an object timer.",
+          "fullName": "Reset repetition count of an object timer",
+          "functionType": "Action",
+          "group": "Timers",
+          "name": "DeleteTimer",
+          "sentence": "Reset repetition count for timer _PARAM2_ of _PARAM0_",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TimerName"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ObjectVariableRemoveChild"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__RepeatEveryXSeconds.Repetitions",
+                    "TimerName"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "",
+              "name": "Object",
+              "type": "objectList"
+            },
+            {
+              "description": "Behavior",
+              "name": "Behavior",
+              "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
+              "type": "behavior"
+            },
+            {
+              "description": "Timer name used to loop",
+              "name": "TimerName",
+              "type": "string"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Triggers every X seconds, where X is defined in the behavior properties.",
+          "fullName": "Repeat every X seconds (deprecated)",
+          "functionType": "Condition",
+          "name": "Repeat",
+          "private": true,
+          "sentence": "Recurring timer _PARAM1_ of _PARAM0_ has triggered",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "ObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "TimerName",
+                    "TimerLength"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "BuiltinCommonInstructions::Or"
+                  },
+                  "parameters": [],
+                  "subInstructions": [
+                    {
+                      "type": {
                         "value": "RepeatEveryXSeconds::RepeatTimer::PropertyLimit"
                       },
                       "parameters": [
@@ -402,21 +712,18 @@
                         "Behavior",
                         "=",
                         "-1"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "RepeatEveryXSeconds::RepeatTimer::PropertyCounter"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "<",
-                        "Object.Behavior::PropertyLimit()"
-                      ],
-                      "subInstructions": []
+                        "Limit"
+                      ]
                     }
                   ]
                 }
@@ -424,18 +731,15 @@
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTimerName()"
-                  ],
-                  "subInstructions": []
+                    "TimerName"
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "RepeatEveryXSeconds::RepeatTimer::SetPropertyCounter"
                   },
                   "parameters": [
@@ -443,41 +747,28 @@
                     "Behavior",
                     "+",
                     "1"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
               "type": "behavior"
             }
@@ -486,51 +777,37 @@
         },
         {
           "description": "Pauses a recurring timer.",
-          "fullName": "Pause a recurring timer",
+          "fullName": "Pause a recurring timer (deprecated)",
           "functionType": "Action",
           "name": "Pause",
-          "private": false,
+          "private": true,
           "sentence": "Pause recurring timer _PARAM1_ of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTimerName()"
-                  ],
-                  "subInstructions": []
+                    "TimerName"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
               "type": "behavior"
             }
@@ -539,51 +816,37 @@
         },
         {
           "description": "Resumes a paused recurring timer.",
-          "fullName": "Resume a recurring timer",
+          "fullName": "Resume a recurring timer (deprecated)",
           "functionType": "Action",
           "name": "Resume",
-          "private": false,
+          "private": true,
           "sentence": "Resume recurring timer _PARAM1_ of _PARAM0_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "UnPauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "Object.Behavior::PropertyTimerName()"
-                  ],
-                  "subInstructions": []
+                    "TimerName"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
               "type": "behavior"
             }
@@ -592,21 +855,18 @@
         },
         {
           "description": "Allows to trigger the recurring timer X times again.",
-          "fullName": "Reset the limit",
+          "fullName": "Reset the limit (deprecated)",
           "functionType": "Action",
           "name": "ResetLimit",
-          "private": false,
+          "private": true,
           "sentence": "Allow to trigger the recurring timer _PARAM1_ of _PARAM0_ X times again",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "RepeatEveryXSeconds::RepeatTimer::SetPropertyCounter"
                   },
                   "parameters": [
@@ -614,31 +874,20 @@
                     "Behavior",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "RepeatEveryXSeconds::RepeatTimer",
               "type": "behavior"
             }
@@ -652,8 +901,9 @@
           "type": "String",
           "label": "The name of the timer to repeat",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
+          "deprecated": true,
           "name": "TimerName"
         },
         {
@@ -661,8 +911,9 @@
           "type": "Number",
           "label": "The time between each trigger (in seconds)",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
+          "deprecated": true,
           "name": "TimerLength"
         },
         {
@@ -670,8 +921,9 @@
           "type": "Number",
           "label": "How many times should the timer trigger? -1 for forever.",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
+          "deprecated": true,
           "name": "Limit"
         },
         {
@@ -679,11 +931,14 @@
           "type": "Number",
           "label": "An internal counter",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Counter"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
### Changes
- Deprecate the properties and use parameters instead to allow to use several object timers
- Add scene/object in names to tell conditions apart in search results
- Remove usages of "trigger once" as it has unexpected result in functions
- Add an expression and condition to check the number of repetition done
- Add an action to reset the repetition counter and delete the timer
- Some wording

### Demo
- https://editor.gdevelop.io?project=https://raw.githubusercontent.com/D8H/GDevelop-examples/repeat/examples/TestRepeat/TestRepeat.json