### PR TITLE
[Reviewed] [Transition] Fix the animation for zoomed layers

### DIFF
--- a/extensions/reviewed/FlashTransitionPainter.json
+++ b/extensions/reviewed/FlashTransitionPainter.json
@@ -8,7 +8,7 @@
   "name": "FlashTransitionPainter",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/movie-filter.svg",
   "shortDescription": "Behavior for shape painter allows you to paint a color all over the screen for period of time with an effect (useful for simulate flash and transition effect).",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": [
     "* __Paint effect:__ Action to paint a color all over the screen for a period of time with specific effect.",
     "effect type:",
@@ -72,11 +72,24 @@
                 },
                 {
                   "type": {
-                    "value": "PauseObjectTimer"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyType"
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_timerEffect\""
+                    "Behavior",
+                    "=",
+                    "\"Flash\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyMaxOpacity"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "255"
                   ]
                 }
               ]
@@ -114,7 +127,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Avoid default parameter of painter that could make the extension doesn't work."
+              "comment": "Avoid default parameter of painter that could make the extension not work."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -148,35 +161,14 @@
                 },
                 {
                   "type": {
-                    "value": "ResetObjectTimer"
+                    "value": "PrimitiveDrawing::UseRelativeCoordinates"
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_timerEffect\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "UnPauseObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"__FlashTransitionPainter_timerEffect\""
+                    ""
                   ]
                 }
               ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Initialise position of painter. \nIncrement or decrement \"_TimeProgressionEffect\" depending on direction."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -184,34 +176,21 @@
               "actions": [
                 {
                   "type": {
-                    "value": "MettreXY"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyProgress"
                   },
                   "parameters": [
                     "Object",
+                    "Behavior",
                     "=",
-                    "CameraX(Object.Layer(),0) - SceneWindowWidth()/2",
-                    "=",
-                    "CameraY(Object.Layer(),0) - SceneWindowHeight()/2"
+                    "min(1, Object.ObjectTimerElapsedTime(\"__FlashTransitionPainter_Time\") / Duration)"
                   ]
                 },
                 {
                   "type": {
-                    "value": "PrimitiveDrawing::FillColor"
+                    "value": "PrimitiveDrawing::Drawer::ClearShapes"
                   },
                   "parameters": [
-                    "Object",
-                    "Object.Behavior::PropertyColor()"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__FlashTransitionPainter_TimeProgressionEffect",
-                    "+",
-                    "(TimeDelta() / Timer)*Object.Variable(__FlashTransitionPainter_ReverseDirection)"
+                    "Object"
                   ]
                 }
               ]
@@ -221,72 +200,13 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "VarObjet"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyProgress"
                   },
                   "parameters": [
                     "Object",
-                    "__FlashTransitionPainter_TimeProgressionEffect",
-                    ">=",
+                    "Behavior",
+                    "=",
                     "1"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__FlashTransitionPainter_ReverseDirection",
-                    "=",
-                    "-1"
-                  ]
-                }
-              ],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"Forward\""
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "VarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__FlashTransitionPainter_TimeProgressionEffect",
-                    "<",
-                    "0"
                   ]
                 }
               ],
@@ -300,569 +220,473 @@
                     "Behavior",
                     ""
                   ]
+                },
+                {
+                  "type": {
+                    "value": "RemoveObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"__FlashTransitionPainter_Time\""
+                  ]
                 }
               ]
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "\"Backward\""
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
-                    "value": "PrimitiveDrawing::Drawer::ClearShapes"
-                  },
-                  "parameters": [
-                    "Object"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Here this the paints functions of different effect depending on the type chosen by the user.\nDetect the direction of the animation and its end."
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Type 1 : flash effect. "
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::Or"
-                  },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"Flash\""
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_OpacityFlash",
-                        "=",
-                        "lerp(0, MaxOpacity, Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::FillOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Variable(__FlashTransitionPainter_OpacityFlash)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::Rectangle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "CameraX(Object.Layer(),0) - SceneWindowWidth()/2",
-                        "CameraY(Object.Layer(),0) - SceneWindowHeight()/2",
-                        "SceneWindowWidth()",
-                        "SceneWindowHeight()"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Type 2 : screen come from top then return."
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyProgress"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "\"Horizontal\""
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "=",
-                        "10"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        "=",
-                        "lerp(0,SceneWindowWidth(),Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Repeat",
-                  "repeatExpression": "5",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "-",
-                        "2"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "+",
-                        "51"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::FillOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::Rectangle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "0",
-                        "0",
-                        "Object.Variable(__FlashTransitionPainter_ProgressiveWidth) + Object.Variable(__FlashTransitionPainter_SmoothEdge)",
-                        "SceneWindowHeight()"
-                      ]
-                    }
+                    "1 - Progress"
                   ]
                 }
               ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Type 3 : screen come from left then return."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "\"Vertical\""
