### PR TITLE
[Reviewed] [Multitouch joystick] Fix the dead zone for `Force` expressions

### DIFF
--- a/extensions/reviewed/SpriteMultitouchJoystick.json
+++ b/extensions/reviewed/SpriteMultitouchJoystick.json
@@ -1043,25 +1043,14 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force",
-                ">",
-                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)"
-              ]
-            }
-          ],
+          "conditions": [],
           "actions": [
             {
               "type": {
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force)"
+                "max(0, Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force) - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)) / (1 - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier))"
               ]
             }
           ]
@@ -1682,26 +1671,14 @@
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
-                  },
-                  "parameters": [
-                    "Object",
-                    "Behavior",
-                    ">",
-                    "DeadZoneRadius"
-                  ]
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "JoystickForce"
+                    "max(0, JoystickForce - DeadZoneRadius) / (1 - DeadZoneRadius)"
                   ]
                 }
               ]
@@ -4749,10 +4726,10 @@
         "folderName": "__ROOT",
         "children": [
           {
-            "objectName": "1saW5lam9pbj"
+            "objectName": "FIMjBBMSwxID"
           },
           {
-            "objectName": "I0IDI0Ij48cG"
+            "objectName": "\u0001"
           }
         ]
       },

--- a/extensions/reviewed/SpriteMultitouchJoystick.json
+++ b/extensions/reviewed/SpriteMultitouchJoystick.json
@@ -8,7 +8,7 @@
   "name": "SpriteMultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Joysticks or buttons for touchscreens.",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": [
     "Multitouch joysticks can be used the same way as physical gamepads:",
     "- 4 or 8 directions",
@@ -862,7 +862,7 @@
               "parameters": [
                 "",
                 ">",
-                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)",
+                "0",
                 "ControllerIdentifier",
                 "JoystickIdentifier",
                 ""
@@ -942,9 +942,9 @@
               "parameters": [
                 "",
                 ">",
-                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)",
-                "GetArgumentAsNumber(\"ControllerIdentifier\")",
-                "GetArgumentAsString(\"JoystickIdentifier\")",
+                "0",
+                "ControllerIdentifier",
+                "JoystickIdentifier",
                 ""
               ]
             },
@@ -1945,13 +1945,14 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
+                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::JoystickForce"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ">",
-                    "DeadZoneRadius"
+                    "0",
+                    ""
                   ]
                 },
                 {
@@ -2011,13 +2012,14 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
+                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::JoystickForce"
                   },
                   "parameters": [
                     "Object",
                     "Behavior",
                     ">",
-                    "DeadZoneRadius"
+                    "0",
+                    ""
                   ]
                 },
                 {
@@ -4726,10 +4728,10 @@
         "folderName": "__ROOT",
         "children": [
           {
-            "objectName": "FIMjBBMSwxID"
+            "objectName": "1saW5lam9pbj"
           },
           {
-            "objectName": "\u0001"
+            "objectName": "\u0012"
           }
         ]
       },

--- a/extensions/reviewed/SpriteMultitouchJoystick.json
+++ b/extensions/reviewed/SpriteMultitouchJoystick.json
@@ -8,7 +8,7 @@
   "name": "SpriteMultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Joysticks or buttons for touchscreens.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": [
     "Multitouch joysticks can be used the same way as physical gamepads:",
     "- 4 or 8 directions",
@@ -42,6 +42,8 @@
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [
     {
       "description": "Check if a button is pressed on a gamepad.",
@@ -156,9 +158,9 @@
                 "value": "ModVarSceneTxt"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Buttons[GetArgumentAsString(\"Button\")].State",
+                "__MultitouchJoystick.Controllers[ControllerIdentifier].Buttons[Button].State",
                 "=",
-                "GetArgumentAsString(\"ButtonState\")"
+                "ButtonState"
               ]
             }
           ]
@@ -201,9 +203,9 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].DeadZone",
+                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone",
                 "=",
-                "GetArgumentAsNumber(\"DeadZoneRadius\")"
+                "DeadZoneRadius"
               ]
             }
           ]
@@ -246,7 +248,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].DeadZone)"
+                "Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone)"
               ]
             }
           ]
@@ -860,9 +862,9 @@
               "parameters": [
                 "",
                 ">",
-                "SpriteMultitouchJoystick::DeadZone(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
-                "GetArgumentAsNumber(\"ControllerIdentifier\")",
-                "GetArgumentAsString(\"JoystickIdentifier\")",
+                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)",
+                "ControllerIdentifier",
+                "JoystickIdentifier",
                 ""
               ]
             },
@@ -872,8 +874,8 @@
               },
               "parameters": [
                 "",
-                "SpriteMultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
-                "GetArgumentAsString(\"Direction\")",
+                "SpriteMultitouchJoystick::JoystickAngle(ControllerIdentifier, JoystickIdentifier)",
+                "Direction",
                 ""
               ]
             }
@@ -940,7 +942,7 @@
               "parameters": [
                 "",
                 ">",
-                "SpriteMultitouchJoystick::DeadZone(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
+                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)",
                 "GetArgumentAsNumber(\"ControllerIdentifier\")",
                 "GetArgumentAsString(\"JoystickIdentifier\")",
                 ""
