### PR TITLE
[Community] [Navigation mesh pathfinding] Fixed problem with Rotation speed not being applied correctly.

### DIFF
--- a/extensions/community/NavMeshPathfinding.json
+++ b/extensions/community/NavMeshPathfinding.json
@@ -8,7 +8,7 @@
   "name": "NavMeshPathfinding",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Maps and Navigation/Maps and Navigation_map_find_search.svg",
   "shortDescription": "Pathfinding allows to compute an efficient path for objects, avoiding obstacles on the way.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": [
     "In comparison to the built-in pathfinding behavior, this one aims to:",
     "- better respect obstacle shapes",
@@ -4368,7 +4368,7 @@
             "        var isometricRatio = manager.configuration._getIsometricRatio();",
             "        var owner = this.behavior.owner;",
             "        var angleOffset = this.behavior._getAngleOffset();",
-            "        var angularMaxSpeed = this.behavior._getMaxSpeed();",
+            "        var angularMaxSpeed = this.behavior._getAngularMaxSpeed();",
             "        var rotateObject = this.behavior._getRotateObject();",
             "        var timeDelta = owner.getElapsedTime(instanceContainer) / 1000;",
             "        this.pathFollower.step(timeDelta);",
@@ -5312,7 +5312,7 @@
           "objectGroups": []
         },
         {
-          "description": "Draw the navigation mesh used for the object.",
+          "description": "Draw the navigation mesh used for the object.\nThe \"Move to a position\" action must have been performed at least once before this action is executed.",
           "fullName": "Draw navigation mesh",
           "functionType": "Action",
           "group": "Debug",
@@ -5980,6 +5980,7 @@
         {
           "value": "400",
           "type": "Number",
+          "unit": "PixelAcceleration",
           "label": "Acceleration",
           "description": "",
           "group": "",
@@ -5989,6 +5990,7 @@
         {
           "value": "200",
           "type": "Number",
+          "unit": "PixelSpeed",
           "label": "Maximum speed",
           "description": "",
           "group": "",
@@ -5998,6 +6000,7 @@
         {
           "value": "180",
           "type": "Number",
+          "unit": "AngularSpeed",
           "label": "Rotation speed",
           "description": "",
           "group": "Rotation",
@@ -6016,6 +6019,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "DegreeAngle",
           "label": "Angle offset",
           "description": "",
           "group": "Rotation",
@@ -6037,6 +6041,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Extra border size",
           "description": "",
           "group": "Collision",
@@ -6303,6 +6308,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "CellSize",
           "name": "SetCellSize",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -6394,6 +6400,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "AreaLeftBound",
           "name": "SetAreaLeftBound",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -6485,6 +6492,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "AreaTopBound",
           "name": "SetAreaTopBound",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -6576,6 +6584,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "AreaRightBound",
           "name": "SetAreaRightBound",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -6667,6 +6676,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "AreaBottomBound",
           "name": "SetAreaBottomBound",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -6769,6 +6779,7 @@
         {
           "value": "10",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Cell size",
           "description": "Cell size for obstacle collision mask rasterization.",
           "group": "",
@@ -6778,6 +6789,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Area left bound",
           "description": "The left bound of the area where objects can go in the scene.",
           "group": "",
@@ -6787,6 +6799,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Area top bound",
           "description": "The top bound of the area where objects can go in the scene.",
           "group": "",
@@ -6796,6 +6809,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Area right bound",
           "description": "The right bound of the area where objects can go in the scene (default to the game resolution).",
           "group": "",
@@ -6805,6 +6819,7 @@
         {
           "value": "0",
           "type": "Number",
+          "unit": "Pixel",
           "label": "Area bottom bound",
           "description": "The bottom bound of the area where objects can go in the scene (default to the game resolution).",
           "group": "",

--- a/extensions/community/NavMeshPathfinding.json
+++ b/extensions/community/NavMeshPathfinding.json
@@ -5312,7 +5312,7 @@
           "objectGroups": []
         },
         {
-          "description": "Draw the navigation mesh used for the object.\nThe \"Move to a position\" action must have been performed at least once before this action is executed.",
+          "description": "Draw the navigation mesh used for the object.\nThis action must be used after \"Move to a position\".",
           "fullName": "Draw navigation mesh",
           "functionType": "Action",
           "group": "Debug",


### PR DESCRIPTION
This PR includes fixes and suggestions.

- Fixed an issue where rotation speed was not being applied correctly.
- Added units to properties.
- Set actions to private that change parameters that cannot be changed later, such as "Change the Cell size."
- Added a note to the description of the "Draw navigation mesh" action.

@D8H , What do you think about these changes?

~~
This extension is great in that it works when added to a new tile map object.
It would be better if the navigation mesh could be updated when tiles are changed.

This current solution is not very smart.
![image](https://github.com/user-attachments/assets/db3d95b3-dee0-43bd-ba7f-b92740e9a4a7)