+                    "\"Both\""
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "=",
-                        "10"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveHeight",
-                        "=",
-                        "lerp(0,SceneWindowHeight(),Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Repeat",
-                  "repeatExpression": "5",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "-",
-                        "2"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "+",
-                        "51"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::FillOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::Rectangle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "0",
-                        "0",
-                        "SceneWindowWidth()",
-                        "Object.Variable(__FlashTransitionPainter_ProgressiveHeight) + Object.Variable(__FlashTransitionPainter_SmoothEdge)"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Type 4 : a circle scale up from the middle then scale down."
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"Circular\""
-                  ]
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "=",
-                        "1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "=",
-                        "0"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        "=",
-                        "lerp(0,(sqrt (pow(SceneWindowHeight(),2) + pow(SceneWindowWidth(),2) ))/2    ,Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "The repeat 5 times is used to have clean and smooth edges , especially for circle.\n"
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Repeat",
-                  "repeatExpression": "5",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdge",
-                        "-",
-                        "0.2"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_SmoothEdgeOpacity",
-                        "+",
-                        "51"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::FillOpacity"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PrimitiveDrawing::Circle"
-                      },
-                      "parameters": [
-                        "Object",
-                        "SceneWindowWidth()/2",
-                        "SceneWindowHeight()/2",
-                        "Object.Variable(__FlashTransitionPainter_ProgressiveWidth) + Object.Variable(__FlashTransitionPainter_SmoothEdge)"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "parameters": [
-            {
-              "description": "Object",
-              "name": "Object",
-              "supplementaryInformation": "PrimitiveDrawing::Drawer",
-              "type": "object"
-            },
-            {
-              "description": "Behavior",
-              "name": "Behavior",
-              "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
-              "type": "behavior"
-            }
-          ],
-          "objectGroups": []
-        },
-        {
-          "fullName": "",
-          "functionType": "Action",
-          "name": "onDeActivate",
-          "sentence": "",
-          "events": [
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Reset variables."
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarObjet"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyProgress"
                   },
                   "parameters": [
                     "Object",
-                    "__FlashTransitionPainter_OpacityFlash",
+                    "Behavior",
                     "=",
-                    "0"
+                    "min(2 * Progress, 2 * (1 - Progress))"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarObjet"
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyProgress"
                   },
                   "parameters": [
                     "Object",
-                    "__FlashTransitionPainter_ReverseDirection",
-                    "=",
-                    "1"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__FlashTransitionPainter_TimeProgressionEffect",
-                    "=",
+                    "Behavior",
+                    ">",
                     "0"
                   ]
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Flash",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Flash\""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::FillOpacity"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "MaxOpacity * Progress"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "Object",
+                            "CameraBorderLeft(Object.Layer())",
+                            "CameraBorderTop(Object.Layer())",
+                            "CameraBorderRight(Object.Layer())",
+                            "CameraBorderBottom(Object.Layer())"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Horizontal",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Screen come from top then return."
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Horizontal\""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(CameraBorderLeft(Object.Layer()), CameraBorderRight(Object.Layer()) + 10, Progress)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "5",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "51 * Index"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "CameraBorderLeft(Object.Layer())",
+                                "CameraBorderTop(Object.Layer())",
+                                "Value - 2 * Index",
+                                "CameraBorderBottom(Object.Layer())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Vertical",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Screen come from left then return."
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Vertical\""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "lerp(CameraBorderTop(Object.Layer()), CameraBorderBottom(Object.Layer()) + 10, Progress)"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "5",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "51 * Index"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Rectangle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "CameraBorderLeft(Object.Layer())",
+                                "CameraBorderTop(Object.Layer())",
+                                "CameraBorderRight(Object.Layer())",
+                                "Value - 2 * Index"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Circular",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "A circle scale up from the middle then scale down."
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "\"Circular\""
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "(DistanceBetweenPositions(0, 0, CameraWidth(), CameraHeight()) / 2 + 1) * Progress"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "The repeat 5 times is used to have clean and smooth edges, especially for circle.\n"
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "5",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::FillOpacity"
+                              },
+                              "parameters": [
+                                "Object",
+                                "=",
+                                "51 * Index"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::Circle"
+                              },
+                              "parameters": [
+                                "Object",
+                                "CameraCenterX(Object.Layer())",
+                                "CameraCenterY(Object.Layer())",
+                                "Value - 0.2 * Index"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
                 }
               ]
             }
