### PR TITLE
[Reviewed] [Turret] Use the new syntax

### DIFF
--- a/extensions/reviewed/Turret.json
+++ b/extensions/reviewed/Turret.json
@@ -1,7 +1,6 @@
 {
   "author": "D8H",
   "category": "Movement",
-  "description": "With this behavior, you can make an object rotate like a turret toward a position.\nIt may be used with the **Bullet** extension to fire objects.",
   "extensionNamespace": "",
   "fullName": "Turret movement",
   "helpPath": "",
@@ -9,7 +8,15 @@
   "name": "Turret",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Cleaning/Cleaning_cleaning_clean_plunger.svg",
   "shortDescription": "A turret movement with customizable speed, acceleration and stop angles.",
-  "version": "1.1.0",
+  "version": "1.1.1",
+  "description": [
+    "With this behavior, you can make an object rotate like a turret toward a position.",
+    "It may be used with the **Bullet** extension to fire objects."
+  ],
+  "origin": {
+    "identifier": "Turret",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "turret",
     "movement",
@@ -27,6 +34,8 @@
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -36,11 +45,9 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "doStepPostEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
@@ -48,58 +55,47 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Deceleration",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "BuiltinCommonInstructions::Or"
                       },
                       "parameters": [],
                       "subInstructions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::And"
                           },
                           "parameters": [],
                           "subInstructions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::PropertyMustMoveClockwise"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::PropertyMustMoveCounterClockwise"
                               },
                               "parameters": [
                                 "Object",
                                 "Behavior"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ]
                         },
                         {
                           "type": {
-                            "inverted": false,
                             "value": "BuiltinCommonInstructions::And"
                           },
                           "parameters": [],
@@ -112,8 +108,7 @@
                               "parameters": [
                                 "Object",
                                 "Behavior"
-                              ],
-                              "subInstructions": []
+                              ]
                             },
                             {
                               "type": {
@@ -123,8 +118,7 @@
                               "parameters": [
                                 "Object",
                                 "Behavior"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ]
                         }
@@ -134,13 +128,10 @@
                   "actions": [],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::PropertySpeed"
                           },
                           "parameters": [
@@ -148,34 +139,28 @@
                             "Behavior",
                             ">",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::SetPropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "-",
-                            "Object.Behavior::PropertyDeceleration() * TimeDelta()"
-                          ],
-                          "subInstructions": []
+                            "Deceleration * TimeDelta()"
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::PropertySpeed"
                               },
                               "parameters": [
@@ -183,14 +168,12 @@
                                 "Behavior",
                                 "<",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::SetPropertySpeed"
                               },
                               "parameters": [
@@ -198,22 +181,17 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     },
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::PropertySpeed"
                           },
                           "parameters": [
@@ -221,34 +199,28 @@
                             "Behavior",
                             "<",
                             "0"
-                          ],
-                          "subInstructions": []
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::SetPropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "+",
-                            "Object.Behavior::PropertyDeceleration() * TimeDelta()"
-                          ],
-                          "subInstructions": []
+                            "Deceleration * TimeDelta()"
+                          ]
                         }
                       ],
                       "events": [
                         {
-                          "disabled": false,
-                          "folded": false,
                           "type": "BuiltinCommonInstructions::Standard",
                           "conditions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::PropertySpeed"
                               },
                               "parameters": [
@@ -256,14 +228,12 @@
                                 "Behavior",
                                 ">",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
                           ],
                           "actions": [
                             {
                               "type": {
-                                "inverted": false,
                                 "value": "Turret::Turret::SetPropertySpeed"
                               },
                               "parameters": [
@@ -271,11 +241,9 @@
                                 "Behavior",
                                 "=",
                                 "0"
-                              ],
-                              "subInstructions": []
+                              ]
                             }
-                          ],
-                          "events": []
+                          ]
                         }
                       ]
                     }