@@ -952,8 +954,8 @@
               },
               "parameters": [
                 "",
-                "SpriteMultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))",
-                "GetArgumentAsString(\"Direction\")",
+                "SpriteMultitouchJoystick::JoystickAngle(ControllerIdentifier, JoystickIdentifier)",
+                "Direction",
                 ""
               ]
             }
@@ -1008,7 +1010,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "SpriteMultitouchJoystick::StickForce(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))"
+                "SpriteMultitouchJoystick::StickForce(ControllerIdentifier, JoystickIdentifier)"
               ]
             }
           ]
@@ -1041,14 +1043,25 @@
       "events": [
         {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
+          "conditions": [
+            {
+              "type": {
+                "value": "VarScene"
+              },
+              "parameters": [
+                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force",
+                ">",
+                "SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)"
+              ]
+            }
+          ],
           "actions": [
             {
               "type": {
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Force)"
+                "Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force)"
               ]
             }
           ]
@@ -1089,9 +1102,9 @@
                 "value": "ModVarScene"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[GetArgumentAsNumber(\"ControllerIdentifier\")].Joystick[GetArgumentAsString(\"JoystickIdentifier\")].Force",
+                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force",
                 "=",
-                "GetArgumentAsNumber(\"Value\")"
+                "Value"
               ]
             }
           ]
@@ -1257,7 +1270,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "SpriteMultitouchJoystick::JoystickForce(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\")) * cos(ToRad(SpriteMultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))))"
+                "SpriteMultitouchJoystick::JoystickForce(ControllerIdentifier, JoystickIdentifier) * cos(ToRad(SpriteMultitouchJoystick::JoystickAngle(ControllerIdentifier, JoystickIdentifier)))"
               ]
             }
           ]
@@ -1297,7 +1310,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "SpriteMultitouchJoystick::JoystickForce(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\")) * sin(ToRad(SpriteMultitouchJoystick::JoystickAngle(GetArgumentAsNumber(\"ControllerIdentifier\"), GetArgumentAsString(\"JoystickIdentifier\"))))"
+                "SpriteMultitouchJoystick::JoystickForce(ControllerIdentifier, JoystickIdentifier) * sin(ToRad(SpriteMultitouchJoystick::JoystickAngle(ControllerIdentifier, JoystickIdentifier)))"
               ]
             }
           ]
@@ -1669,14 +1682,26 @@
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
+              "conditions": [
+                {
+                  "type": {
+                    "value": "SpriteMultitouchJoystick::MultitouchJoystick::PropertyJoystickForce"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Behavior",
+                    ">",
+                    "DeadZoneRadius"
+                  ]
+                }
+              ],
               "actions": [
                 {
                   "type": {
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyJoystickForce()"
+                    "JoystickForce"
                   ]
                 }
               ]
@@ -1720,7 +1745,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Value\")"
+                    "Value"
                   ]
                 },
                 {
@@ -1729,9 +1754,9 @@
                   },
                   "parameters": [
                     "",
-                    "Object.Behavior::PropertyControllerIdentifier()",
-                    "Object.Behavior::PropertyJoystickIdentifier()",
-                    "Object.Behavior::PropertyJoystickForce()",
+                    "ControllerIdentifier",
+                    "JoystickIdentifier",
+                    "JoystickForce",
                     ""
                   ]
                 }
@@ -1769,7 +1794,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyJoystickAngle()"
+                    "JoystickAngle"
                   ]
                 }
               ]
@@ -1949,7 +1974,7 @@
                     "Object",
                     "Behavior",
                     ">",
-                    "Object.Behavior::PropertyDeadZoneRadius()"
+                    "DeadZoneRadius"
                   ]
                 },
                 {
@@ -1958,8 +1983,8 @@
                   },
                   "parameters": [
                     "",
-                    "Object.Behavior::JoystickAngle()",
-                    "GetArgumentAsString(\"Direction\")",
+                    "JoystickAngle",
+                    "Direction",
                     ""
                   ]
                 }
@@ -2015,7 +2040,7 @@
                     "Object",
                     "Behavior",
                     ">",
-                    "Object.Behavior::PropertyDeadZoneRadius()"
+                    "DeadZoneRadius"
                   ]
                 },
                 {
@@ -2024,8 +2049,8 @@
                   },
                   "parameters": [
                     "",
-                    "Object.Behavior::JoystickAngle()",
-                    "GetArgumentAsString(\"Direction\")",
+                    "JoystickAngle",
+                    "Direction",
                     ""
                   ]
                 }
@@ -2344,7 +2369,7 @@
                     "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "Object.Behavior::PropertyDeadZoneRadius()"
+                    "DeadZoneRadius"
                   ]
                 }
               ]
@@ -2387,7 +2412,7 @@
                     "Object",
                     "Behavior",
                     "=",
-                    "GetArgumentAsNumber(\"Value\")"
+                    "Value"
                   ]
                 }
               ]