@@ -900,21 +724,33 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Initialise all variables and then activate the behavior.\nIf user doesn't assign value to color and type , we take the last value registred.\nIf user doesn't assign value to timer we take a default value (0.2)."
+              "comment": "Initialise all variables and then activate the behavior.\nIf user doesn't assign value to color and type , we take the last value registred."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": true,
+                    "value": "CompareObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"__FlashTransitionPainter_Time\"",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
-                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
+                    "value": "ActivateBehavior"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "=",
-                    "Duration + (3*TimeDelta())"
+                    "yes"
                   ]
                 },
                 {
@@ -923,7 +759,18 @@
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_timerEffect\""
+                    "\"__FlashTransitionPainter_Time\""
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyDuration"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "Duration"
                   ]
                 },
                 {
@@ -935,17 +782,6 @@
                     "Behavior",
                     "=",
                     "Direction"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarObjet"
-                  },
-                  "parameters": [
-                    "Object",
-                    "__FlashTransitionPainter_ReverseDirection",
-                    "=",
-                    "1"
                   ]
                 }
               ],
@@ -995,110 +831,11 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyColor"
+                        "value": "PrimitiveDrawing::FillColor"
                       },
                       "parameters": [
                         "Object",
-                        "Behavior",
-                        "=",
                         "Color"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "0"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "0.2"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"Both\""
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "Duration / 2 + (3*TimeDelta())"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "CompareArgumentAsString"
-                      },
-                      "parameters": [
-                        "\"Direction\"",
-                        "=",
-                        "\"Backward\""
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ReverseDirection",
-                        "=",
-                        "-1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_TimeProgressionEffect",
-                        "=",
-                        "1"
                       ]
                     }
                   ]
@@ -1127,22 +864,6 @@
                         "Behavior",
                         "=",
                         "MaxOpacity"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "yes"
                       ]
                     }
                   ]
@@ -1201,94 +922,17 @@
           "sentence": "When paint effect of _PARAM0_ ends",
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Detect when the animation ends with a timer which is initialised in PaintEffect function."
-            },
-            {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "BuiltinCommonInstructions::Or"
-                  },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"Backward\""
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        "=",
-                        "\"Forward\""
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ObjectTimer"
+                    "value": "CompareObjectTimer"
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_timerEffect\"",
-                    "Object.Behavior::PropertyTimer() - (3*TimeDelta())"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "SetReturnBoolean"
-                  },
-                  "parameters": [
-                    "True"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    "=",
-                    "\"Both\""
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ObjectTimer"
-                  },
-                  "parameters": [
-                    "Object",
-                    "\"__FlashTransitionPainter_timerEffect\"",
-                    "Object.Behavior::PropertyTimer()*2 - (3*TimeDelta())"
+                    "\"__FlashTransitionPainter_Time\"",
+                    ">=",
+                    "Duration"
                   ]
                 }
               ],
@@ -1323,24 +967,25 @@
       ],
       "propertyDescriptors": [
         {
-          "value": "1",
+          "value": "0",
           "type": "Number",
-          "label": "Timer",
+          "unit": "Dimensionless",
+          "label": "",
           "description": "",
           "group": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "Timer"
+          "name": "Progress"
         },
         {
-          "value": "255;255;255",
-          "type": "String",
-          "label": "Color",
+          "value": "",
+          "type": "Number",
+          "label": "",
           "description": "",
           "group": "",
           "extraInformation": [],
           "hidden": true,
-          "name": "Color"
+          "name": "Duration"
         },
         {
           "value": "",
@@ -1371,6 +1016,26 @@
           "extraInformation": [],
           "hidden": true,
           "name": "MaxOpacity"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Index"
+        },
+        {
+          "value": "0",
+          "type": "Number",
+          "label": "",
+          "description": "",
+          "group": "",
+          "extraInformation": [],
+          "hidden": true,
+          "name": "Value"
         }
       ],
       "sharedPropertyDescriptors": []

