### PR TITLE
[Reviewed] [Boids Movement] Fix typo of VelocityX and VelocityY being swapped

### DIFF
--- a/extensions/reviewed/BoidsMovement.json
+++ b/extensions/reviewed/BoidsMovement.json
@@ -8,7 +8,7 @@
   "name": "BoidsMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Restaurant/Restaurant_restaurant_seafood_animal_fish.svg",
   "shortDescription": "Simulates flocks movement.",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": [
     "Simulates swarms or flocks movement following the separation, alignment, cohesion principles. The flock can be attracted to a location or avoid some obstacles.",
     "",
@@ -995,7 +995,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "(Object.Behavior::VelocityY() * (Object.CenterY() - CenterY) + Object.Behavior::VelocityX() * (CenterX - Object.CenterX())) / Object.Behavior::Speed()"
+                    "(Object.Behavior::VelocityX() * (Object.CenterY() - CenterY) + Object.Behavior::VelocityY() * (CenterX - Object.CenterX())) / Object.Behavior::Speed()"
                   ]
                 }
               ]
@@ -1269,7 +1269,7 @@
           "description": "Return the current vertical speed.",
           "fullName": "Velocity Y",
           "functionType": "Expression",
-          "name": "VelocityY",
+          "name": "VelocityX",
           "sentence": "",
           "events": [
             {
@@ -1282,7 +1282,7 @@
                 "const directionY = eventsFunctionContext.getArgument(\"DirectionY\");",
                 "const decisionWeight = eventsFunctionContext.getArgument(\"DecisionWeight\");",
                 "",
-                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.y;"
+                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.x;"
               ],
               "parameterObjects": "Object",
               "useStrict": true,
@@ -1311,7 +1311,7 @@
           "description": "Return the current horizontal speed.",
           "fullName": "Velocity X",
           "functionType": "Expression",
-          "name": "VelocityX",
+          "name": "VelocityY",
           "sentence": "",
           "events": [
             {
@@ -1324,7 +1324,7 @@
                 "const directionY = eventsFunctionContext.getArgument(\"DirectionY\");",
                 "const decisionWeight = eventsFunctionContext.getArgument(\"DecisionWeight\");",
                 "",
-                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.x;"
+                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.y;"
               ],
               "parameterObjects": "Object",
               "useStrict": true,

--- a/extensions/reviewed/BoidsMovement.json
+++ b/extensions/reviewed/BoidsMovement.json
@@ -8,7 +8,7 @@
   "name": "BoidsMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Restaurant/Restaurant_restaurant_seafood_animal_fish.svg",
   "shortDescription": "Simulates flocks movement.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": [
     "Simulates swarms or flocks movement following the separation, alignment, cohesion principles. The flock can be attracted to a location or avoid some obstacles.",
     "",
@@ -1266,8 +1266,8 @@
           "objectGroups": []
         },
         {
-          "description": "Return the current vertical speed.",
-          "fullName": "Velocity Y",
+          "description": "Return the current horizontal speed.",
+          "fullName": "Velocity X",
           "functionType": "Expression",
           "name": "VelocityX",
           "sentence": "",
@@ -1308,8 +1308,8 @@
           "objectGroups": []
         },
         {
-          "description": "Return the current horizontal speed.",
-          "fullName": "Velocity X",
+          "description": "Return the current vertical  speed.",
+          "fullName": "Velocity Y",
           "functionType": "Expression",
           "name": "VelocityY",
           "sentence": "",

--- a/extensions/reviewed/BoidsMovement.json
+++ b/extensions/reviewed/BoidsMovement.json
@@ -8,7 +8,7 @@
   "name": "BoidsMovement",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Restaurant/Restaurant_restaurant_seafood_animal_fish.svg",
   "shortDescription": "Simulates flocks movement.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": [
     "Simulates swarms or flocks movement following the separation, alignment, cohesion principles. The flock can be attracted to a location or avoid some obstacles.",
     "",
@@ -995,7 +995,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "(Object.Behavior::VelocityX() * (Object.CenterY() - CenterY) + Object.Behavior::VelocityY() * (CenterX - Object.CenterX())) / Object.Behavior::Speed()"
+                    "(Object.Behavior::VelocityY() * (Object.CenterY() - CenterY) + Object.Behavior::VelocityX() * (CenterX - Object.CenterX())) / Object.Behavior::Speed()"
                   ]
                 }
               ]
@@ -1269,7 +1269,7 @@
           "description": "Return the current vertical speed.",
           "fullName": "Velocity Y",
           "functionType": "Expression",
-          "name": "VelocityX",
+          "name": "VelocityY",
           "sentence": "",
           "events": [
             {
@@ -1282,7 +1282,7 @@
                 "const directionY = eventsFunctionContext.getArgument(\"DirectionY\");",
                 "const decisionWeight = eventsFunctionContext.getArgument(\"DecisionWeight\");",
                 "",
-                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.x;"
+                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.y;"
               ],
               "parameterObjects": "Object",
               "useStrict": true,
@@ -1311,7 +1311,7 @@
           "description": "Return the current horizontal speed.",
           "fullName": "Velocity X",
           "functionType": "Expression",
-          "name": "VelocityY",
+          "name": "VelocityX",
           "sentence": "",
           "events": [
             {
@@ -1324,7 +1324,7 @@
                 "const directionY = eventsFunctionContext.getArgument(\"DirectionY\");",
                 "const decisionWeight = eventsFunctionContext.getArgument(\"DecisionWeight\");",
                 "",
-                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.y;"
+                "eventsFunctionContext.returnValue = behavior.__boidsExtension.boid.velocity.x;"
               ],
               "parameterObjects": "Object",
               "useStrict": true,


### PR DESCRIPTION
Should also fix potential problems with "avoid object" action by setting the correct TrajectorySpeed.