@@ -289,27 +257,21 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Acceleration",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyMustMoveClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -319,79 +281,65 @@
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertySpeed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "+",
-                        "Object.Behavior::PropertyAcceleration() * TimeDelta()"
-                      ],
-                      "subInstructions": []
+                        "Acceleration * TimeDelta()"
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::PropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             ">",
-                            "Object.Behavior::PropertySpeedMax()"
-                          ],
-                          "subInstructions": []
+                            "SpeedMax"
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::SetPropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "=",
-                            "Object.Behavior::PropertySpeedMax()"
-                          ],
-                          "subInstructions": []
+                            "SpeedMax"
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyMustMoveCounterClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -401,61 +349,51 @@
                       "parameters": [
                         "Object",
                         "Behavior"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertySpeed"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "-",
-                        "Object.Behavior::PropertyAcceleration() * TimeDelta()"
-                      ],
-                      "subInstructions": []
+                        "Acceleration * TimeDelta()"
+                      ]
                     }
                   ],
                   "events": [
                     {
-                      "disabled": false,
-                      "folded": false,
                       "type": "BuiltinCommonInstructions::Standard",
                       "conditions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::PropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "<",
-                            "- Object.Behavior::PropertySpeedMax()"
-                          ],
-                          "subInstructions": []
+                            "- SpeedMax"
+                          ]
                         }
                       ],
                       "actions": [
                         {
                           "type": {
-                            "inverted": false,
                             "value": "Turret::Turret::SetPropertySpeed"
                           },
                           "parameters": [
                             "Object",
                             "Behavior",
                             "=",
-                            "- Object.Behavior::PropertySpeedMax()"
-                          ],
-                          "subInstructions": []
+                            "- SpeedMax"
+                          ]
                         }
-                      ],
-                      "events": []
+                      ]
                     }
                   ]
                 }
@@ -467,63 +405,48 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Angle",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
-                        "Object.Behavior::PropertyAimingAngle() + Object.Behavior::PropertySpeed() * TimeDelta()",
-                        "Object.Variable(turret_Speed) * TimeDelta()"
-                      ],
-                      "subInstructions": []
+                        "AimingAngle + Speed * TimeDelta()",
+                        ""
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyHasMoved"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "False"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertySpeed"
                       },
                       "parameters": [
@@ -531,25 +454,21 @@
                         "Behavior",
                         "!=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyHasMoved"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -559,44 +478,35 @@
               "colorG": 176,
               "colorR": 74,
               "creationTime": 0,
-              "disabled": false,
-              "folded": false,
               "name": "Controls Reset",
               "source": "",
               "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyMustMoveClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "False"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyMustMoveCounterClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "False"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
               "parameters": []
@@ -604,22 +514,13 @@
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -631,59 +532,42 @@
           "fullName": "Is moving",
           "functionType": "Condition",
           "name": "IsMoving",
-          "private": false,
           "sentence": "_PARAM0_ is moving",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::PropertyHasMoved"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnBoolean"
                   },
                   "parameters": [
                     "True"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -695,49 +579,34 @@
           "fullName": "Move clockwise",
           "functionType": "Action",
           "name": "MoveClockwise",
-          "private": false,
           "sentence": "Move _PARAM0_ clockwise",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyMustMoveClockwise"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -749,49 +618,34 @@
           "fullName": "Move counter-clockwise",
           "functionType": "Action",
           "name": "MoveCounterClockwise",
-          "private": false,
           "sentence": "Move _PARAM0_ counter-clockwise",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyMustMoveCounterClockwise"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "yes"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -799,38 +653,29 @@
           "objectGroups": []
         },
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
           "name": "onCreated",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetAimingAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "(Object.Behavior::PropertyAngleMin() + Object.Behavior::PropertyAngleMax()) / 2",
+                    "(AngleMin + AngleMax) / 2",
                     "(mod(Object.Behavior::PropertyAngleMin(), 360) + mod(Object.Behavior::PropertyAngleMax(), 360)) / 2"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -840,50 +685,35 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Origin angle is the farest angle from AngleMin and AngleMax, it's used by MoveToward",
-              "comment2": ""
+              "comment": "Origin angle is the farest angle from AngleMin and AngleMax, it's used by MoveToward"
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyOriginAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "(Object.Behavior::PropertyAngleMin() + Object.Behavior::PropertyAngleMax()) / 2 - 180"
-                  ],
-                  "subInstructions": []
+                    "(AngleMin + AngleMax) / 2 - 180"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -895,12 +725,9 @@
           "fullName": "Set aiming angle toward a position",
           "functionType": "Action",
           "name": "SetAimingAngleToward",
-          "private": false,
           "sentence": "Set the aiming angle of _PARAM0_ toward _PARAM2_;_PARAM3_",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -910,71 +737,46 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Use OriginAngle to obtain an angle that is the nearest from AngleMin and AngleMax",
-              "comment2": ""
+              "comment": "Use OriginAngle to obtain an angle that is the nearest from AngleMin and AngleMax"
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetAimingAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
-                    "mod(ToDeg(atan2(GetArgumentAsNumber(\"TargetY\") - Object.Y(), GetArgumentAsNumber(\"TargetX\") - Object.X())) - Object.Behavior::PropertyOriginAngle(), 360) + Object.Behavior::PropertyOriginAngle()",
+                    "mod(ToDeg(atan2(TargetY - Object.Y(), TargetX - Object.X())) - OriginAngle, 360) + OriginAngle",
                     "mod(ToDeg(atan2(GetArgumentAsNumber(\"TargetY\") - Object.Y(), GetArgumentAsNumber(\"TargetX\") - Object.X())) - Object.Behavior::PropertyOriginAngle(), 360) + Object.Behavior::PropertyOriginAngle()"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "X position",