--- a/extensions/reviewed/FlashTransitionPainter.json
+++ b/extensions/reviewed/FlashTransitionPainter.json
@@ -1,7 +1,6 @@
 {
   "author": "Westboy31",
   "category": "Visual effect",
-  "description": "* __Paint effect:__ Action to paint a color all over the screen for a period of time with specific effect.\neffect type:\n    * __Flash:__ is a monochrome color appear with fade then disappear with fade out.\n    * __Vertical:__ is a monochrome color comes from right side then comes back.\n    * __Horizontal:__ is a monochrome color come from top side then comes back.\n    * __Circular:__ is a circle which increases from the center and narrows.\n* __Paint effect ended:__ event when the paint effect ends.",
   "extensionNamespace": "",
   "fullName": "Flash and transition painter",
   "helpPath": "",
@@ -10,12 +9,26 @@
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/movie-filter.svg",
   "shortDescription": "Behavior for shape painter allows you to paint a color all over the screen for period of time with an effect (useful for simulate flash and transition effect).",
   "version": "0.1.0",
-  "tags": [
-    "Shape Painter",
-    "Flash",
-    "Transition",
-    "Effect"
+  "description": [
+    "* __Paint effect:__ Action to paint a color all over the screen for a period of time with specific effect.",
+    "effect type:",
+    "    * __Flash:__ is a monochrome color appear with fade then disappear with fade out.",
+    "    * __Vertical:__ is a monochrome color comes from right side then comes back.",
+    "    * __Horizontal:__ is a monochrome color come from top side then comes back.",
+    "    * __Circular:__ is a circle which increases from the center and narrows.",
+    "* __Paint effect ended:__ event when the paint effect ends."
   ],
+  "origin": {
+    "identifier": "FlashTransitionPainter",
+    "name": "gdevelop-extension-store"
+  },
+  "tags": [
+    "shape painter",
+    "flash",
+    "transition",
+    "effect"
+  ],
+  "authorIds": [],
   "dependencies": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
@@ -26,16 +39,12 @@
       "objectType": "PrimitiveDrawing::Drawer",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "onCreated",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -45,60 +54,44 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Disable effect when the game starts.",
-              "comment2": ""
+              "comment": "Disable effect when the game starts."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ActivateBehavior"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "PrimitiveDrawing::Drawer",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
               "type": "behavior"
             }
@@ -106,16 +99,12 @@
           "objectGroups": []
         },
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "doStepPostEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -125,75 +114,59 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Avoid default parameter of painter that could make the extension doesn't work.",
-              "comment2": ""
+              "comment": "Avoid default parameter of painter that could make the extension doesn't work."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": []
+                  "parameters": []
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PrimitiveDrawing::ClearBetweenFrames"
                   },
                   "parameters": [
                     "Object",
-                    "yes"
-                  ],
-                  "subInstructions": []
+                    "no"
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PrimitiveDrawing::OutlineSize"
                   },
                   "parameters": [
                     "Object",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "UnPauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -203,18 +176,14 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Initialise position of painter. \nIncrement or decrement \"_TimeProgressionEffect\" depending on direction.",
-              "comment2": ""
+              "comment": "Initialise position of painter. \nIncrement or decrement \"_TimeProgressionEffect\" depending on direction."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MettreXY"
                   },
                   "parameters": [
@@ -223,81 +192,166 @@
                     "CameraX(Object.Layer(),0) - SceneWindowWidth()/2",
                     "=",
                     "CameraY(Object.Layer(),0) - SceneWindowHeight()/2"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "PrimitiveDrawing::FillColor"
                   },
                   "parameters": [
                     "Object",
                     "Object.Behavior::PropertyColor()"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
                     "Object",
                     "__FlashTransitionPainter_TimeProgressionEffect",
                     "+",
-                    "(TimeDelta() / Object.Behavior::PropertyTimer())*Object.Variable(__FlashTransitionPainter_ReverseDirection)"
-                  ],
-                  "subInstructions": []
+                    "(TimeDelta() / Timer)*Object.Variable(__FlashTransitionPainter_ReverseDirection)"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Here this the paints functions of different effect depending on the type chosen by the user.\nDetect the direction of the animation and its end.",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Type 1 : flash effect. ",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
+                    "value": "VarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__FlashTransitionPainter_TimeProgressionEffect",
+                    ">=",
+                    "1"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__FlashTransitionPainter_ReverseDirection",
+                    "=",
+                    "-1"
+                  ]
+                }
+              ],
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "\"Forward\""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ActivateBehavior"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__FlashTransitionPainter_TimeProgressionEffect",
+                    "<",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ActivateBehavior"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ""
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PrimitiveDrawing::Drawer::ClearShapes"
+                  },
+                  "parameters": [
+                    "Object"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Here this the paints functions of different effect depending on the type chosen by the user.\nDetect the direction of the animation and its end."
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Type 1 : flash effect. "
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
                       },
                       "parameters": [
@@ -305,12 +359,10 @@
                         "Behavior",
                         "=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
                       },
                       "parameters": [
@@ -318,8 +370,7 @@
                         "Behavior",
                         "=",
                         "\"Flash\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -327,146 +378,32 @@
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_OpacityFlash",
-                        ">=",
-                        "Object.Behavior::PropertyMaxOpacity()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ReverseDirection",
-                        "=",
-                        "-1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Forward\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ActivateBehavior"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_OpacityFlash",
-                        "<",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
                         "Object",
                         "__FlashTransitionPainter_OpacityFlash",
                         "=",
-                        "lerp(0, Object.Behavior::PropertyMaxOpacity(), Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ],
-                      "subInstructions": []
+                        "lerp(0, MaxOpacity, Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::FillOpacity"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "Object.Variable(__FlashTransitionPainter_OpacityFlash)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Rectangle"
                       },
                       "parameters": [
@@ -475,17 +412,13 @@
                         "CameraY(Object.Layer(),0) - SceneWindowHeight()/2",
                         "SceneWindowWidth()",
                         "SceneWindowHeight()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -495,17 +428,13 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Type 2 : screen come from top then return.",
-              "comment2": ""
+              "comment": "Type 2 : screen come from top then return."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
                   },
                   "parameters": [
@@ -513,128 +442,17 @@
                     "Behavior",
                     "=",
                     "\"Horizontal\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        ">=",
-                        "SceneWindowWidth()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ReverseDirection",
-                        "=",
-                        "-1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Forward\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ActivateBehavior"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        "<",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -642,12 +460,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "=",
                         "10"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -655,12 +471,10 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -668,22 +482,17 @@
                         "__FlashTransitionPainter_ProgressiveWidth",
                         "=",
                         "lerp(0,SceneWindowWidth(),Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Repeat",
                   "repeatExpression": "5",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -691,12 +500,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "-",
                         "2"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -704,24 +511,20 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "+",
                         "51"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::FillOpacity"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Rectangle"
                       },
                       "parameters": [
@@ -730,17 +533,13 @@
                         "0",
                         "Object.Variable(__FlashTransitionPainter_ProgressiveWidth) + Object.Variable(__FlashTransitionPainter_SmoothEdge)",
                         "SceneWindowHeight()"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -750,17 +549,13 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Type 3 : screen come from left then return.",
-              "comment2": ""
+              "comment": "Type 3 : screen come from left then return."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
                   },
                   "parameters": [
@@ -768,128 +563,17 @@
                     "Behavior",
                     "=",
                     "\"Vertical\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveHeight",
-                        ">=",
-                        "SceneWindowHeight()"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ReverseDirection",
-                        "=",
-                        "-1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Forward\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ActivateBehavior"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveHeight",
-                        "<",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -897,12 +581,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "=",
                         "10"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -910,12 +592,10 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -923,22 +603,17 @@
                         "__FlashTransitionPainter_ProgressiveHeight",
                         "=",
                         "lerp(0,SceneWindowHeight(),Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Repeat",
                   "repeatExpression": "5",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -946,12 +621,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "-",
                         "2"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -959,24 +632,20 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "+",
                         "51"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::FillOpacity"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Rectangle"
                       },
                       "parameters": [
@@ -985,17 +654,13 @@
                         "0",
                         "SceneWindowWidth()",
                         "Object.Variable(__FlashTransitionPainter_ProgressiveHeight) + Object.Variable(__FlashTransitionPainter_SmoothEdge)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1005,17 +670,13 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Type 4 : a circle scale up from the middle then scale down.",
-              "comment2": ""
+              "comment": "Type 4 : a circle scale up from the middle then scale down."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyType"
                   },
                   "parameters": [
@@ -1023,128 +684,17 @@
                     "Behavior",
                     "=",
                     "\"Circular\""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        ">=",
-                        "(sqrt (pow(SceneWindowHeight(),2) + pow(SceneWindowWidth(),2) )) /2    "
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ReverseDirection",
-                        "=",
-                        "-1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            "=",
-                            "\"Forward\""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ActivateBehavior"
-                          },
-                          "parameters": [
-                            "Object",
-                            "Behavior",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__FlashTransitionPainter_ProgressiveWidth",
-                        "<",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ActivateBehavior"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Behavior",
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1152,12 +702,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "=",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1165,12 +713,10 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1178,22 +724,29 @@
                         "__FlashTransitionPainter_ProgressiveWidth",
                         "=",
                         "lerp(0,(sqrt (pow(SceneWindowHeight(),2) + pow(SceneWindowWidth(),2) ))/2    ,Object.Variable(__FlashTransitionPainter_TimeProgressionEffect))"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "The repeat 5 times is used to have clean and smooth edges , especially for circle.\n"
+                },
+                {
                   "type": "BuiltinCommonInstructions::Repeat",
                   "repeatExpression": "5",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1201,12 +754,10 @@
                         "__FlashTransitionPainter_SmoothEdge",
                         "-",
                         "0.2"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1214,24 +765,20 @@
                         "__FlashTransitionPainter_SmoothEdgeOpacity",
                         "+",
                         "51"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::FillOpacity"
                       },
                       "parameters": [
                         "Object",
                         "=",
                         "Object.Variable(__FlashTransitionPainter_SmoothEdgeOpacity)"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PrimitiveDrawing::Circle"
                       },
                       "parameters": [
@@ -1239,48 +786,23 @@
                         "SceneWindowWidth()/2",
                         "SceneWindowHeight()/2",
                         "Object.Variable(__FlashTransitionPainter_ProgressiveWidth) + Object.Variable(__FlashTransitionPainter_SmoothEdge)"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "The repeat 5 times is used to have clean and smooth edges , especially for circle.\n",
-              "comment2": ""
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "PrimitiveDrawing::Drawer",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
               "type": "behavior"
             }