@@ -2417,7 +2442,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ControllerIdentifier"
         },
         {
@@ -2427,7 +2451,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "JoystickIdentifier"
         },
         {
@@ -2437,7 +2460,6 @@
           "description": "The deadzone is an area for which movement on sticks won't be taken into account (instead, the stick will be considered as not moved)",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "DeadZoneRadius"
         },
         {
@@ -2862,7 +2884,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ControllerIdentifier"
         },
         {
@@ -2872,7 +2893,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ButtonIdentifier"
         },
         {
@@ -3095,7 +3115,6 @@
           "extraInformation": [
             "PlatformBehavior::PlatformerObjectBehavior"
           ],
-          "hidden": false,
           "name": "Property"
         },
         {
@@ -3105,7 +3124,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ControllerIdentifier"
         },
         {
@@ -3118,7 +3136,6 @@
             "Primary",
             "Secondary"
           ],
-          "hidden": false,
           "name": "JoystickIdentifier"
         },
         {
@@ -3128,7 +3145,6 @@
           "description": "",
           "group": "Controls",
           "extraInformation": [],
-          "hidden": false,
           "name": "JumpButton"
         }
       ],
@@ -3657,7 +3673,6 @@
           "extraInformation": [
             "TopDownMovementBehavior::TopDownMovementBehavior"
           ],
-          "hidden": false,
           "name": "TopDownMovement"
         },
         {
@@ -3667,7 +3682,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ControllerIdentifier"
         },
         {
@@ -3680,7 +3694,6 @@
             "Primary",
             "Secondary"
           ],
-          "hidden": false,
           "name": "JoystickIdentifier"
         },
         {
@@ -3694,7 +3707,6 @@
             "360°",
             "8 Directions"
           ],
-          "hidden": false,
           "name": "StickMode"
         }
       ],
@@ -3703,6 +3715,12 @@
   ],
   "eventsBasedObjects": [
     {
+      "areaMaxX": 64,
+      "areaMaxY": 64,
+      "areaMaxZ": 64,
+      "areaMinX": 0,
+      "areaMinY": 0,
+      "areaMinZ": 0,
       "defaultName": "Joystick",
       "description": "Joystick for touchscreens.",
       "fullName": "Multitouch Joystick",
@@ -4290,7 +4308,7 @@
                   "parameters": [
                     "Border",
                     "MultitouchJoystick",
-                    "GetArgumentAsString(\"Direction\")",
+                    "Direction",
                     ""
                   ]
                 }
@@ -4340,7 +4358,7 @@
                   "parameters": [
                     "Border",
                     "MultitouchJoystick",
-                    "GetArgumentAsString(\"Direction\")",
+                    "Direction",
                     ""
                   ]
                 }
@@ -4598,7 +4616,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "ControllerIdentifier"
         },
         {
@@ -4611,7 +4628,6 @@
             "Primary",
             "Secondary"
           ],
-          "hidden": false,
           "name": "JoystickIdentifier"
         },
         {
@@ -4621,7 +4637,6 @@
           "description": "The deadzone is an area for which movement on sticks won't be taken into account (instead, the stick will be considered as not moved)",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "DeadZoneRadius"
         },
         {
@@ -4671,9 +4686,9 @@
       ],
       "objects": [
         {
+          "adaptCollisionMaskAutomatically": false,
           "assetStoreId": "",
           "name": "Thumb",
-          "tags": "",
           "type": "Sprite",
           "updateIfNotVisible": false,
           "variables": [],
@@ -4694,9 +4709,9 @@
           ]
         },
         {
+          "adaptCollisionMaskAutomatically": false,
           "assetStoreId": "",
           "name": "Border",
-          "tags": "",
           "type": "Sprite",
           "updateIfNotVisible": false,
           "variables": [],
@@ -4729,7 +4744,50 @@
             }
           ]
         }
-      ]
+      ],
+      "objectsFolderStructure": {
+        "folderName": "__ROOT",
+        "children": [
+          {
+            "objectName": "1saW5lam9pbj"
+          },
+          {
+            "objectName": "I0IDI0Ij48cG"
+          }
+        ]
+      },
+      "objectsGroups": [],
+      "layers": [
+        {
+          "ambientLightColorB": 200,
+          "ambientLightColorG": 200,
+          "ambientLightColorR": 200,
+          "camera3DFarPlaneDistance": 10000,
+          "camera3DFieldOfView": 45,
+          "camera3DNearPlaneDistance": 3,
+          "cameraType": "",
+          "followBaseLayerCamera": false,
+          "isLightingLayer": false,
+          "isLocked": false,
+          "name": "",
+          "renderingType": "",
+          "visibility": true,
+          "cameras": [
+            {
+              "defaultSize": true,
+              "defaultViewport": true,
+              "height": 0,
+              "viewportBottom": 1,
+              "viewportLeft": 0,
+              "viewportRight": 1,
+              "viewportTop": 0,
+              "width": 0
+            }
+          ],
+          "effects": []
+        }
+      ],
+      "instances": []
     }
   ]
 }


### PR DESCRIPTION
### Changes
- `Force()`, `ForceX()`, `ForceY()` now return 0 when the stick is in the dead zone.
- The force starts at 0 at the end of the dead zone and progressively goes to 1.