-              "longDescription": "",
               "name": "TargetX",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Y position",
-              "longDescription": "",
               "name": "TargetY",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -985,12 +787,9 @@
           "fullName": "Move toward a position",
           "functionType": "Action",
           "name": "MoveToward",
-          "private": false,
           "sentence": "Move _PARAM0_ toward _PARAM2_; _PARAM3_ within a _PARAM4_° margin",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1000,34 +799,26 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Use OriginAngle to obtain an angle that is the nearest from AngleMin and AngleMax",
-              "comment2": ""
+              "comment": "Use OriginAngle to obtain an angle that is the nearest from AngleMin and AngleMax"
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyTargetAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "mod(ToDeg(atan2(GetArgumentAsNumber(\"TargetY\") - Object.Y(), GetArgumentAsNumber(\"TargetX\") - Object.X())) - Object.Behavior::PropertyOriginAngle(), 360) + Object.Behavior::PropertyOriginAngle()"
-                  ],
-                  "subInstructions": []
+                    "mod(ToDeg(atan2(TargetY - Object.Y(), TargetX - Object.X())) - OriginAngle, 360) + OriginAngle"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1037,104 +828,83 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "There is stop angles",
-              "comment2": ""
+              "comment": "There is stop angles"
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "Egal"
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyAngleMin()",
+                    "AngleMin",
                     "<",
-                    "Object.Behavior::PropertyAngleMax()"
-                  ],
-                  "subInstructions": []
+                    "AngleMax"
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ">",
-                        "Object.Behavior::PropertyTargetAngle() + GetArgumentAsNumber(\"AngleMargin\")"
-                      ],
-                      "subInstructions": []
+                        "TargetAngle + AngleMargin"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::MoveCounterClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "True"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "<",
-                        "Object.Behavior::PropertyTargetAngle() - GetArgumentAsNumber(\"AngleMargin\")"
-                      ],
-                      "subInstructions": []
+                        "TargetAngle - AngleMargin"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::MoveClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1144,149 +914,106 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "No stop angle, the direction is chosen according to the shortest path (never more that 180°)",
-              "comment2": ""
+              "comment": "No stop angle, the direction is chosen according to the shortest path (never more that 180°)"
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "Egal"
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyAngleMin()",
+                    "AngleMin",
                     "=",
-                    "Object.Behavior::PropertyAngleMax()"
-                  ],
-                  "subInstructions": []
+                    "AngleMax"
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "Egal"
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
                       },
                       "parameters": [
-                        "mod(180 + Object.Behavior::PropertyTargetAngle() - Object.Behavior::PropertyAimingAngle(), 360)",
+                        "mod(180 + TargetAngle - AimingAngle, 360)",
                         "<",
-                        "180 - GetArgumentAsNumber(\"AngleMargin\")"
-                      ],
-                      "subInstructions": []
+                        "180 - AngleMargin"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::MoveCounterClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "True"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "Egal"
+                        "value": "BuiltinCommonInstructions::CompareNumbers"
                       },
                       "parameters": [
-                        "mod(180 + Object.Behavior::PropertyAimingAngle() - Object.Behavior::PropertyTargetAngle(), 360)",
+                        "mod(180 + AimingAngle - TargetAngle, 360)",
                         "<",
-                        "180 - GetArgumentAsNumber(\"AngleMargin\")"
-                      ],
-                      "subInstructions": []
+                        "180 - AngleMargin"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::MoveClockwise"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "yes"
-                      ],
-                      "subInstructions": []
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "X position",
-              "longDescription": "",
               "name": "TargetX",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Y position",
-              "longDescription": "",
               "name": "TargetY",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Angle margin",
-              "longDescription": "",
               "name": "AngleMargin",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -1297,34 +1024,26 @@
           "fullName": "Aiming angle",
           "functionType": "Action",
           "name": "SetAimingAngle",
-          "private": false,
           "sentence": "Change the aiming angle of _PARAM0_ to _PARAM2_°",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyAimingAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"AimingAngle\")"
-                  ],
-                  "subInstructions": []
+                    "AimingAngle"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1334,47 +1053,37 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Use mod to avoid the angle value to be too large.",
-              "comment2": ""
+              "comment": "Use mod to avoid the angle value to be too large."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "Egal"
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyAngleMin()",
+                    "AngleMin",
                     "=",