@@ -1288,16 +810,12 @@
           "objectGroups": []
         },
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "onDeActivate",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1307,18 +825,14 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Reset variables.",
-              "comment2": ""
+              "comment": "Reset variables."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -1326,12 +840,10 @@
                     "__FlashTransitionPainter_OpacityFlash",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -1339,12 +851,10 @@
                     "__FlashTransitionPainter_ReverseDirection",
                     "=",
                     "1"
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ModVarObjet"
                   },
                   "parameters": [
@@ -1352,31 +862,21 @@
                     "__FlashTransitionPainter_TimeProgressionEffect",
                     "=",
                     "0"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "PrimitiveDrawing::Drawer",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
               "type": "behavior"
             }
@@ -1388,12 +888,9 @@
           "fullName": "Paint Effect",
           "functionType": "Action",
           "name": "PaintEffect",
-          "private": false,
           "sentence": "Paint effect type _PARAM4_ of _PARAM0_ with direction _PARAM5_ and color _PARAM2_ for _PARAM3_ seconds",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1403,152 +900,117 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Initialise all variables and then activate the behavior.\nIf user doesn't assign value to color and type , we take the last value registred.\nIf user doesn't assign value to timer we take a default value (0.2).",
-              "comment2": ""
+              "comment": "Initialise all variables and then activate the behavior.\nIf user doesn't assign value to color and type , we take the last value registred.\nIf user doesn't assign value to timer we take a default value (0.2)."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "BehaviorActivated"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior"
-                  ],
-                  "subInstructions": []
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Timer\") + (3*TimeDelta())"
-                  ],
-                  "subInstructions": []
+                    "Duration + (3*TimeDelta())"
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ResetObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyDirection"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsString(\"Direction\")"
-                  ],
-                  "subInstructions": []
+                    "Direction"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "ModVarObjet"
+                  },
+                  "parameters": [
+                    "Object",
+                    "__FlashTransitionPainter_ReverseDirection",
+                    "=",
+                    "1"
+                  ]
                 }
               ],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
+                        "value": "CompareArgumentAsString"
                       },
                       "parameters": [
-                        "GetArgumentAsString(\"Type\")",
+                        "\"Type\"",
                         "!=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyType"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "GetArgumentAsString(\"Type\")"
-                      ],
-                      "subInstructions": []
+                        "Type"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
+                        "value": "CompareArgumentAsString"
                       },
                       "parameters": [
-                        "GetArgumentAsString(\"Color\")",
+                        "\"Color\"",
                         "!=",
                         "\"\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyColor"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "GetArgumentAsString(\"Color\")"
-                      ],
-                      "subInstructions": []
+                        "Color"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyTimer"
                       },
                       "parameters": [
@@ -1556,14 +1018,12 @@
                         "Behavior",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
                       },
                       "parameters": [
@@ -1571,20 +1031,15 @@
                         "Behavior",
                         "=",
                         "0.2"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
                       },
                       "parameters": [
@@ -1592,49 +1047,40 @@
                         "Behavior",
                         "=",
                         "\"Both\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyTimer"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "GetArgumentAsNumber(\"Timer\")/2 + (3*TimeDelta())"
-                      ],
-                      "subInstructions": []
+                        "Duration / 2 + (3*TimeDelta())"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
+                        "value": "CompareArgumentAsString"
                       },
                       "parameters": [
-                        "GetArgumentAsString(\"Direction\")",
+                        "\"Direction\"",
                         "=",
                         "\"Backward\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1642,12 +1088,10 @@
                         "__FlashTransitionPainter_ReverseDirection",
                         "=",
                         "-1"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ModVarObjet"
                       },
                       "parameters": [
@@ -1655,140 +1099,95 @@
                         "__FlashTransitionPainter_TimeProgressionEffect",
                         "=",
                         "1"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "Egal"
+                        "value": "CompareArgumentAsNumber"
                       },
                       "parameters": [
-                        "GetArgumentAsNumber(\"MaxOpacity\")",
+                        "\"MaxOpacity\"",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyMaxOpacity"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "GetArgumentAsNumber(\"MaxOpacity\")"
-                      ],
-                      "subInstructions": []
+                        "MaxOpacity"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "ActivateBehavior"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "PrimitiveDrawing::Drawer",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Color",
-              "longDescription": "",
               "name": "Color",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "color"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Duration",
-              "longDescription": "",
-              "name": "Timer",
-              "optional": false,
-              "supplementaryInformation": "",
+              "name": "Duration",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Type of effect ",
-              "longDescription": "",
               "name": "Type",
-              "optional": false,
               "supplementaryInformation": "[\"Flash\",\"Horizontal\",\"Vertical\",\"Circular\"]",
               "type": "stringWithSelector"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Direction transition",
-              "longDescription": "",
               "name": "Direction",
-              "optional": false,
               "supplementaryInformation": "[\"Both\",\"Forward\",\"Backward\"]",
               "type": "stringWithSelector"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "End opacity (only for flash)",
-              "longDescription": "",
               "name": "MaxOpacity",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -1799,12 +1198,9 @@
           "fullName": "Paint effect ended ",
           "functionType": "Condition",
           "name": "PaintEffectIsEnd",
-          "private": false,
           "sentence": "When paint effect of _PARAM0_ ends",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1814,24 +1210,19 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Detect when the animation ends with a timer which is initialised in PaintEffect function.",
-              "comment2": ""
+              "comment": "Detect when the animation ends with a timer which is initialised in PaintEffect function."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::Or"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
                       },
                       "parameters": [
@@ -1839,12 +1230,10 @@
                         "Behavior",
                         "=",
                         "\"Backward\""
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
                       },
                       "parameters": [
@@ -1852,46 +1241,37 @@
                         "Behavior",
                         "=",
                         "\"Forward\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\"",
                     "Object.Behavior::PropertyTimer() - (3*TimeDelta())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "FlashTransitionPainter::FlashTransitionPainter::PropertyDirection"
                   },
                   "parameters": [
@@ -1899,55 +1279,41 @@
                     "Behavior",
                     "=",
                     "\"Both\""
-                  ],
-                  "subInstructions": []
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "ObjectTimer"
                   },
                   "parameters": [
                     "Object",
                     "\"__FlashTransitionPainter_timerEffect\"",
                     "Object.Behavior::PropertyTimer()*2 - (3*TimeDelta())"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
               "supplementaryInformation": "PrimitiveDrawing::Drawer",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "FlashTransitionPainter::FlashTransitionPainter",
               "type": "behavior"
             }