-                    "Object.Behavior::PropertyAngleMax()"
-                  ],
-                  "subInstructions": []
+                    "AngleMax"
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::SetPropertyAimingAngle"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     "=",
-                    "mod(Object.Behavior::PropertyAimingAngle(), 360)"
-                  ],
-                  "subInstructions": []
+                    "mod(AimingAngle, 360)"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -1384,166 +1093,126 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "There are stop angles, the angle is bounded by these.",
-              "comment2": ""
+              "comment": "There are stop angles, the angle is bounded by these."
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "Egal"
+                    "value": "BuiltinCommonInstructions::CompareNumbers"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyAngleMin()",
+                    "AngleMin",
                     "<",
-                    "Object.Behavior::PropertyAngleMax()"
-                  ],
-                  "subInstructions": []
+                    "AngleMax"
+                  ]
                 }
               ],
               "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         ">",
-                        "Object.Behavior::PropertyAngleMax()"
-                      ],
-                      "subInstructions": []
+                        "AngleMax"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "Object.Behavior::PropertyAngleMax()"
-                      ],
-                      "subInstructions": []
+                        "AngleMax"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::PropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "<",
-                        "Object.Behavior::PropertyAngleMin()"
-                      ],
-                      "subInstructions": []
+                        "AngleMin"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "Turret::Turret::SetPropertyAimingAngle"
                       },
                       "parameters": [
                         "Object",
                         "Behavior",
                         "=",
-                        "Object.Behavior::PropertyAngleMin()"
-                      ],
-                      "subInstructions": []
+                        "AngleMin"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Turret::Turret::PropertyRotate"
                   },
                   "parameters": [
                     "Object",
                     "Behavior"
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetAngle"
                   },
                   "parameters": [
                     "Object",
                     "=",
-                    "Object.Behavior::PropertyAimingAngle()"
-                  ],
-                  "subInstructions": []
+                    "AimingAngle"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Aiming angle",
-              "longDescription": "",
               "name": "AimingAngle",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "expression"
             }
           ],
@@ -1554,47 +1223,35 @@
           "fullName": "Aiming angle",
           "functionType": "Expression",
           "name": "AimingAngle",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyAimingAngle()"
-                  ],
-                  "subInstructions": []
+                    "AimingAngle"
+                  ]
                 }
-              ],
-              "events": []
+              ]
             }
           ],
+          "expressionType": {
+            "type": "expression"
+          },
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "Turret::Turret",
               "type": "behavior"
             }
@@ -1608,8 +1265,8 @@
           "type": "Number",
           "label": "Maximum rotation speed (in degrees per second)",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "SpeedMax"
         },
         {
@@ -1617,8 +1274,8 @@
           "type": "Number",
           "label": "Acceleration",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "Acceleration"
         },
         {
@@ -1626,8 +1283,8 @@
           "type": "Number",
           "label": "Deceleration",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "Deceleration"
         },
         {
@@ -1635,8 +1292,8 @@
           "type": "Boolean",
           "label": "Rotate the object",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "Rotate"
         },
         {
@@ -1644,8 +1301,8 @@
           "type": "Number",
           "label": "Maximum angle (use the same value for min and max to set no constraint)",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "AngleMax"
         },
         {
@@ -1653,8 +1310,8 @@
           "type": "Number",
           "label": "Minimum angle (use the same value for min and max to set no constraint)",
           "description": "",
+          "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "AngleMin"
         },
         {
@@ -1662,6 +1319,7 @@
           "type": "Number",
           "label": "Aiming angle property",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "AimingAngle"
@@ -1671,6 +1329,7 @@
           "type": "Number",
           "label": "Speed",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "Speed"
@@ -1680,6 +1339,7 @@
           "type": "Boolean",
           "label": "Must move clockwise",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "MustMoveClockwise"
@@ -1689,6 +1349,7 @@
           "type": "Boolean",
           "label": "Must move counter-clockwise",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "MustMoveCounterClockwise"
@@ -1698,6 +1359,7 @@
           "type": "Boolean",
           "label": "Has moved",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "HasMoved"
@@ -1707,6 +1369,7 @@
           "type": "Number",
           "label": "Target angle (MoveToward)",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "TargetAngle"
@@ -1716,11 +1379,14 @@
           "type": "Number",
           "label": "Origin angle: the farest angle from AngleMin and AngleMax",
           "description": "",
+          "group": "",
           "extraInformation": [],
           "hidden": true,
           "name": "OriginAngle"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }


### PR DESCRIPTION
### Changes
- Use the new syntax for properties
- Remove an unused parameter expression that gave a false positive on variable usage.

### Todo
- The formulas are overly complicated. Angle expressions could be used instead of low-level trigonometry.