@@ -1961,6 +1327,7 @@
           "type": "Number",
           "label": "Timer",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Timer"
@@ -1970,6 +1337,7 @@
           "type": "String",
           "label": "Color",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Color"
@@ -1979,6 +1347,7 @@
           "type": "String",
           "label": "Type of effect ",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Type"
@@ -1988,6 +1357,7 @@
           "type": "String",
           "label": "Direction of transition",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Direction"
@@ -1997,11 +1367,14 @@
           "type": "Number",
           "label": "The maximum of the opacity only for flash",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "MaxOpacity"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/FlashTransitionPainter.json
+++ b/extensions/reviewed/FlashTransitionPainter.json
@@ -23,7 +23,6 @@
     "name": "gdevelop-extension-store"
   },
   "tags": [
-    "shape painter",
     "flash",
     "transition",
     "effect"
@@ -44,18 +43,6 @@
           "name": "onCreated",
           "sentence": "",
           "events": [
-            {
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Disable effect when the game starts."
-            },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
@@ -127,7 +114,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Avoid default parameter of painter that could make the extension not work."
+              "comment": "Ensure shape painter properties are set correctly for this extension to work.\n"
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -223,7 +210,7 @@
                 },
                 {
                   "type": {
-                    "value": "RemoveObjectTimer"
+                    "value": "PauseObjectTimer"
                   },
                   "parameters": [
                     "Object",
@@ -378,7 +365,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Screen come from top then return."
+                      "comment": "from left to right"
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -420,6 +407,18 @@
                         }
                       ],
                       "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Smooth edges\n"
+                        },
                         {
                           "type": "BuiltinCommonInstructions::Repeat",
                           "repeatExpression": "5",
@@ -484,7 +483,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Screen come from left then return."
+                      "comment": "from top to bottom"
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -526,6 +525,18 @@
                         }
                       ],
                       "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Smooth edges\n"
+                        },
                         {
                           "type": "BuiltinCommonInstructions::Repeat",
                           "repeatExpression": "5",
@@ -590,7 +601,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "A circle scale up from the middle then scale down."
+                      "comment": "A circle scale up from the middle."
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -642,7 +653,7 @@
                             "textG": 0,
                             "textR": 0
                           },
-                          "comment": "The repeat 5 times is used to have clean and smooth edges, especially for circle.\n"
+                          "comment": "Smooth edges\n"
                         },
                         {
                           "type": "BuiltinCommonInstructions::Repeat",
@@ -732,13 +743,11 @@
                 {
                   "type": {
                     "inverted": true,
-                    "value": "CompareObjectTimer"
+                    "value": "BehaviorActivated"
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_Time\"",
-                    ">",
-                    "0"
+                    "Behavior"
                   ]
                 }
               ],
@@ -751,6 +760,15 @@
                     "Object",
                     "Behavior",
                     "yes"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "UnPauseObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"__FlashTransitionPainter_Time\""
                   ]
                 },
                 {
@@ -782,6 +800,17 @@
                     "Behavior",
                     "=",
                     "Direction"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "FlashTransitionPainter::FlashTransitionPainter::SetPropertyProgress"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    "=",
+                    "0"
                   ]
                 }
               ],
@@ -926,13 +955,11 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "CompareObjectTimer"
+                    "value": "ObjectTimerPaused"
                   },
                   "parameters": [
                     "Object",
-                    "\"__FlashTransitionPainter_Time\"",
-                    ">=",
-                    "Duration"
+                    "\"__FlashTransitionPainter_Time\""
                   ]
                 }
               ],
@@ -978,7 +1005,7 @@
           "name": "Progress"
         },
         {
-          "value": "",
+          "value": "0",
           "type": "Number",
           "label": "",
           "description": "",


### PR DESCRIPTION
### Demo
- [Transition.zip](https://github.com/GDevelopApp/GDevelop-extensions/files/15051358/Transition.zip)

### Changes
- Fix the animation for zoomed layers
- Always keep the last frame when `"Forwoard"` is chosen
- Simplify the events

### Todo
- Add a property for the smoothing radius
- Use the shape painter color and opacity instead of the parameters
- Use easing
  - Make 3 actions:
    - Fade in
    - Fade out
    - Fade in and out
      - with 2 durations and 2 easing and a pause