### PR TITLE
Use extension variables and simplify events of various extensions

### DIFF
--- a/extensions/reviewed/CameraImpulse.json
+++ b/extensions/reviewed/CameraImpulse.json
@@ -1,7 +1,6 @@
 {
   "author": "",
   "category": "Camera",
-  "description": "Move the camera following an impulse trajectory.\n\nIt can be used to simulate earthquakes or impacts.",
   "extensionNamespace": "",
   "fullName": "Camera impulse",
   "helpPath": "",
@@ -9,7 +8,16 @@
   "name": "CameraImpulse",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Glyphster Pack/Master/SVG/Arrows/Arrows_thin_arrow_up_down_directions.svg",
   "shortDescription": "Move the camera following an impulse trajectory.",
-  "version": "1.0.1",
+  "version": "1.1.0",
+  "description": [
+    "Move the camera following an impulse trajectory.",
+    "",
+    "It can be used to simulate earthquakes or impacts."
+  ],
+  "origin": {
+    "identifier": "CameraImpulse",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "implusion",
     "shaking",
@@ -23,14 +31,96 @@
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [
+    {
+      "name": "Impulses",
+      "type": "structure",
+      "children": []
+    },
+    {
+      "name": "Impulse",
+      "type": "structure",
+      "children": [
+        {
+          "name": "AwayDuration",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "AwayEasing",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "BackDuration",
+          "type": "string",
+          "value": ""
+        },
+        {
+          "name": "BackEasing",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "DeltaX",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "DeltaY",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "Layer",
+          "type": "string",
+          "value": ""
+        },
+        {
+          "name": "StayDuration",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "Time",
+          "type": "number",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "name": "Identifer",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "Layers",
+      "type": "structure",
+      "children": []
+    },
+    {
+      "name": "Layer",
+      "type": "structure",
+      "children": [
+        {
+          "name": "CameraDeltaX",
+          "type": "number",
+          "value": 0
+        },
+        {
+          "name": "CameraDeltaY",
+          "type": "number",
+          "value": 0
+        }
+      ]
+    }
+  ],
   "eventsFunctions": [
     {
-      "description": "",
       "fullName": "",
       "functionType": "Action",
-      "group": "",
       "name": "onScenePostEvents",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -43,14 +133,13 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Step time counters.",
-          "comment2": ""
+          "comment": "Step time counters."
         },
         {
           "type": "BuiltinCommonInstructions::ForEachChildVariable",
-          "iterableVariableName": "__CameraImpulse.Impulses",
-          "valueIteratorVariableName": "__CameraImpulse.Impulse",
-          "keyIteratorVariableName": "__CameraImpulse.Identifer",
+          "iterableVariableName": "Impulses",
+          "valueIteratorVariableName": "Impulse",
+          "keyIteratorVariableName": "Identifer",
           "conditions": [],
           "actions": [],
           "events": [
@@ -60,10 +149,10 @@
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__CameraImpulse.Impulses[VariableString(__CameraImpulse.Identifer)].Time",
+                    "Impulses[Identifer].Time",
                     "+",
                     "TimeDelta()"
                   ]
@@ -82,14 +171,13 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Apply impulses on cameras.",
-          "comment2": ""
+          "comment": "Apply impulses on cameras."
         },
         {
           "type": "BuiltinCommonInstructions::ForEachChildVariable",
-          "iterableVariableName": "__CameraImpulse.Impulses",
-          "valueIteratorVariableName": "__CameraImpulse.Impulse",
-          "keyIteratorVariableName": "__CameraImpulse.Identifer",
+          "iterableVariableName": "Impulses",
+          "valueIteratorVariableName": "Impulse",
+          "keyIteratorVariableName": "Identifer",
           "conditions": [],
           "actions": [],
           "events": [
@@ -98,22 +186,23 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "VarScene"
+                    "value": "NumberVariable"
                   },
                   "parameters": [
-                    "__CameraImpulse.Impulse.Time",
+                    "Impulse.Time",
                     ">=",
-                    "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration) + Variable(__CameraImpulse.Impulse.BackDuration)"
+                    "Impulse.AwayDuration + Impulse.StayDuration + Impulse.BackDuration"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "VariableClearChildren"
+                    "value": "RemoveVariableChild"
                   },
                   "parameters": [
-                    "__CameraImpulse.Impulses[VariableString(__CameraImpulse.Identifer)]"
+                    "Impulses",
+                    "Identifer"
                   ]
                 }
               ]
@@ -123,12 +212,12 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "VarScene"
+                    "value": "NumberVariable"
                   },
                   "parameters": [
-                    "__CameraImpulse.Impulse.Time",
+                    "Impulse.Time",
                     "<",
-                    "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration) + Variable(__CameraImpulse.Impulse.BackDuration)"
+                    "Impulse.AwayDuration + Impulse.StayDuration + Impulse.BackDuration"
                   ]
                 }
               ],
@@ -144,32 +233,31 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Going away",
-                  "comment2": ""
+                  "comment": "Going away"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "value": "VarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Impulse.Time",
+                        "Impulse.Time",
                         "<",
-                        "Variable(__CameraImpulse.Impulse.AwayDuration)"
+                        "Impulse.AwayDuration"
                       ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.DistanceFactor",
+                        "DistanceFactor",
                         "=",
-                        "Tween::Ease(VariableString(__CameraImpulse.Impulse.AwayEasing), 0, 1, Variable(__CameraImpulse.Impulse.Time) / Variable(__CameraImpulse.Impulse.AwayDuration))"
+                        "Tween::Ease(Impulse.AwayEasing, 0, 1, Impulse.Time / Impulse.AwayDuration)"
                       ]
                     }
                   ]
@@ -184,40 +272,39 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Staying",
-                  "comment2": ""
+                  "comment": "Staying"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "value": "VarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Impulse.Time",
+                        "Impulse.Time",
                         ">=",
-                        "Variable(__CameraImpulse.Impulse.AwayDuration)"
+                        "Impulse.AwayDuration"
                       ]
                     },
                     {
                       "type": {
-                        "value": "VarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Impulse.Time",
+                        "Impulse.Time",
                         "<",
-                        "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration)"
+                        "Impulse.AwayDuration + Impulse.StayDuration"
                       ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.DistanceFactor",
+                        "DistanceFactor",
                         "=",
                         "1"
                       ]
@@ -234,32 +321,31 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Going back",
-                  "comment2": ""
+                  "comment": "Going back"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "value": "VarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Impulse.Time",
+                        "Impulse.Time",
                         ">=",
-                        "Variable(__CameraImpulse.Impulse.AwayDuration) + Variable(__CameraImpulse.Impulse.StayDuration)"
+                        "Impulse.AwayDuration + Impulse.StayDuration"
                       ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.DistanceFactor",
+                        "DistanceFactor",
                         "=",
-                        "Tween::Ease(VariableString(__CameraImpulse.Impulse.BackEasing), 0, 1, (1 - (Variable(__CameraImpulse.Impulse.Time) - Variable(__CameraImpulse.Impulse.AwayDuration) - Variable(__CameraImpulse.Impulse.StayDuration)) / Variable(__CameraImpulse.Impulse.BackDuration)))"
+                        "Tween::Ease(Impulse.BackEasing, 0, 1, (1 - (Impulse.Time - Impulse.AwayDuration - Impulse.StayDuration) / Impulse.BackDuration))"
                       ]
                     }
                   ]
@@ -274,8 +360,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Keep the camera displacement to revert it in onScenePreEvents",
-                  "comment2": ""
+                  "comment": "Keep the camera displacement to revert it in onScenePreEvents"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -283,49 +368,56 @@
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaX",
+                        "Layers[Impulse.Layer].CameraDeltaX",
                         "+",
-                        "Variable(__CameraImpulse.Impulse.DeltaX) * Variable(__CameraImpulse.DistanceFactor)"
+                        "Impulse.DeltaX * DistanceFactor"
                       ]
                     },
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaY",
+                        "Layers[Impulse.Layer].CameraDeltaY",
                         "+",
-                        "Variable(__CameraImpulse.Impulse.DeltaY) * Variable(__CameraImpulse.DistanceFactor)"
+                        "Impulse.DeltaY * DistanceFactor"
                       ]
                     },
                     {
                       "type": {
-                        "value": "SetCameraX"
+                        "value": "SetCameraCenterX"
                       },
                       "parameters": [
                         "",
                         "+",
-                        "Variable(__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaX)",
-                        "VariableString(__CameraImpulse.Impulse.Layer)",
+                        "Layers[Impulse.Layer].CameraDeltaX",
+                        "Impulse.Layer",
                         "0"
                       ]
                     },
                     {
                       "type": {
-                        "value": "SetCameraY"
+                        "value": "SetCameraCenterY"
                       },
                       "parameters": [
                         "",
                         "+",
-                        "Variable(__CameraImpulse.Layers[VariableString(__CameraImpulse.Impulse.Layer)].CameraDeltaY)",
-                        "VariableString(__CameraImpulse.Impulse.Layer)",
+                        "Layers[Impulse.Layer].CameraDeltaY",
+                        "Impulse.Layer",
                         "0"
                       ]
                     }
                   ]
+                }
+              ],
+              "variables": [
+                {
+                  "name": "DistanceFactor",
+                  "type": "number",
+                  "value": 0
                 }
               ]
             }
@@ -336,12 +428,9 @@
       "objectGroups": []
     },
     {
-      "description": "",
       "fullName": "",
       "functionType": "Action",
-      "group": "",
       "name": "onScenePreEvents",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -354,59 +443,72 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Revert the impulses.",
-          "comment2": ""
+          "comment": "Revert the impulses."
         },
         {
-          "type": "BuiltinCommonInstructions::ForEachChildVariable",
-          "iterableVariableName": "__CameraImpulse.Layers",
-          "valueIteratorVariableName": "__CameraImpulse.Layer",
-          "keyIteratorVariableName": "__CameraImpulse.LayerName",
+          "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
-          "actions": [
+          "actions": [],
+          "events": [
             {
-              "type": {
-                "value": "SetCameraX"
-              },
-              "parameters": [
-                "",
-                "-",
-                "Variable(__CameraImpulse.Layer.CameraDeltaX)",
-                "VariableString(__CameraImpulse.LayerName)",
-                "0"
+              "type": "BuiltinCommonInstructions::ForEachChildVariable",
+              "iterableVariableName": "Layers",
+              "valueIteratorVariableName": "Layer",
+              "keyIteratorVariableName": "LayerName",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetCameraCenterX"
+                  },
+                  "parameters": [
+                    "",
+                    "-",
+                    "Layer.CameraDeltaX",
+                    "LayerName",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetCameraCenterY"
+                  },
+                  "parameters": [
+                    "",
+                    "-",
+                    "Layer.CameraDeltaY",
+                    "LayerName",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetNumberVariable"
+                  },
+                  "parameters": [
+                    "Layers[LayerName].CameraDeltaX",
+                    "=",
+                    "0"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "SetNumberVariable"
+                  },
+                  "parameters": [
+                    "Layers[LayerName].CameraDeltaY",
+                    "=",
+                    "0"
+                  ]
+                }
               ]
-            },
+            }
+          ],
+          "variables": [
             {
-              "type": {
-                "value": "SetCameraY"
-              },
-              "parameters": [
-                "",
-                "-",
-                "Variable(__CameraImpulse.Layer.CameraDeltaY)",
-                "VariableString(__CameraImpulse.LayerName)",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__CameraImpulse.Layers[VariableString(__CameraImpulse.LayerName)].CameraDeltaX",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__CameraImpulse.Layers[VariableString(__CameraImpulse.LayerName)].CameraDeltaY",
-                "=",
-                "0"
-              ]
+              "name": "LayerName",
+              "type": "string",
+              "value": ""
             }
           ]
         }
@@ -418,9 +520,7 @@
       "description": "Add an impulse to the camera position.",
       "fullName": "Add a camera impulse",
       "functionType": "Action",
-      "group": "",
       "name": "AddImpulse",
-      "private": false,
       "sentence": "Add an impulse _PARAM1_ to the camera from layer _PARAM2_ with an amplitude of _PARAM3_  and an angle of _PARAM4_,  going away in _PARAM5_ seconds with _PARAM6_ easing, staying _PARAM7_  seconds, going back in _PARAM8_ seconds with _PARAM9_ easing",
       "events": [
         {
@@ -429,90 +529,90 @@
           "actions": [
             {
               "type": {
-                "value": "ModVarSceneTxt"
+                "value": "SetStringVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].Layer",
+                "Impulses[NewIdentifier].Layer",
                 "=",
-                "Layer"
+                "LayerName"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].DeltaX",
+                "Impulses[NewIdentifier].DeltaX",
                 "=",
                 "DisplacementX"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].DeltaY",
+                "Impulses[NewIdentifier].DeltaY",
                 "=",
                 "DisplacementY"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].AwayDuration",
+                "Impulses[NewIdentifier].AwayDuration",
                 "=",
                 "AwayDuration"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].StayDuration",
+                "Impulses[NewIdentifier].StayDuration",
                 "=",
                 "StayDuration"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].BackDuration",
+                "Impulses[NewIdentifier].BackDuration",
                 "=",
                 "BackDuration"
               ]
             },
             {
               "type": {
-                "value": "ModVarSceneTxt"
+                "value": "SetStringVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].AwayEasing",
+                "Impulses[NewIdentifier].AwayEasing",
                 "=",
                 "AwayEasing"
               ]
             },
             {
               "type": {
-                "value": "ModVarSceneTxt"
+                "value": "SetStringVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].BackEasing",
+                "Impulses[NewIdentifier].BackEasing",
                 "=",
                 "BackEasing"
               ]
             },
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CameraImpulse.Impulses[Identifier].Time",
+                "Impulses[NewIdentifier].Time",
                 "=",
                 "0"
               ]
@@ -522,92 +622,49 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Identifier",
-          "longDescription": "",
-          "name": "Identifier",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "NewIdentifier",
           "type": "string"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Layer",
-          "longDescription": "",
-          "name": "Layer",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "LayerName",
           "type": "string"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Displacement X",
-          "longDescription": "",
           "name": "DisplacementX",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Displacement Y",
-          "longDescription": "",
           "name": "DisplacementY",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get away duration (in seconds)",
-          "longDescription": "",
           "name": "AwayDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get away easing",
-          "longDescription": "",
           "name": "AwayEasing",
-          "optional": false,
           "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
           "type": "stringWithSelector"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Stay duration (in seconds)",
-          "longDescription": "",
           "name": "StayDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get back duration (in seconds)",
-          "longDescription": "",
           "name": "BackDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get back easing",
-          "longDescription": "",
           "name": "BackEasing",
-          "optional": false,
           "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
           "type": "stringWithSelector"
         }
@@ -618,9 +675,7 @@
       "description": "Add an impulse to the camera position.",
       "fullName": "Add a camera impulse (angle)",
       "functionType": "Action",
-      "group": "",
       "name": "AddImpulseAngle",
-      "private": false,
       "sentence": "Add an impulse _PARAM1_ to the camera from layer _PARAM2_ with an amplitude of _PARAM3_  and an angle of _PARAM4_,  going away in _PARAM5_ seconds with _PARAM6_ easing, staying _PARAM7_  seconds, going back in _PARAM8_ seconds with _PARAM9_ easing",
       "events": [
         {
@@ -634,7 +689,7 @@
               "parameters": [
                 "",
                 "Identifier",
-                "Layer",
+                "LayerName",
                 "XFromAngleAndDistance(Angle, Amplitude)",
                 "YFromAngleAndDistance(Angle, Amplitude)",
                 "AwayDuration",
@@ -650,92 +705,49 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Identifier",
-          "longDescription": "",
           "name": "Identifier",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "string"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Layer",
-          "longDescription": "",
-          "name": "Layer",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "LayerName",
           "type": "string"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Amplitude",
-          "longDescription": "",
           "name": "Amplitude",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Angle (in degree)",
-          "longDescription": "",
           "name": "Angle",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get away duration (in seconds)",
-          "longDescription": "",
           "name": "AwayDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get away easing",
-          "longDescription": "",
           "name": "AwayEasing",
-          "optional": false,
           "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
           "type": "stringWithSelector"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Stay duration (in seconds)",
-          "longDescription": "",
           "name": "StayDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get back duration (in seconds)",
-          "longDescription": "",
           "name": "BackDuration",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Get back easing",
-          "longDescription": "",
           "name": "BackEasing",
-          "optional": false,
           "supplementaryInformation": "[\"linear\",\"easeInQuad\",\"easeOutQuad\",\"easeInOutQuad\",\"easeInCubic\",\"easeOutCubic\",\"easeInOutCubic\",\"easeInQuart\",\"easeOutQuart\",\"easeInOutQuart\",\"easeInQuint\",\"easeOutQuint\",\"easeInOutQuint\",\"easeInOutSine\",\"easeInExpo\",\"easeOutExpo\",\"easeInOutExpo\",\"easeInCirc\",\"easeOutCirc\",\"easeInOutCirc\",\"easeOutBounce\",\"easeInBack\",\"easeOutBack\",\"easeInOutBack\",\"elastic\",\"swingFromTo\",\"swingFrom\",\"swingTo\",\"bounce\",\"bouncePast\",\"easeFromTo\",\"easeFrom\",\"easeTo\"]",
           "type": "stringWithSelector"
         }
@@ -746,9 +758,7 @@
       "description": "Check if a camera impulse is playing.",
       "fullName": "Camera impulse is playing",
       "functionType": "Condition",
-      "group": "",
       "name": "IsPlaying",
-      "private": false,
       "sentence": "Camera impulse _PARAM1_ is playing",
       "events": [
         {
@@ -756,10 +766,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VariableChildExists"
+                "value": "VariableChildExists2"
               },
               "parameters": [
-                "__CameraImpulse.Impulses",
+                "Impulses",
                 "Identifier"
               ]
             }
@@ -778,18 +788,14 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Identifier",
-          "longDescription": "",
           "name": "Identifier",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "string"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/CursorType.json
+++ b/extensions/reviewed/CursorType.json
@@ -1,7 +1,6 @@
 {
   "author": "@Bouh, @arthuro555",
   "category": "User interface",
-  "description": "Provides an action to change the type of the cursor, and a behavior to change the cursor when an object is hovered.\n\nFind the list of cursors here: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
   "extensionNamespace": "",
   "fullName": "Cursor type",
   "helpPath": "",
@@ -9,7 +8,12 @@
   "name": "CursorType",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/cursor-default-outline.svg",
   "shortDescription": "Provides an action to change the type of the cursor, and a behavior to change the cursor when an object is hovered.",
-  "version": "0.0.7",
+  "version": "0.0.8",
+  "description": [
+    "Provides an action to change the type of the cursor, and a behavior to change the cursor when an object is hovered.",
+    "",
+    "Find the list of cursors here: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor"
+  ],
   "origin": {
     "identifier": "CursorType",
     "name": "gdevelop-extension-store"
@@ -26,19 +30,29 @@
     "2OwwM8ToR9dx9RJ2sAKTcrLmCB92"
   ],
   "dependencies": [],
+  "globalVariables": [
+    {
+      "name": "ZOrderSorting",
+      "type": "number",
+      "value": 0
+    }
+  ],
+  "sceneVariables": [
+    {
+      "name": "DefaultCursor",
+      "type": "string",
+      "value": "default"
+    }
+  ],
   "eventsFunctions": [
     {
       "description": "Change the type of the cursor.",
       "fullName": "Cursor type",
       "functionType": "Action",
-      "group": "",
       "name": "ChangeCursorType",
-      "private": false,
       "sentence": "Change the cursor to _PARAM1_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -48,48 +62,41 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Set as variable instead of directly setting as a CursorHover behavior can override it.\nBy using a variable, we ensure to be able to change it back to that \"default\" after the override is over.",
-          "comment2": ""
+          "comment": "Set as variable instead of directly setting as a CursorHover behavior can override it.\nBy using a variable, we ensure to be able to change it back to that \"default\" after the override is over."
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "ModVarGlobalTxt"
+                "value": "SetStringVariable"
               },
               "parameters": [
-                "__CursorType.DefaultCursor",
+                "DefaultCursor",
                 "=",
-                "cursor_type"
-              ],
-              "subInstructions": []
+                "CursorType"
+              ]
+            },
+            {
+              "type": {
+                "value": "CursorType::DoChangeCursorType"
+              },
+              "parameters": [
+                "",
+                "CursorType",
+                ""
+              ]
             }
-          ],
-          "events": []
-        },
-        {
-          "disabled": true,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "// Reset to default cursor\nruntimeScene.getGame().getRenderer().getCanvas().style.cursor =\n    runtimeScene\n        .getGame()\n        .getVariables()\n        .get(\"__CursorType\").getChild(\"DefaultCursor\")\n        .getAsString();\n",
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": false
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
           "defaultValue": "default",
           "description": "The new cursor type",
           "longDescription": "List of available cursors on https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
-          "name": "cursor_type",
-          "optional": false,
+          "name": "CursorType",
           "supplementaryInformation": "[\"auto\",\"default\",\"none\",\"context-menu\",\"help\",\"pointer\",\"progress\",\"wait\",\"cell\",\"crosshair\",\"text\",\"vertical-text\",\"alias\",\"copy\",\"move\",\"no-drop\",\"not-allowed\",\"grab\",\"grabbing\",\"all-scroll\",\"col-resize\",\"row-resize\",\"n-resize\",\"e-resize\",\"s-resize\",\"w-resize\",\"ne-resize\",\"nw-resize\",\"se-resize\",\"sw-resize\",\"ew-resize\",\"ns-resize\",\"nwse-resize\",\"zoom-in\",\"zoom-out\"]",
           "type": "stringWithSelector"
         }
@@ -97,17 +104,43 @@
       "objectGroups": []
     },
     {
-      "description": "",
+      "description": "Do change the type of the cursor.",
+      "fullName": "Do change cursor type",
+      "functionType": "Action",
+      "name": "DoChangeCursorType",
+      "private": true,
+      "sentence": "Do change the cursor to _PARAM1_",
+      "events": [
+        {
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": [
+            "const cursorType = eventsFunctionContext.getArgument(\"CursorType\");",
+            "",
+            "runtimeScene.getGame().getRenderer().getCanvas().style.cursor = cursorType;",
+            ""
+          ],
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "description": "The new cursor type",
+          "name": "CursorType",
+          "supplementaryInformation": "[]",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
       "fullName": "",
       "functionType": "Action",
-      "group": "",
       "name": "onScenePreEvents",
-      "private": false,
       "sentence": "",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -117,87 +150,33 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Reset ordering as the object with highest Z-Order might not exist anymore or be not be hovered anymore.",
-          "comment2": ""
+          "comment": "Reset ordering as the object with highest Z-Order might not exist anymore or be not be hovered anymore."
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "ModVarGlobal"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__CursorType.ZOrderSorting",
+                "ZOrderSorting",
                 "=",
                 "0"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Set default value of the default cursor if the variable has just been created",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
+              ]
+            },
             {
               "type": {
-                "inverted": false,
-                "value": "VarSceneTxt"
+                "value": "CursorType::DoChangeCursorType"
               },
               "parameters": [
-                "__CursorType.DefaultCursor",
-                "=",
-                "\"\""
-              ],
-              "subInstructions": []
+                "",
+                "DefaultCursor",
+                ""
+              ]
             }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarGlobalTxt"
-              },
-              "parameters": [
-                "__CursorType.DefaultCursor",
-                "=",
-                "\"default\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "// Reset to default cursor\nruntimeScene.getGame().getRenderer().getCanvas().style.cursor =\n    runtimeScene\n        .getGame()\n        .getVariables()\n        .get(\"__CursorType\").getChild(\"DefaultCursor\")\n        .getAsString();\n",
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": true
+          ]
         }
       ],
       "parameters": [],
@@ -212,17 +191,12 @@
       "objectType": "",
       "eventsFunctions": [
         {
-          "description": "",
           "fullName": "",
           "functionType": "Action",
-          "group": "",
           "name": "doStepPostEvents",
-          "private": false,
           "sentence": "",
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
                 "b": 109,
@@ -232,29 +206,23 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Check the z Order to ensure the cursor shown is the one from the foremost object ",
-              "comment2": ""
+              "comment": "Check the z Order to ensure the cursor shown is the one from the foremost object "
             },
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "Plan"
                   },
                   "parameters": [
                     "Object",
                     ">",
-                    "GlobalVariable(__CursorType.ZOrderSorting)"
-                  ],
-                  "subInstructions": []
+                    "ZOrderSorting"
+                  ]
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "SourisSurObjet"
                   },
                   "parameters": [
@@ -262,55 +230,42 @@
                     "",
                     "",
                     ""
-                  ],
-                  "subInstructions": []
+                  ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "ModVarGlobal"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__CursorType.ZOrderSorting",
+                    "ZOrderSorting",
                     "=",
                     "Object.ZOrder()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": [
+                  ]
+                },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::JsCode",
-                  "inlineCode": "// Set cursor to behavior property cursor_type\nobjects.forEach(object => {\n\n    runtimeScene\n        .getGame()\n        .getRenderer()\n        .getCanvas()\n        .style\n        .cursor = object\n            .getBehavior(\n                eventsFunctionContext.getBehaviorName(\"Behavior\")\n            )\n            ._getcursor_type();\n});",
-                  "parameterObjects": "Object",
-                  "useStrict": true,
-                  "eventsSheetExpanded": true
+                  "type": {
+                    "value": "CursorType::DoChangeCursorType"
+                  },
+                  "parameters": [
+                    "",
+                    "CursorType",
+                    ""
+                  ]
                 }
               ]
             }
           ],
           "parameters": [
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Object",
-              "longDescription": "",
               "name": "Object",
-              "optional": false,
-              "supplementaryInformation": "",
               "type": "object"
             },
             {
-              "codeOnly": false,
-              "defaultValue": "",
               "description": "Behavior",
-              "longDescription": "",
               "name": "Behavior",
-              "optional": false,
               "supplementaryInformation": "CursorType::CursorHover",
               "type": "behavior"
             }
@@ -362,10 +317,11 @@
             "zoom-in",
             "zoom-out"
           ],
-          "hidden": false,
-          "name": "cursor_type"
+          "name": "CursorType"
         }
-      ]
+      ],
+      "sharedPropertyDescriptors": []
     }
-  ]
+  ],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/DoubleClick.json
+++ b/extensions/reviewed/DoubleClick.json
@@ -1,7 +1,6 @@
 {
   "author": "Silver-Streak",
   "category": "Input",
-  "description": "Allow you to check for double-clicks with the left, middle, or right button of a mouse. It will also allow you to detect double-taps on touchscreens. \n\nPlease note: Touch devices do not have alternatives for middle/right clicks. Taps on a touch device will get counted for _any_ use of these conditions, so you should either design your controls accordingly, or build out separate events if the device has a touch screen.",
   "extensionNamespace": "",
   "fullName": "Double-click",
   "helpPath": "",
@@ -9,7 +8,16 @@
   "name": "DoubleClick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_mouse_wireless_pc.svg",
   "shortDescription": "Check for a double-click with a mouse, or a double-tap on a touchscreen.",
-  "version": "1.0.3",
+  "version": "1.1.0",
+  "description": [
+    "Check for a double-click with a mouse, or a double-tap on a touchscreen.",
+    "",
+    "Please note: Touch devices do not have alternatives for middle/right clicks. Taps on a touch device will get counted for _any_ use of these conditions, so you should either design your controls accordingly, or build out separate events if the device has a touch screen."
+  ],
+  "origin": {
+    "identifier": "DoubleClick",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "mouse",
     "cursor",
@@ -21,856 +29,229 @@
     "8Ih1aa8f5gWUp4UB2BdhQ2iXWxJ3"
   ],
   "dependencies": [],
+  "globalVariables": [
+    {
+      "name": "MaxDelay",
+      "type": "number",
+      "value": 0.5
+    },
+    {
+      "name": "LeftCount",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "LeftReleased",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "LastPressTime",
+      "type": "structure",
+      "children": [
+        {
+          "name": "Left",
+          "type": "number",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "name": "IsReleased",
+      "type": "structure",
+      "children": [
+        {
+          "name": "Left",
+          "type": "boolean",
+          "value": false
+        }
+      ]
+    }
+  ],
+  "sceneVariables": [
+    {
+      "name": "Variable",
+      "type": "number",
+      "value": 0
+    }
+  ],
   "eventsFunctions": [
     {
       "description": "Check if the specified mouse button is clicked twice in a short amount of time.",
       "fullName": "Double-clicked (or double-tapped)",
       "functionType": "Condition",
       "name": "HasDoubleClicked",
-      "private": false,
-      "sentence": "_PARAM1_ mouse button is double-clicked (or double-tap on a touchscreen)",
+      "sentence": "_PARAM1_ mouse button is double-clicked",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Trigger once must never be used in functions as every call would share the same one."
+        },
+        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
-                "value": "StrEqual"
+                "inverted": true,
+                "value": "MouseButtonFromTextPressed"
               },
               "parameters": [
-                "MouseButton",
-                "=",
-                "\"Left\""
-              ],
-              "subInstructions": []
+                "",
+                "MouseButton"
+              ]
             }
           ],
-          "actions": [],
-          "events": [
+          "actions": [
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_LeftClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "RemoveTimer"
-                  },
-                  "parameters": [
-                    "",
-                    "\"__DoubleClick_LeftClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_LeftCount",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseButtonReleased"
-                  },
-                  "parameters": [
-                    "",
-                    "Left"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_LeftReleased",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_LeftClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SourisBouton"
-                  },
-                  "parameters": [
-                    "",
-                    "Left"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftCount",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftReleased",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ResetTimer"
-                      },
-                      "parameters": [
-                        "",
-                        "\"__DoubleClick_LeftClickTimer\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftCount",
-                        "+",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftCount",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftReleased",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetReturnBoolean"
-                      },
-                      "parameters": [
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_LeftReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
+              "type": {
+                "value": "SetBooleanVariable"
+              },
+              "parameters": [
+                "IsReleased[MouseButton]",
+                "True",
+                "1"
               ]
             }
           ]
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
-                "value": "StrEqual"
+                "value": "MouseButtonFromTextPressed"
               },
               "parameters": [
-                "MouseButton",
-                "=",
-                "\"Middle\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [],
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_MiddleClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "RemoveTimer"
-                  },
-                  "parameters": [
-                    "",
-                    "\"__DoubleClick_MiddleClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_MiddleCount",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+                "",
+                "MouseButton"
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseButtonReleased"
-                  },
-                  "parameters": [
-                    "",
-                    "Middle"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_MiddleReleased",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
+              "type": {
+                "value": "BooleanVariable"
+              },
+              "parameters": [
+                "IsReleased[MouseButton]",
+                "True",
+                "1"
+              ]
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_MiddleClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SourisBouton"
-                  },
-                  "parameters": [
-                    "",
-                    "Middle"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleCount",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleReleased",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ResetTimer"
-                      },
-                      "parameters": [
-                        "",
-                        "\"__DoubleClick_MiddleClickTimer\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleCount",
-                        "+",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleCount",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleReleased",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetReturnBoolean"
-                      },
-                      "parameters": [
-                        "True"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_MiddleReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareNumbers"
+              },
+              "parameters": [
+                "TimeFromStart()",
+                ">=",
+                "MaxDelay"
               ]
             }
-          ]
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
+          ],
+          "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "StrEqual"
+                "value": "SetBooleanVariable"
               },
               "parameters": [
-                "MouseButton",
-                "=",
-                "\"Right\""
-              ],
-              "subInstructions": []
+                "IsReleased[MouseButton]",
+                "False",
+                "1"
+              ]
             }
           ],
-          "actions": [],
           "events": [
             {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_RightClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
+              "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "RemoveTimer"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "",
-                    "\"__DoubleClick_RightClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_RightCount",
+                    "Delay",
                     "=",
-                    "0"
-                  ],
-                  "subInstructions": []
+                    "TimeFromStart() - LastPressTime[MouseButton]"
+                  ]
                 }
               ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseButtonReleased"
-                  },
-                  "parameters": [
-                    "",
-                    "Right"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DoubleClick_RightReleased",
-                    "=",
-                    "0"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": true,
-                    "value": "Timer"
-                  },
-                  "parameters": [
-                    "",
-                    "GlobalVariable(__DoubleClick_MaxDelay)",
-                    "\"__DoubleClick_RightClickTimer\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SourisBouton"
-                  },
-                  "parameters": [
-                    "",
-                    "Right"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [],
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "VarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__DoubleClick_RightCount",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_RightReleased",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
+                        "Delay",
+                        "<=",
+                        "MaxDelay"
+                      ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ResetTimer"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "",
-                        "\"__DoubleClick_RightClickTimer\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_RightCount",
-                        "+",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_RightReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_RightCount",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarScene"
-                      },
-                      "parameters": [
-                        "__DoubleClick_RightReleased",
+                        "LastPressTime[MouseButton]",
                         "=",
                         "0"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": [],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
                         "value": "SetReturnBoolean"
                       },
                       "parameters": [
                         "True"
-                      ],
-                      "subInstructions": []
-                    },
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarScene"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "__DoubleClick_RightReleased",
-                        "=",
-                        "1"
-                      ],
-                      "subInstructions": []
+                        "Delay",
+                        ">",
+                        "MaxDelay"
+                      ]
                     }
                   ],
-                  "events": []
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetNumberVariable"
+                      },
+                      "parameters": [
+                        "LastPressTime[MouseButton]",
+                        "=",
+                        "TimeFromStart()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "variables": [
+                {
+                  "name": "Delay",
+                  "type": "number",
+                  "value": 0
                 }
               ]
             }
@@ -879,13 +260,9 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Mouse button to track",
           "longDescription": "As touch devices do not have middle/right tap equivalents, you will need to account for this within your events if you're not using the left mouse button and building for touch devices.",
           "name": "MouseButton",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "mouse"
         }
       ],
@@ -896,78 +273,36 @@
       "fullName": "Set the double click delay",
       "functionType": "Action",
       "name": "SetMaxDelay",
-      "private": false,
       "sentence": "Set the double-click maximum delay between two clicks (or two taps) to _PARAM1_s",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "inverted": false,
-                "value": "ModVarGlobal"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__DoubleClick_MaxDelay",
+                "MaxDelay",
                 "=",
-                "MaxDelay"
-              ],
-              "subInstructions": []
+                "Value"
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Maximum delay (in seconds)",
           "longDescription": "By default, this value is 0.5 seconds.",
-          "name": "MaxDelay",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "Value",
           "type": "expression"
         }
       ],
       "objectGroups": []
-    },
-    {
-      "description": "",
-      "fullName": "",
-      "functionType": "Action",
-      "name": "onFirstSceneLoaded",
-      "private": false,
-      "sentence": "",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarGlobal"
-              },
-              "parameters": [
-                "__DoubleClick_MaxDelay",
-                "=",
-                "0.5"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        }
-      ],
-      "parameters": [],
-      "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/DoubleClick.json
+++ b/extensions/reviewed/DoubleClick.json
@@ -34,17 +34,9 @@
       "name": "MaxDelay",
       "type": "number",
       "value": 0.5
-    },
-    {
-      "name": "LeftCount",
-      "type": "number",
-      "value": 0
-    },
-    {
-      "name": "LeftReleased",
-      "type": "number",
-      "value": 0
-    },
+    }
+  ],
+  "sceneVariables": [
     {
       "name": "LastPressTime",
       "type": "structure",
@@ -66,13 +58,6 @@
           "value": false
         }
       ]
-    }
-  ],
-  "sceneVariables": [
-    {
-      "name": "Variable",
-      "type": "number",
-      "value": 0
     }
   ],
   "eventsFunctions": [

--- a/extensions/reviewed/DragCameraWithPointer.json
+++ b/extensions/reviewed/DragCameraWithPointer.json
@@ -1,7 +1,6 @@
 {
   "author": "@ddabrahim",
   "category": "Camera",
-  "description": "Move a camera by dragging the mouse (or touchscreen). \n\nHow to use:\n- Run this action on every frame that you want the camera to be movable by the mouse (or touchscreen)\n- Select the mouse button to use (choose \"left\" for touchscreen)\n- Select which directions the camera will move (vertical, horizontal, or both) \n- Select the layer that will be moved\n\nTips:\n- If no parameters are selected, the camera will move in both directions when the left mouse button (or touchscreen) are dragged.",
   "extensionNamespace": "",
   "fullName": "Drag camera with the mouse (or touchscreen)",
   "helpPath": "",
@@ -9,7 +8,19 @@
   "name": "DragCameraWithPointer",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/drag-variant.svg",
   "shortDescription": "Move a camera by dragging the mouse (or touchscreen).",
-  "version": "1.1.1",
+  "version": "1.2.0",
+  "description": [
+    "Move a camera by dragging the mouse (or touchscreen). ",
+    "",
+    "How to use:",
+    "- Run this action on every frame that you want the camera to be movable by the mouse (or touchscreen)",
+    "- Select the mouse button to use (choose \"left\" for touchscreen)",
+    "- Select which directions the camera will move (vertical, horizontal, or both) ",
+    "- Select the layer that will be moved",
+    "",
+    "Tips:",
+    "- If no parameters are selected, the camera will move in both directions when the left mouse button (or touchscreen) are dragged."
+  ],
   "origin": {
     "identifier": "DragCameraWithPointer",
     "name": "gdevelop-extension-store"
@@ -29,178 +40,59 @@
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [
+    {
+      "name": "ScrollStartX",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "ScrollStartY",
+      "type": "number",
+      "value": 0
+    }
+  ],
   "eventsFunctions": [
     {
       "description": "Move a camera by dragging the mouse (or touchscreen).",
       "fullName": "Drag camera with the mouse",
       "functionType": "Action",
-      "group": "",
       "name": "DragCameraWithPointer",
-      "private": false,
       "sentence": "Drag camera on layer _PARAM2_ in _PARAM3_ directions using _PARAM4_ mouse button",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "When mouse button is pressed, get starting position of mouse",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "BuiltinCommonInstructions::Or"
               },
               "parameters": [],
               "subInstructions": [
                 {
                   "type": {
-                    "inverted": false,
                     "value": "MouseButtonFromTextPressed"
                   },
                   "parameters": [
                     "",
                     "InputButton"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::And"
-                  },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "MouseButtonPressed"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": true,
-                        "value": "GetArgumentAsBoolean"
-                      },
-                      "parameters": [
-                        "\"InputButton\""
-                      ],
-                      "subInstructions": []
-                    }
                   ]
-                }
-              ]
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Once"
-              },
-              "parameters": [],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__DragCameraWithPointer.scrollStartX",
-                "=",
-                "MouseX(CamLayer,CamNumber)"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__DragCameraWithPointer.scrollStartY",
-                "=",
-                "MouseY(CamLayer,CamNumber)"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "When mouse button is pressed, get current position of mouse and calculate distance between the previous and current position on X and Y axis",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Or"
-              },
-              "parameters": [],
-              "subInstructions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "MouseButtonFromTextPressed"
-                  },
-                  "parameters": [
-                    "",
-                    "InputButton"
-                  ],
-                  "subInstructions": []
                 },
                 {
                   "type": {
-                    "inverted": false,
                     "value": "BuiltinCommonInstructions::And"
                   },
                   "parameters": [],
                   "subInstructions": [
                     {
                       "type": {
-                        "inverted": false,
                         "value": "MouseButtonPressed"
                       },
                       "parameters": [
                         "",
                         "Left"
-                      ],
-                      "subInstructions": []
+                      ]
                     },
                     {
                       "type": {
@@ -209,8 +101,7 @@
                       },
                       "parameters": [
                         "\"InputButton\""
-                      ],
-                      "subInstructions": []
+                      ]
                     }
                   ]
                 }
@@ -220,301 +111,93 @@
           "actions": [],
           "events": [
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DragCameraWithPointer.scrollTargetX",
-                    "=",
-                    "MouseX(CamLayer,CamNumber)"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DragCameraWithPointer.scrollTargetY",
-                    "=",
-                    "MouseY(CamLayer,CamNumber)"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DragCameraWithPointer.scrollDistanceX",
-                    "=",
-                    "(Variable(__DragCameraWithPointer.scrollTargetX) - Variable(__DragCameraWithPointer.scrollStartX))"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__DragCameraWithPointer.scrollDistanceY",
-                    "=",
-                    "(Variable(__DragCameraWithPointer.scrollTargetY) - Variable(__DragCameraWithPointer.scrollStartY))"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "If selected direction is horizontal, both, or left blank, move camera on X axis",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Or"
+                    "value": "BuiltinCommonInstructions::Once"
                   },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"horizontal\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"both\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"\""
-                      ],
-                      "subInstructions": []
-                    }
-                  ]
+                  "parameters": []
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
+                  "type": {
+                    "value": "SetNumberVariable"
                   },
-                  "comment": "Only move camera when the distance is more than one pixel",
-                  "comment2": ""
+                  "parameters": [
+                    "ScrollStartX",
+                    "=",
+                    "CursorX(Layer, Camera)"
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "abs(Variable(__DragCameraWithPointer.scrollDistanceX))",
-                        ">=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraX"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "Variable(__DragCameraWithPointer.scrollDistanceX)",
-                        "CamLayer",
-                        "CamNumber"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
+                  "type": {
+                    "value": "SetNumberVariable"
+                  },
+                  "parameters": [
+                    "ScrollStartY",
+                    "=",
+                    "CursorY(Layer, Camera)"
+                  ]
                 }
               ]
             },
             {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "If direction is vertical, both, or left blank, move camera on Y axis",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Or"
+                    "value": "StrEqual"
                   },
-                  "parameters": [],
-                  "subInstructions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"vertical\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"both\""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "StrEqual"
-                      },
-                      "parameters": [
-                        "Direction",
-                        "=",
-                        "\"\""
-                      ],
-                      "subInstructions": []
-                    }
+                  "parameters": [
+                    "Direction",
+                    "!=",
+                    "\"vertical\""
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
+                  "type": {
+                    "value": "SetCameraCenterX"
                   },
-                  "comment": "Only move camera when the distance is more than one pixel",
-                  "comment2": ""
-                },
+                  "parameters": [
+                    "",
+                    "-",
+                    "CursorX(Layer, Camera) - ScrollStartX",
+                    "Layer",
+                    "Camera"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "Egal"
-                      },
-                      "parameters": [
-                        "abs(Variable(__DragCameraWithPointer.scrollDistanceY))",
-                        ">=",
-                        "1"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SetCameraY"
-                      },
-                      "parameters": [
-                        "",
-                        "-",
-                        "Variable(__DragCameraWithPointer.scrollDistanceY)",
-                        "CamLayer",
-                        "CamNumber"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
+                  "type": {
+                    "value": "StrEqual"
+                  },
+                  "parameters": [
+                    "Direction",
+                    "!=",
+                    "\"horizontal\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetCameraCenterY"
+                  },
+                  "parameters": [
+                    "",
+                    "-",
+                    "CursorY(Layer, Camera) - ScrollStartY",
+                    "Layer",
+                    "Camera"
+                  ]
                 }
               ]
             }
@@ -523,48 +206,30 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Camera number (default: 0)",
-          "longDescription": "",
-          "name": "CamNumber",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "Camera",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Camera layer (default: \"\")",
-          "longDescription": "",
-          "name": "CamLayer",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "Layer",
           "type": "layer"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Directions that the camera can move (horizontal, vertical, both)",
-          "longDescription": "",
           "name": "Direction",
-          "optional": false,
           "supplementaryInformation": "[\"vertical\",\"horizontal\",\"both\"]",
           "type": "stringWithSelector"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Mouse button (use \"Left\" for touchscreen)",
-          "longDescription": "",
           "name": "InputButton",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "mouse"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/EdgeScrollCamera.json
+++ b/extensions/reviewed/EdgeScrollCamera.json
@@ -1,7 +1,6 @@
 {
   "author": "",
   "category": "Camera",
-  "description": "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.\n\nHow to use:\n- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene\n- Run the action \"Configure edge camera scrolling\" at the beginning of scene\n\nTips:\n- \"Progressive speed\" makes the camera scroll faster the closer the cursor gets to the edge of screen\n- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF\n- Use the action \"Enforce camera boundaries\" to restrict what the player can see\n- Use the extension \"Copy camera settings\" if you want multiple layers to move\n\nExpressions:\n- EdgeScrollSpeedX() - Current scroll speed (horizontal)\n- EdgeScrollSpeedY() - Current scroll speed (vertical)\n",
   "extensionNamespace": "",
   "fullName": "Edge scroll camera",
   "helpPath": "",
@@ -9,7 +8,29 @@
   "name": "EdgeScrollCamera",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/camera-metering-matrix.svg",
   "shortDescription": "Scroll camera when cursor is near edge of screen.",
-  "version": "1.0.1",
+  "version": "1.1.0",
+  "description": [
+    "Edge scroll camera allows the player to move around the scene simply by moving the cursor near the edge they want the camera to move towards.  This is common in RTS games, but it can be useful for many things.",
+    "",
+    "How to use:",
+    "- Run the action \"Enable (or disable) edge camera scrolling\" at the beginning of scene",
+    "- Run the action \"Configure edge camera scrolling\" at the beginning of scene",
+    "",
+    "Tips:",
+    "- \"Progressive speed\" makes the camera scroll faster the closer the cursor gets to the edge of screen",
+    "- Use the action \"Enable (or disable) edge camera scrolling\" to turn the scrolling ON or OFF",
+    "- Use the action \"Enforce camera boundaries\" to restrict what the player can see",
+    "- Use the extension \"Copy camera settings\" if you want multiple layers to move",
+    "",
+    "Expressions:",
+    "- EdgeScrollSpeedX() - Current scroll speed (horizontal)",
+    "- EdgeScrollSpeedY() - Current scroll speed (vertical)",
+    ""
+  ],
+  "origin": {
+    "identifier": "EdgeScrollCamera",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "camera",
     "scroll",
@@ -22,14 +43,59 @@
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [
+    {
+      "name": "Enabled",
+      "type": "boolean",
+      "value": false
+    },
+    {
+      "name": "Style",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "Layer",
+      "type": "string",
+      "value": ""
+    },
+    {
+      "name": "Camera",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "ScrollSpeed",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "ScreenMargin",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "CursorMoved",
+      "type": "boolean",
+      "value": false
+    },
+    {
+      "name": "CurrentScrollSpeedX",
+      "type": "number",
+      "value": 0
+    },
+    {
+      "name": "CurrentScrollSpeedY",
+      "type": "number",
+      "value": 0
+    }
+  ],
   "eventsFunctions": [
     {
-      "description": "",
       "fullName": "",
       "functionType": "Action",
-      "group": "",
       "name": "onSceneLoaded",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -42,8 +108,7 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Set default values",
-          "comment2": ""
+          "comment": "Set default values"
         },
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -70,12 +135,9 @@
       "objectGroups": []
     },
     {
-      "description": "",
       "fullName": "",
       "functionType": "Action",
-      "group": "",
       "name": "onScenePreEvents",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -92,11 +154,12 @@
               "conditions": [
                 {
                   "type": {
-                    "value": "SceneVariableAsBoolean"
+                    "value": "BooleanVariable"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.Enabled",
-                    "True"
+                    "Enabled",
+                    "True",
+                    ""
                   ]
                 }
               ],
@@ -112,8 +175,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Prevent camera movement until cursor has moved (cursor starts at 0,0 which triggers scrolling)",
-                  "comment2": ""
+                  "comment": "Prevent camera movement until cursor has moved (cursor starts at 0,0 which triggers scrolling)"
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -126,45 +188,40 @@
                       "subInstructions": [
                         {
                           "type": {
-                            "value": "MouseX"
+                            "value": "CursorX"
                           },
                           "parameters": [
                             "",
                             "!=",
                             "0",
-                            "VariableString(__EdgeScrollCamera.Layer)",
-                            "Variable(__EdgeScrollCamera.Camera)"
+                            "Layer",
+                            "Camera"
                           ]
                         },
                         {
                           "type": {
-                            "value": "MouseY"
+                            "value": "CursorY"
                           },
                           "parameters": [
                             "",
                             "!=",
                             "0",
-                            "VariableString(__EdgeScrollCamera.Layer)",
-                            "Variable(__EdgeScrollCamera.Camera)"
+                            "Layer",
+                            "Camera"
                           ]
                         }
                       ]
-                    },
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": []
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "value": "SetSceneVariableAsBoolean"
+                        "value": "SetBooleanVariable"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.CursorMoved",
-                        "True"
+                        "CursorMoved",
+                        "True",
+                        ""
                       ]
                     }
                   ]
@@ -174,31 +231,32 @@
                   "conditions": [
                     {
                       "type": {
-                        "value": "SceneVariableAsBoolean"
+                        "value": "BooleanVariable"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.CursorMoved",
-                        "True"
+                        "CursorMoved",
+                        "True",
+                        ""
                       ]
                     }
                   ],
                   "actions": [
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.CurrentScrollSpeedX",
+                        "CurrentScrollSpeedX",
                         "=",
                         "0"
                       ]
                     },
                     {
                       "type": {
-                        "value": "ModVarScene"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "__EdgeScrollCamera.CurrentScrollSpeedY",
+                        "CurrentScrollSpeedY",
                         "=",
                         "0"
                       ]
@@ -224,8 +282,7 @@
                             "textG": 0,
                             "textR": 0
                           },
-                          "comment": "Only move camera while mouse is inside game window",
-                          "comment2": ""
+                          "comment": "Only move camera while mouse is inside game window"
                         },
                         {
                           "type": "BuiltinCommonInstructions::Standard",
@@ -251,34 +308,33 @@
                                 "textG": 0,
                                 "textR": 0
                               },
-                              "comment": "Up",
-                              "comment2": ""
+                              "comment": "Up"
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "MouseY"
+                                    "value": "CursorY"
                                   },
                                   "parameters": [
                                     "",
                                     "<=",
-                                    "CameraBorderTop(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                    "VariableString(__EdgeScrollCamera.Layer)",
-                                    "Variable(__EdgeScrollCamera.Camera)"
+                                    "CameraBorderTop(Layer, Camera) + ScreenMargin",
+                                    "Layer",
+                                    "Camera"
                                   ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "value": "ModVarScene"
+                                    "value": "SetNumberVariable"
                                   },
                                   "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                    "CurrentScrollSpeedY",
                                     "=",
-                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderTop(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderTop(Layer, Camera) - CursorY(Layer, Camera))"
                                   ]
                                 }
                               ]
@@ -293,34 +349,33 @@
                                 "textG": 0,
                                 "textR": 0
                               },
-                              "comment": "Down",
-                              "comment2": ""
+                              "comment": "Down"
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "MouseY"
+                                    "value": "CursorY"
                                   },
                                   "parameters": [
                                     "",
                                     ">=",
-                                    "CameraBorderBottom(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                    "VariableString(__EdgeScrollCamera.Layer)",
-                                    "Variable(__EdgeScrollCamera.Camera)"
+                                    "CameraBorderBottom(Layer, Camera) - ScreenMargin",
+                                    "Layer",
+                                    "Camera"
                                   ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "value": "ModVarScene"
+                                    "value": "SetNumberVariable"
                                   },
                                   "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                    "CurrentScrollSpeedY",
                                     "=",
-                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderBottom(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseY(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderBottom(Layer, Camera) - CursorY(Layer, Camera))"
                                   ]
                                 }
                               ]
@@ -335,34 +390,33 @@
                                 "textG": 0,
                                 "textR": 0
                               },
-                              "comment": "Left",
-                              "comment2": ""
+                              "comment": "Left"
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "MouseX"
+                                    "value": "CursorX"
                                   },
                                   "parameters": [
                                     "",
                                     "<=",
-                                    "CameraBorderLeft(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                                    "VariableString(__EdgeScrollCamera.Layer)",
-                                    "Variable(__EdgeScrollCamera.Camera)"
+                                    "CameraBorderLeft(Layer, Camera) + ScreenMargin",
+                                    "Layer",
+                                    "Camera"
                                   ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "value": "ModVarScene"
+                                    "value": "SetNumberVariable"
                                   },
                                   "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                    "CurrentScrollSpeedX",
                                     "=",
-                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderLeft(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                    "-EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderLeft(Layer, Camera) - CursorX(Layer, Camera))"
                                   ]
                                 }
                               ]
@@ -377,34 +431,33 @@
                                 "textG": 0,
                                 "textR": 0
                               },
-                              "comment": "Right",
-                              "comment2": ""
+                              "comment": "Right"
                             },
                             {
                               "type": "BuiltinCommonInstructions::Standard",
                               "conditions": [
                                 {
                                   "type": {
-                                    "value": "MouseX"
+                                    "value": "CursorX"
                                   },
                                   "parameters": [
                                     "",
                                     ">=",
-                                    "CameraBorderRight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                                    "VariableString(__EdgeScrollCamera.Layer)",
-                                    "Variable(__EdgeScrollCamera.Camera)"
+                                    "CameraBorderRight(Layer, Camera) - ScreenMargin",
+                                    "VariableString(Layer)",
+                                    "Camera"
                                   ]
                                 }
                               ],
                               "actions": [
                                 {
                                   "type": {
-                                    "value": "ModVarScene"
+                                    "value": "SetNumberVariable"
                                   },
                                   "parameters": [
-                                    "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                    "CurrentScrollSpeedX",
                                     "=",
-                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderRight(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)) - MouseX(VariableString(__EdgeScrollCamera.Layer), Variable(__EdgeScrollCamera.Camera)))"
+                                    "EdgeScrollCamera::AbsoluteScrollSpeed(CameraBorderRight(Layer, Camera) - CursorX(Layer, Camera))"
                                   ]
                                 }
                               ]
@@ -428,10 +481,10 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "VarScene"
+                                "value": "NumberVariable"
                               },
                               "parameters": [
-                                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                                "CurrentScrollSpeedX",
                                 "!=",
                                 "0"
                               ]
@@ -440,14 +493,14 @@
                           "actions": [
                             {
                               "type": {
-                                "value": "SetCameraX"
+                                "value": "SetCameraCenterX"
                               },
                               "parameters": [
                                 "",
                                 "+",
-                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX) * TimeDelta()",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
+                                "CurrentScrollSpeedX * TimeDelta()",
+                                "Layer",
+                                "Camera"
                               ]
                             }
                           ]
@@ -457,10 +510,10 @@
                           "conditions": [
                             {
                               "type": {
-                                "value": "VarScene"
+                                "value": "NumberVariable"
                               },
                               "parameters": [
-                                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                                "CurrentScrollSpeedY",
                                 "!=",
                                 "0"
                               ]
@@ -469,14 +522,14 @@
                           "actions": [
                             {
                               "type": {
-                                "value": "SetCameraY"
+                                "value": "SetCameraCenterY"
                               },
                               "parameters": [
                                 "",
                                 "+",
-                                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY) * TimeDelta()",
-                                "VariableString(__EdgeScrollCamera.Layer)",
-                                "Variable(__EdgeScrollCamera.Camera)"
+                                "CurrentScrollSpeedY * TimeDelta()",
+                                "Layer",
+                                "Camera"
                               ]
                             }
                           ]
@@ -499,51 +552,24 @@
       "description": "Enable (or disable) camera edge scrolling .  Use \"Configure camera edge scrolling\" to adjust settings.",
       "fullName": "Enable (or disable) camera edge scrolling",
       "functionType": "Action",
-      "group": "",
       "name": "EnableEdgeScrollCamera",
-      "private": false,
       "sentence": "Enable camera edge scrolling: _PARAM1_",
       "events": [
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Disable",
-          "comment2": ""
-        },
         {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "SetSceneVariableAsBoolean"
+                "value": "SetBooleanVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "False"
+                "Enabled",
+                "False",
+                ""
               ]
             }
           ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Enable",
-          "comment2": ""
         },
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -560,11 +586,12 @@
           "actions": [
             {
               "type": {
-                "value": "SetSceneVariableAsBoolean"
+                "value": "SetBooleanVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.Enabled",
-                "True"
+                "Enabled",
+                "True",
+                ""
               ]
             }
           ]
@@ -572,13 +599,10 @@
       ],
       "parameters": [
         {
-          "codeOnly": false,
           "defaultValue": "yes",
           "description": "Enable camera edge scrolling",
-          "longDescription": "",
           "name": "EnableEdgeScrolling",
           "optional": true,
-          "supplementaryInformation": "",
           "type": "yesorno"
         }
       ],
@@ -588,172 +612,119 @@
       "description": "Configure camera edge scrolling that moves when mouse is near an edge of the screen.",
       "fullName": "Configure camera edge scrolling",
       "functionType": "Action",
-      "group": "",
       "name": "ConfigureEdgeScrollCamera",
-      "private": false,
       "sentence": "Configure camera edge scrolling (layer: _PARAM3_, screen margin: _PARAM1_, scroll speed: _PARAM2_, style: _PARAM5_)",
       "events": [
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "name": "Save values to use in the pre-events lifecycle function",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Save values to use in the pre-events lifecycle function"
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareStrings"
-                  },
-                  "parameters": [
-                    "ScrollStyle",
-                    "=",
-                    "\"Constant speed\""
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Style",
-                    "=",
-                    "\"Constant speed\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "BuiltinCommonInstructions::CompareStrings"
-                  },
-                  "parameters": [
-                    "ScrollStyle",
-                    "=",
-                    "\"Progressive speed\""
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Style",
-                    "=",
-                    "\"Progressive speed\""
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Layer",
-                    "=",
-                    "Layer"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.Camera",
-                    "=",
-                    "Camera"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.ScrollSpeed",
-                    "=",
-                    "ScrollSpeed"
-                  ]
-                },
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__EdgeScrollCamera.ScreenMargin",
-                    "=",
-                    "max(1, ScreenMargin)"
-                  ]
-                }
+              "type": {
+                "value": "BuiltinCommonInstructions::CompareStrings"
+              },
+              "parameters": [
+                "NewStyle",
+                "!=",
+                "\"\""
               ]
             }
           ],
-          "parameters": []
+          "actions": [
+            {
+              "type": {
+                "value": "SetStringVariable"
+              },
+              "parameters": [
+                "Style",
+                "=",
+                "NewStyle"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "SetStringVariable"
+              },
+              "parameters": [
+                "Layer",
+                "=",
+                "NewLayer"
+              ]
+            },
+            {
+              "type": {
+                "value": "SetNumberVariable"
+              },
+              "parameters": [
+                "Camera",
+                "=",
+                "NewCamera"
+              ]
+            },
+            {
+              "type": {
+                "value": "SetNumberVariable"
+              },
+              "parameters": [
+                "ScrollSpeed",
+                "=",
+                "NewScrollSpeed"
+              ]
+            },
+            {
+              "type": {
+                "value": "SetNumberVariable"
+              },
+              "parameters": [
+                "ScreenMargin",
+                "=",
+                "max(1, NewScreenMargin)"
+              ]
+            }
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Screen margin (pixels)",
-          "longDescription": "",
-          "name": "ScreenMargin",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "NewScreenMargin",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Scroll speed (in pixels per second)",
-          "longDescription": "",
-          "name": "ScrollSpeed",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "NewScrollSpeed",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Layer",
-          "longDescription": "",
-          "name": "Layer",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "NewLayer",
           "type": "layer"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Camera",
-          "longDescription": "",
-          "name": "Camera",
-          "optional": false,
-          "supplementaryInformation": "",
+          "name": "NewCamera",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Scroll style",
-          "longDescription": "",
-          "name": "ScrollStyle",
-          "optional": false,
+          "name": "NewStyle",
           "supplementaryInformation": "[\"Progressive speed\",\"Constant speed\"]",
           "type": "stringWithSelector"
         }
@@ -764,9 +735,7 @@
       "description": "Check if the camera is scrolling.",
       "fullName": "Camera is scrolling",
       "functionType": "Condition",
-      "group": "",
       "name": "IsCameraScrolling",
-      "private": false,
       "sentence": "Camera is scrolling",
       "events": [
         {
@@ -788,20 +757,20 @@
           "conditions": [
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                "CurrentScrollSpeedX",
                 "=",
                 "0"
               ]
             },
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                "CurrentScrollSpeedY",
                 "=",
                 "0"
               ]
@@ -826,9 +795,7 @@
       "description": "Check if the camera is scrolling up.",
       "fullName": "Camera is scrolling up",
       "functionType": "Condition",
-      "group": "",
       "name": "IsCameraScrollingUp",
-      "private": false,
       "sentence": "Camera is scrolling up",
       "events": [
         {
@@ -836,10 +803,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                "CurrentScrollSpeedY",
                 "<",
                 "0"
               ]
@@ -864,9 +831,7 @@
       "description": "Check if the camera is scrolling down.",
       "fullName": "Camera is scrolling down",
       "functionType": "Condition",
-      "group": "",
       "name": "IsCameraScrollingDown",
-      "private": false,
       "sentence": "Camera is scrolling down",
       "events": [
         {
@@ -874,10 +839,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedY",
+                "CurrentScrollSpeedY",
                 ">",
                 "0"
               ]
@@ -902,9 +867,7 @@
       "description": "Check if the camera is scrolling left.",
       "fullName": "Camera is scrolling left",
       "functionType": "Condition",
-      "group": "",
       "name": "IsCameraScrollingLeft",
-      "private": false,
       "sentence": "Camera is scrolling left",
       "events": [
         {
@@ -912,10 +875,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                "CurrentScrollSpeedX",
                 "<",
                 "0"
               ]
@@ -940,9 +903,7 @@
       "description": "Check if the camera is scrolling right.",
       "fullName": "Camera is scrolling right",
       "functionType": "Condition",
-      "group": "",
       "name": "IsCameraScrollingRight",
-      "private": false,
       "sentence": "Camera is scrolling right",
       "events": [
         {
@@ -950,10 +911,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarScene"
+                "value": "NumberVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.CurrentScrollSpeedX",
+                "CurrentScrollSpeedX",
                 ">",
                 "0"
               ]
@@ -978,222 +939,114 @@
       "description": "Draw a rectangle that shows where edge scrolling will be triggered.",
       "fullName": "Draw edge scrolling screen margin",
       "functionType": "Action",
-      "group": "",
       "name": "DrawEdgeScrollingBorder",
-      "private": false,
       "sentence": "Draw edge scrolling screen margin with _PARAM1_ on layer: _PARAM2_",
       "events": [
         {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "name": "Draw edge scrolling border",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [
+            {
+              "type": {
+                "value": "BooleanVariable"
+              },
+              "parameters": [
+                "Enabled",
+                "True",
+                ""
+              ]
+            }
+          ],
+          "actions": [],
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "SceneVariableAsBoolean"
+                    "value": "SceneInstancesCount"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.Enabled",
-                    "True"
+                    "",
+                    "ShapePainter",
+                    "<",
+                    "1"
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Create and initialize shape painter",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "BuiltinCommonInstructions::Once"
-                          },
-                          "parameters": []
-                        }
-                      ],
-                      "actions": [],
-                      "events": [
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "SceneInstancesCount"
-                              },
-                              "parameters": [
-                                "",
-                                "ShapePainter",
-                                "<",
-                                "1"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "Create"
-                              },
-                              "parameters": [
-                                "",
-                                "ShapePainter",
-                                "0",
-                                "0",
-                                "Layer"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "ShapePainter",
-                                "!=",
-                                "0"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "PrimitiveDrawing::FillOpacity"
-                              },
-                              "parameters": [
-                                "ShapePainter",
-                                "=",
-                                "0"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "value": "PrimitiveDrawing::AreCoordinatesRelative"
-                              },
-                              "parameters": [
-                                "ShapePainter"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "PrimitiveDrawing::UseRelativeCoordinates"
-                              },
-                              "parameters": [
-                                "ShapePainter",
-                                "no"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "BuiltinCommonInstructions::Standard",
-                          "conditions": [
-                            {
-                              "type": {
-                                "inverted": true,
-                                "value": "PrimitiveDrawing::ClearBetweenFrames"
-                              },
-                              "parameters": [
-                                "ShapePainter"
-                              ]
-                            }
-                          ],
-                          "actions": [
-                            {
-                              "type": {
-                                "value": "PrimitiveDrawing::ClearBetweenFrames"
-                              },
-                              "parameters": [
-                                "ShapePainter",
-                                "yes"
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
+                  "type": {
+                    "value": "Create"
+                  },
+                  "parameters": [
+                    "",
+                    "ShapePainter",
+                    "0",
+                    "0",
+                    "Layer"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "PrimitiveDrawing::FillOpacity"
+                  },
+                  "parameters": [
+                    "ShapePainter",
+                    "=",
+                    "0"
+                  ]
                 },
                 {
-                  "colorB": 228,
-                  "colorG": 176,
-                  "colorR": 74,
-                  "creationTime": 0,
-                  "name": "Draw border",
-                  "source": "",
-                  "type": "BuiltinCommonInstructions::Group",
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "PrimitiveDrawing::Rectangle"
-                          },
-                          "parameters": [
-                            "ShapePainter",
-                            "CameraBorderLeft(Layer,Camera) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "CameraBorderTop(Layer,Camera) + Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "CameraBorderRight(Layer,Camera) - Variable(__EdgeScrollCamera.ScreenMargin)",
-                            "CameraBorderBottom(Layer,Camera) - Variable(__EdgeScrollCamera.ScreenMargin)"
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "parameters": []
+                  "type": {
+                    "value": "PrimitiveDrawing::UseRelativeCoordinates"
+                  },
+                  "parameters": [
+                    "ShapePainter",
+                    "no"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "PrimitiveDrawing::ClearBetweenFrames"
+                  },
+                  "parameters": [
+                    "ShapePainter",
+                    "yes"
+                  ]
+                },
+                {
+                  "type": {
+                    "value": "PrimitiveDrawing::Rectangle"
+                  },
+                  "parameters": [
+                    "ShapePainter",
+                    "CameraBorderLeft(Layer, Camera) + ScreenMargin",
+                    "CameraBorderTop(Layer,Camera) + ScreenMargin",
+                    "CameraBorderRight(Layer,Camera) - ScreenMargin",
+                    "CameraBorderBottom(Layer,Camera) - ScreenMargin"
+                  ]
                 }
               ]
             }
-          ],
-          "parameters": []
+          ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Shape painter",
-          "longDescription": "",
           "name": "ShapePainter",
-          "optional": false,
           "supplementaryInformation": "PrimitiveDrawing::Drawer",
           "type": "objectList"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Layer",
-          "longDescription": "",
           "name": "Layer",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "layer"
         }
       ],
@@ -1203,9 +1056,7 @@
       "description": "Return the speed the camera is currently scrolling in horizontal direction (in pixels per second).",
       "fullName": "Horizontal edge scroll speed",
       "functionType": "Expression",
-      "group": "",
       "name": "SpeedX",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -1217,12 +1068,15 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__EdgeScrollCamera.CurrentScrollSpeedX)"
+                "CurrentScrollSpeedX"
               ]
             }
           ]
         }
       ],
+      "expressionType": {
+        "type": "expression"
+      },
       "parameters": [],
       "objectGroups": []
     },
@@ -1230,9 +1084,7 @@
       "description": "Return the speed the camera is currently scrolling in vertical direction (in pixels per second).",
       "fullName": "Vertical edge scroll speed",
       "functionType": "Expression",
-      "group": "",
       "name": "SpeedY",
-      "private": false,
       "sentence": "",
       "events": [
         {
@@ -1244,12 +1096,15 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__EdgeScrollCamera.CurrentScrollSpeedY)"
+                "CurrentScrollSpeedY"
               ]
             }
           ]
         }
       ],
+      "expressionType": {
+        "type": "expression"
+      },
       "parameters": [],
       "objectGroups": []
     },
@@ -1257,7 +1112,6 @@
       "description": "Return the absolute scroll speed according to the mouse distance from the border.",
       "fullName": "Absolute scroll speed",
       "functionType": "Expression",
-      "group": "",
       "name": "AbsoluteScrollSpeed",
       "private": true,
       "sentence": "",
@@ -1272,18 +1126,17 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Progressive style increases speed the closer the cursor is to the edge of screen",
-          "comment2": ""
+          "comment": "Progressive style increases speed the closer the cursor is to the edge of screen"
         },
         {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "value": "VarSceneTxt"
+                "value": "StringVariable"
               },
               "parameters": [
-                "__EdgeScrollCamera.Style",
+                "Style",
                 "=",
                 "\"Progressive speed\""
               ]
@@ -1295,7 +1148,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "(1 - abs(BorderDistance) / Variable(__EdgeScrollCamera.ScreenMargin)) * Variable(__EdgeScrollCamera.ScrollSpeed)"
+                "(1 - abs(BorderDistance) / ScreenMargin) * ScrollSpeed"
               ]
             }
           ]
@@ -1310,8 +1163,7 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "The camera borders can have rounding errors, make sure the max speed can be reached.",
-          "comment2": ""
+          "comment": "The camera borders can have rounding errors, make sure the max speed can be reached."
         },
         {
           "type": "BuiltinCommonInstructions::Standard",
@@ -1324,10 +1176,10 @@
               "subInstructions": [
                 {
                   "type": {
-                    "value": "VarSceneTxt"
+                    "value": "StringVariable"
                   },
                   "parameters": [
-                    "__EdgeScrollCamera.Style",
+                    "Style",
                     "=",
                     "\"Constant speed\""
                   ]
@@ -1351,26 +1203,25 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__EdgeScrollCamera.ScrollSpeed)"
+                "ScrollSpeed"
               ]
             }
           ]
         }
       ],
+      "expressionType": {
+        "type": "expression"
+      },
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Border distance",
-          "longDescription": "",
           "name": "BorderDistance",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/FlashLayer.json
+++ b/extensions/reviewed/FlashLayer.json
@@ -1,7 +1,6 @@
 {
   "author": "Tristan Rhodes (tristan@victrisgames.com)",
   "category": "Visual effect",
-  "description": "Useful to make a temporary effect (flash on hit, flickering lights, lightning flash, show text like Batman and Robin \"Bam!\", etc)\n\nIt is recommended to select a layer on the top, and one that is hidden by default.",
   "extensionNamespace": "",
   "fullName": "Flash layer",
   "helpPath": "",
@@ -9,303 +8,95 @@
   "name": "FlashLayer",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg",
   "shortDescription": "Make a layer visible for a specified duration, and then hide the layer.",
-  "version": "0.2.1",
+  "version": "0.3.0",
+  "description": [
+    "Useful to make a temporary effect (flash on hit, flickering lights, lightning flash, show text like Batman and Robin \"Bam!\", etc)",
+    "",
+    "It is recommended to select a layer on the top, and one that is hidden by default."
+  ],
+  "origin": {
+    "identifier": "FlashLayer",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "effect",
     "vfx",
     "layer",
-    "flash",
-    "visible",
-    "hide"
+    "flash"
   ],
   "authorIds": [
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [
     {
       "description": "Make a layer visible for a specified duration, and then hide the layer.",
       "fullName": "Flash layer",
       "functionType": "Action",
       "name": "FlashLayer",
-      "private": false,
       "sentence": "Make layer _PARAM1_ visible for _PARAM2_ seconds",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save input parameters",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarSceneTxt"
-              },
-              "parameters": [
-                "__FlashLayer_Layer",
-                "=",
-                "LayerToFlash"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FlashLayer_Duration",
-                "=",
-                "Duration"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Set default values",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__FlashLayer_Duration",
-                "=",
-                "0"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FlashLayer_Duration",
-                "=",
-                "0.1"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Start timer and show layer",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ResetTimer"
+                "inverted": true,
+                "value": "LayerVisible"
               },
               "parameters": [
                 "",
-                "\"__FlashLayer_Timer\""
-              ],
-              "subInstructions": []
-            },
+                "Layer"
+              ]
+            }
+          ],
+          "actions": [
             {
               "type": {
-                "inverted": false,
                 "value": "ShowLayer"
               },
               "parameters": [
                 "",
-                "VariableString(__FlashLayer_Layer)"
-              ],
-              "subInstructions": []
+                "Layer"
+              ]
             },
             {
               "type": {
-                "inverted": false,
-                "value": "ModVarScene"
+                "value": "Wait"
               },
               "parameters": [
-                "__FlashLayer_InProgress",
-                "=",
-                "1"
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Layer (Default: \"\")",
-          "longDescription": "",
-          "name": "LayerToFlash",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "layer"
-        },
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Duration (seconds) (Default: 0.1) ",
-          "longDescription": "",
-          "name": "Duration",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "expression"
-        }
-      ],
-      "objectGroups": []
-    },
-    {
-      "description": "",
-      "fullName": "",
-      "functionType": "Action",
-      "name": "onScenePostEvents",
-      "private": false,
-      "sentence": "",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Hide layer, reset time-scale to initial value, and delete timer",
-          "comment2": ""
-        },
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__FlashLayer_InProgress",
-                "=",
-                "1"
-              ],
-              "subInstructions": []
+                "Duration"
+              ]
             },
             {
               "type": {
-                "inverted": false,
-                "value": "Timer"
-              },
-              "parameters": [
-                "",
-                "Variable(__FlashLayer_Duration)",
-                "\"__FlashLayer_Timer\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
                 "value": "HideLayer"
               },
               "parameters": [
                 "",
-                "VariableString(__FlashLayer_Layer)"
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "RemoveTimer"
-              },
-              "parameters": [
-                "",
-                "\"__FlashLayer_Timer\""
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__FlashLayer_InProgress",
-                "=",
-                "0"
-              ],
-              "subInstructions": []
+                "Layer"
+              ]
             }
-          ],
-          "events": []
+          ]
         }
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "description": "Layer",
+          "name": "Layer",
+          "type": "layer"
+        },
+        {
+          "description": "Duration (in seconds)",
+          "name": "Duration",
+          "type": "expression"
+        }
+      ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/PanelSpriteButton.json
+++ b/extensions/reviewed/PanelSpriteButton.json
@@ -8,7 +8,7 @@
   "name": "PanelSpriteButton",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Interface Elements/Interface Elements_interface_ui_button_ok_cta_clock_tap.svg",
   "shortDescription": "A button that can be customized.",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": [
     "The button can be customized with a background for each state and a label. It handles user interactions and a simple condition can be used to check if it is clicked.",
     "",
@@ -26,6 +26,8 @@
     "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -1207,9 +1209,16 @@
   ],
   "eventsBasedObjects": [
     {
+      "areaMaxX": 64,
+      "areaMaxY": 64,
+      "areaMaxZ": 64,
+      "areaMinX": 0,
+      "areaMinY": 0,
+      "areaMinZ": 0,
       "defaultName": "Button",
       "description": "A button that can be customized.",
       "fullName": "Button (panel sprite)",
+      "isUsingLegacyInstancesRenderer": true,
       "name": "PanelSpriteButton",
       "eventsFunctions": [
         {
@@ -1838,66 +1847,83 @@
                       ]
                     }
                   ],
-                  "actions": [
+                  "actions": [],
+                  "events": [
                     {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Idle",
-                        "Width",
-                        "=",
-                        "Object.Width()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Idle",
-                        "Height",
-                        "=",
-                        "Object.Height()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteButton::Scale"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Width"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Idle.Variable(Width)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Height"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Idle.Variable(Height)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteButton::PanelSpriteButton::CenterLabel"
-                      },
-                      "parameters": [
-                        "Object",
-                        ""
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Width",
+                            "=",
+                            "Object.Width()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Height",
+                            "=",
+                            "Object.Height()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteButton::Scale"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Width"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Width"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Height"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Height"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteButton::PanelSpriteButton::CenterLabel"
+                          },
+                          "parameters": [
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "variables": [
+                        {
+                          "name": "Width",
+                          "type": "number",
+                          "value": 0
+                        },
+                        {
+                          "name": "Height",
+                          "type": "number",
+                          "value": 0
+                        }
                       ]
                     }
                   ]
@@ -2506,7 +2532,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "PressedLabelOffsetY"
         },
         {
@@ -2518,7 +2543,6 @@
           "extraInformation": [
             "Label"
           ],
-          "hidden": false,
           "name": "LeftPadding"
         },
         {
@@ -2530,7 +2554,6 @@
           "extraInformation": [
             "Label"
           ],
-          "hidden": false,
           "name": "RightPadding"
         },
         {
@@ -2542,7 +2565,6 @@
           "extraInformation": [
             "Label"
           ],
-          "hidden": false,
           "name": "TopPadding"
         },
         {
@@ -2554,7 +2576,6 @@
           "extraInformation": [
             "Label"
           ],
-          "hidden": false,
           "name": "BottomPadding"
         },
         {
@@ -2564,7 +2585,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "HoveredFadeOutDuration"
         }
       ],
@@ -2575,7 +2595,6 @@
           "italic": false,
           "name": "Label",
           "smoothed": true,
-          "tags": "",
           "type": "TextObject::Text",
           "underlined": false,
           "variables": [],
@@ -2589,6 +2608,27 @@
             "b": 0,
             "g": 0,
             "r": 0
+          },
+          "content": {
+            "bold": false,
+            "isOutlineEnabled": false,
+            "isShadowEnabled": false,
+            "italic": false,
+            "outlineColor": "255;255;255",
+            "outlineThickness": 2,
+            "shadowAngle": 90,
+            "shadowBlurRadius": 2,
+            "shadowColor": "0;0;0",
+            "shadowDistance": 4,
+            "shadowOpacity": 127,
+            "smoothed": true,
+            "underlined": false,
+            "text": "Text",
+            "font": "",
+            "textAlignment": "",
+            "verticalTextAlignment": "top",
+            "characterSize": 20,
+            "color": "0;0;0"
           }
         },
         {
@@ -2598,7 +2638,6 @@
           "leftMargin": 0,
           "name": "Idle",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": false,
           "topMargin": 0,
@@ -2628,7 +2667,6 @@
           "leftMargin": 0,
           "name": "Hovered",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": false,
           "topMargin": 0,
@@ -2650,7 +2688,6 @@
           "leftMargin": 0,
           "name": "Pressed",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": false,
           "topMargin": 0,
@@ -2660,7 +2697,56 @@
           "effects": [],
           "behaviors": []
         }
-      ]
+      ],
+      "objectsFolderStructure": {
+        "folderName": "__ROOT",
+        "children": [
+          {
+            "objectName": "Label"
+          },
+          {
+            "objectName": "Idle"
+          },
+          {
+            "objectName": "Hovered"
+          },
+          {
+            "objectName": "Pressed"
+          }
+        ]
+      },
+      "objectsGroups": [],
+      "layers": [
+        {
+          "ambientLightColorB": 200,
+          "ambientLightColorG": 200,
+          "ambientLightColorR": 200,
+          "camera3DFarPlaneDistance": 10000,
+          "camera3DFieldOfView": 45,
+          "camera3DNearPlaneDistance": 3,
+          "cameraType": "",
+          "followBaseLayerCamera": false,
+          "isLightingLayer": false,
+          "isLocked": false,
+          "name": "",
+          "renderingType": "",
+          "visibility": true,
+          "cameras": [
+            {
+              "defaultSize": true,
+              "defaultViewport": true,
+              "height": 0,
+              "viewportBottom": 1,
+              "viewportLeft": 0,
+              "viewportRight": 1,
+              "viewportTop": 0,
+              "width": 0
+            }
+          ],
+          "effects": []
+        }
+      ],
+      "instances": []
     }
   ]
 }

--- a/extensions/reviewed/PanelSpriteContinuousBar.json
+++ b/extensions/reviewed/PanelSpriteContinuousBar.json
@@ -8,7 +8,7 @@
   "name": "PanelSpriteContinuousBar",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/Glyphster Pack/Master/SVG/Interface Elements/ea06363a57846caab544f536b78a952234b68d4941d41c1577852a1d61aefec3_Interface Elements_interface_ui_loading_progress_bar.svg",
   "shortDescription": "A bar that represents a resource in the game (health, mana, ammo, etc).",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": [
     "A bar that represents a resource in the game (health, mana, ammo, etc).",
     "",
@@ -34,6 +34,8 @@
     "q8ubdigLvIRXLxsJDDTaokO41mc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -59,8 +61,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "This is done after the events to allow users to read the previous value at the end of the change.",
-              "comment2": ""
+              "comment": "This is done after the events to allow users to read the previous value at the end of the change."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -652,7 +653,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "Value"
         },
         {
@@ -662,7 +662,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "MaxValue"
         },
         {
@@ -682,7 +681,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "PreviousHighValueDuration"
         }
       ],
@@ -691,9 +689,16 @@
   ],
   "eventsBasedObjects": [
     {
+      "areaMaxX": 64,
+      "areaMaxY": 64,
+      "areaMaxZ": 64,
+      "areaMinX": 0,
+      "areaMinY": 0,
+      "areaMinZ": 0,
       "defaultName": "ResourceBar",
       "description": "A bar that represents a resource in the game (health, mana, ammo, etc).",
       "fullName": "Resource bar (continuous)",
+      "isUsingLegacyInstancesRenderer": true,
       "name": "PanelSpriteContinuousBar",
       "eventsFunctions": [
         {
@@ -712,8 +717,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "This allows to detect a change of \"intial value\" on hot reload.",
-              "comment2": ""
+              "comment": "This allows to detect a change of \"intial value\" on hot reload."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -741,8 +745,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Create the child-object instances.",
-              "comment2": ""
+              "comment": "Create the child-object instances."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -843,8 +846,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Create the label over the bar.",
-              "comment2": ""
+              "comment": "Create the label over the bar."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -926,8 +928,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Pass the configuration to the behavior.",
-              "comment2": ""
+              "comment": "Pass the configuration to the behavior."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1142,8 +1143,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Children instances must be resized when the parent size change:\n- background is resized to take the full dimensions of the parent\n- the bar size is refreshed according to the value\n- the label is put back at the center of the bar\n\nThe scale is set back to 1 because it means that the parent instance has the same dimensions as the union of its children instances.",
-                  "comment2": ""
+                  "comment": "Children instances must be resized when the parent size change:\n- background is resized to take the full dimensions of the parent\n- the bar size is refreshed according to the value\n- the label is put back at the center of the bar\n\nThe scale is set back to 1 because it means that the parent instance has the same dimensions as the union of its children instances."
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -1177,66 +1177,83 @@
                       ]
                     }
                   ],
-                  "actions": [
+                  "actions": [],
+                  "events": [
                     {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Width",
-                        "=",
-                        "Object.Width()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Height",
-                        "=",
-                        "Object.Height()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteContinuousBar::PanelSpriteContinuousBar::Scale"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Width"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Background.Variable(Width)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Height"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Background.Variable(Height)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteContinuousBar::PanelSpriteContinuousBar::UpdateLayout"
-                      },
-                      "parameters": [
-                        "Object",
-                        ""
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Width",
+                            "=",
+                            "Object.Width()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Height",
+                            "=",
+                            "Object.Height()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteContinuousBar::PanelSpriteContinuousBar::Scale"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Width"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Width"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Height"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Height"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteContinuousBar::PanelSpriteContinuousBar::UpdateLayout"
+                          },
+                          "parameters": [
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "variables": [
+                        {
+                          "name": "Width",
+                          "type": "number",
+                          "value": 0
+                        },
+                        {
+                          "name": "Height",
+                          "type": "number",
+                          "value": 0
+                        }
                       ]
                     }
                   ]
@@ -2272,7 +2289,6 @@
             "FillBar",
             "Buffer"
           ],
-          "hidden": false,
           "name": "BarLeftPadding"
         },
         {
@@ -2286,7 +2302,6 @@
             "FillBar",
             "Buffer"
           ],
-          "hidden": false,
           "name": "BarTopPadding"
         },
         {
@@ -2300,7 +2315,6 @@
             "FillBar",
             "Buffer"
           ],
-          "hidden": false,
           "name": "BarRightPadding"
         },
         {
@@ -2314,7 +2328,6 @@
             "FillBar",
             "Buffer"
           ],
-          "hidden": false,
           "name": "BarBottomPadding"
         },
         {
@@ -2324,7 +2337,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "MaxValue"
         },
         {
@@ -2334,7 +2346,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "InitialValue"
         },
         {
@@ -2354,7 +2365,6 @@
           "description": "",
           "group": "Animation",
           "extraInformation": [],
-          "hidden": false,
           "name": "PreviousHighValueDuration"
         },
         {
@@ -2364,7 +2374,6 @@
           "description": "",
           "group": "Animation",
           "extraInformation": [],
-          "hidden": false,
           "name": "EasingDuration"
         },
         {
@@ -2376,7 +2385,6 @@
           "extraInformation": [
             "Label"
           ],
-          "hidden": false,
           "name": "ShowLabel"
         },
         {
@@ -2423,7 +2431,6 @@
           "italic": false,
           "name": "Label",
           "smoothed": true,
-          "tags": "",
           "type": "TextObject::Text",
           "underlined": false,
           "variables": [],
@@ -2437,6 +2444,27 @@
             "b": 0,
             "g": 0,
             "r": 0
+          },
+          "content": {
+            "bold": false,
+            "isOutlineEnabled": false,
+            "isShadowEnabled": false,
+            "italic": false,
+            "outlineColor": "255;255;255",
+            "outlineThickness": 2,
+            "shadowAngle": 90,
+            "shadowBlurRadius": 2,
+            "shadowColor": "0;0;0",
+            "shadowDistance": 4,
+            "shadowOpacity": 127,
+            "smoothed": true,
+            "underlined": false,
+            "text": "2 / 3",
+            "font": "",
+            "textAlignment": "center",
+            "verticalTextAlignment": "top",
+            "characterSize": 20,
+            "color": "0;0;0"
           }
         },
         {
@@ -2446,7 +2474,6 @@
           "leftMargin": 0,
           "name": "FillBar",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": true,
           "topMargin": 0,
@@ -2475,7 +2502,6 @@
           "leftMargin": 0,
           "name": "Buffer",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": true,
           "topMargin": 0,
@@ -2497,7 +2523,6 @@
           "leftMargin": 0,
           "name": "Background",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": true,
           "topMargin": 0,
@@ -2507,7 +2532,56 @@
           "effects": [],
           "behaviors": []
         }
-      ]
+      ],
+      "objectsFolderStructure": {
+        "folderName": "__ROOT",
+        "children": [
+          {
+            "objectName": "Label"
+          },
+          {
+            "objectName": "FillBar"
+          },
+          {
+            "objectName": "Buffer"
+          },
+          {
+            "objectName": "Background"
+          }
+        ]
+      },
+      "objectsGroups": [],
+      "layers": [
+        {
+          "ambientLightColorB": 200,
+          "ambientLightColorG": 200,
+          "ambientLightColorR": 200,
+          "camera3DFarPlaneDistance": 10000,
+          "camera3DFieldOfView": 45,
+          "camera3DNearPlaneDistance": 3,
+          "cameraType": "",
+          "followBaseLayerCamera": false,
+          "isLightingLayer": false,
+          "isLocked": false,
+          "name": "",
+          "renderingType": "",
+          "visibility": true,
+          "cameras": [
+            {
+              "defaultSize": true,
+              "defaultViewport": true,
+              "height": 0,
+              "viewportBottom": 1,
+              "viewportLeft": 0,
+              "viewportRight": 1,
+              "viewportTop": 0,
+              "width": 0
+            }
+          ],
+          "effects": []
+        }
+      ],
+      "instances": []
     }
   ]
 }

--- a/extensions/reviewed/PanelSpriteSlider.json
+++ b/extensions/reviewed/PanelSpriteSlider.json
@@ -8,7 +8,7 @@
   "name": "PanelSpriteSlider",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/Line Hero Pack/Master/SVG/UI Essentials/1678c39a3b2bd3df4f82a8a293770db4986a6bcfd3f78e738ddfc86e39176423_UI Essentials_sliders_options.svg",
   "shortDescription": "A draggable slider that users can move to select a numerical value.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": [
     "A draggable slider that users can move to select a numerical value. The slider can be customized with sprites.",
     "",
@@ -29,6 +29,8 @@
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -487,7 +489,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "Value"
         },
         {
@@ -497,7 +498,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "MinValue"
         },
         {
@@ -507,7 +507,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "MaxValue"
         },
         {
@@ -517,7 +516,6 @@
           "description": "",
           "group": "",
           "extraInformation": [],
-          "hidden": false,
           "name": "StepSize"
         }
       ],
@@ -555,8 +553,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "The \"Validated\" state only last one frame.",
-                  "comment2": ""
+                  "comment": "The \"Validated\" state only last one frame."
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -606,8 +603,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Make sure the cursor position is only checked once per frame.",
-                      "comment2": ""
+                      "comment": "Make sure the cursor position is only checked once per frame."
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -671,8 +667,7 @@
                         "textG": 0,
                         "textR": 0
                       },
-                      "comment": "Touches are always pressed, so ShouldCheckHovering doesn't matter.",
-                      "comment2": ""
+                      "comment": "Touches are always pressed, so ShouldCheckHovering doesn't matter."
                     },
                     {
                       "type": "BuiltinCommonInstructions::Standard",
@@ -1665,9 +1660,16 @@
   ],
   "eventsBasedObjects": [
     {
+      "areaMaxX": 64,
+      "areaMaxY": 64,
+      "areaMaxZ": 64,
+      "areaMinX": 0,
+      "areaMinY": 0,
+      "areaMinZ": 0,
       "defaultName": "Slider",
       "description": "Let users select a numerical value by dragging a slider.",
       "fullName": "Slider",
+      "isUsingLegacyInstancesRenderer": true,
       "name": "PanelSpriteSlider",
       "eventsFunctions": [
         {
@@ -1686,8 +1688,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "This allows to detect a change of \"intial value\" on hot reload.",
-              "comment2": ""
+              "comment": "This allows to detect a change of \"intial value\" on hot reload."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1715,8 +1716,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Create the child-object instances.",
-              "comment2": ""
+              "comment": "Create the child-object instances."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1800,8 +1800,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Create the label that is displayed over the thumb.",
-              "comment2": ""
+              "comment": "Create the label that is displayed over the thumb."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -1858,8 +1857,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Pass the configuration to the behavior.",
-              "comment2": ""
+              "comment": "Pass the configuration to the behavior."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -2321,8 +2319,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Children instances must be resized when the parent size change:\n- background is resized to take the full dimensions of the parent\n- the label is put back at the center of the bar\n\nThe scale is set back to 1 because it means that the parent instance has the same dimensions as the union of its children instances.",
-                  "comment2": ""
+                  "comment": "Children instances must be resized when the parent size change:\n- background is resized to take the full dimensions of the parent\n- the label is put back at the center of the bar\n\nThe scale is set back to 1 because it means that the parent instance has the same dimensions as the union of its children instances."
                 },
                 {
                   "type": "BuiltinCommonInstructions::Standard",
@@ -2356,66 +2353,83 @@
                       ]
                     }
                   ],
-                  "actions": [
+                  "actions": [],
+                  "events": [
                     {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Width",
-                        "=",
-                        "Object.Width()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Height",
-                        "=",
-                        "Object.Height()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteSlider::PanelSpriteSlider::Scale"
-                      },
-                      "parameters": [
-                        "Object",
-                        "=",
-                        "1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Width"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Background.Variable(Width)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteObject::Height"
-                      },
-                      "parameters": [
-                        "Background",
-                        "=",
-                        "Background.Variable(Height)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "PanelSpriteSlider::PanelSpriteSlider::UpdateLayout"
-                      },
-                      "parameters": [
-                        "Object",
-                        ""
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Width",
+                            "=",
+                            "Object.Width()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Height",
+                            "=",
+                            "Object.Height()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteSlider::PanelSpriteSlider::Scale"
+                          },
+                          "parameters": [
+                            "Object",
+                            "=",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Width"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Width"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Height"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Height"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteSlider::PanelSpriteSlider::UpdateLayout"
+                          },
+                          "parameters": [
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "variables": [
+                        {
+                          "name": "Width",
+                          "type": "number",
+                          "value": 0
+                        },
+                        {
+                          "name": "Height",
+                          "type": "number",
+                          "value": 0
+                        }
                       ]
                     }
                   ]
@@ -2433,8 +2447,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "The parent size is not defined in onCreate so it needs to be done here.",
-              "comment2": ""
+              "comment": "The parent size is not defined in onCreate so it needs to be done here."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -3334,8 +3347,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Pass configuration to the behavior and update children.",
-              "comment2": ""
+              "comment": "Pass configuration to the behavior and update children."
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -3544,7 +3556,6 @@
             "Label",
             "FillBar"
           ],
-          "hidden": false,
           "name": "BarLeftPadding"
         },
         {
@@ -3557,7 +3568,6 @@
             "Label",
             "FillBar"
           ],
-          "hidden": false,
           "name": "BarTopPadding"
         },
         {
@@ -3570,7 +3580,6 @@
             "Label",
             "FillBar"
           ],
-          "hidden": false,
           "name": "BarRightPadding"
         },
         {
@@ -3583,7 +3592,6 @@
             "Label",
             "FillBar"
           ],
-          "hidden": false,
           "name": "BarBottomPadding"
         },
         {
@@ -3593,7 +3601,6 @@
           "description": "",
           "group": "Label",
           "extraInformation": [],
-          "hidden": false,
           "name": "ShowLabelAtChanges"
         },
         {
@@ -3603,7 +3610,6 @@
           "description": "",
           "group": "Label",
           "extraInformation": [],
-          "hidden": false,
           "name": "LabelMargin"
         },
         {
@@ -3613,7 +3619,6 @@
           "description": "",
           "group": "Value",
           "extraInformation": [],
-          "hidden": false,
           "name": "MinValue"
         },
         {
@@ -3623,7 +3628,6 @@
           "description": "",
           "group": "Value",
           "extraInformation": [],
-          "hidden": false,
           "name": "MaxValue"
         },
         {
@@ -3633,7 +3637,6 @@
           "description": "",
           "group": "Value",
           "extraInformation": [],
-          "hidden": false,
           "name": "StepSize"
         },
         {
@@ -3643,7 +3646,6 @@
           "description": "",
           "group": "Value",
           "extraInformation": [],
-          "hidden": false,
           "name": "InitialValue"
         },
         {
@@ -3700,7 +3702,6 @@
           "italic": false,
           "name": "Label",
           "smoothed": true,
-          "tags": "",
           "type": "TextObject::Text",
           "underlined": false,
           "variables": [],
@@ -3714,6 +3715,27 @@
             "b": 0,
             "g": 0,
             "r": 0
+          },
+          "content": {
+            "bold": false,
+            "isOutlineEnabled": false,
+            "isShadowEnabled": false,
+            "italic": false,
+            "outlineColor": "255;255;255",
+            "outlineThickness": 2,
+            "shadowAngle": 90,
+            "shadowBlurRadius": 2,
+            "shadowColor": "0;0;0",
+            "shadowDistance": 4,
+            "shadowOpacity": 127,
+            "smoothed": true,
+            "underlined": false,
+            "text": "It displays the value when it changes.",
+            "font": "",
+            "textAlignment": "",
+            "verticalTextAlignment": "top",
+            "characterSize": 20,
+            "color": "0;0;0"
           }
         },
         {
@@ -3723,7 +3745,6 @@
           "leftMargin": 0,
           "name": "Thumb",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": false,
           "topMargin": 0,
@@ -3746,7 +3767,6 @@
           "leftMargin": 0,
           "name": "FillBar",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": true,
           "topMargin": 0,
@@ -3772,7 +3792,6 @@
           "leftMargin": 0,
           "name": "Background",
           "rightMargin": 0,
-          "tags": "",
           "texture": "",
           "tiled": true,
           "topMargin": 0,
@@ -3793,7 +3812,56 @@
             }
           ]
         }
-      ]
+      ],
+      "objectsFolderStructure": {
+        "folderName": "__ROOT",
+        "children": [
+          {
+            "objectName": "Label"
+          },
+          {
+            "objectName": "Thumb"
+          },
+          {
+            "objectName": "FillBar"
+          },
+          {
+            "objectName": "Background"
+          }
+        ]
+      },
+      "objectsGroups": [],
+      "layers": [
+        {
+          "ambientLightColorB": 200,
+          "ambientLightColorG": 200,
+          "ambientLightColorR": 200,
+          "camera3DFarPlaneDistance": 10000,
+          "camera3DFieldOfView": 45,
+          "camera3DNearPlaneDistance": 3,
+          "cameraType": "",
+          "followBaseLayerCamera": false,
+          "isLightingLayer": false,
+          "isLocked": false,
+          "name": "",
+          "renderingType": "",
+          "visibility": true,
+          "cameras": [
+            {
+              "defaultSize": true,
+              "defaultViewport": true,
+              "height": 0,
+              "viewportBottom": 1,
+              "viewportLeft": 0,
+              "viewportRight": 1,
+              "viewportTop": 0,
+              "width": 0
+            }
+          ],
+          "effects": []
+        }
+      ],
+      "instances": []
     }
   ]
 }

--- a/extensions/reviewed/SpriteMultitouchJoystick.json
+++ b/extensions/reviewed/SpriteMultitouchJoystick.json
@@ -8,7 +8,7 @@
   "name": "SpriteMultitouchJoystick",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Videogames/Videogames_controller_joystick_arrows_direction.svg",
   "shortDescription": "Joysticks or buttons for touchscreens.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": [
     "Multitouch joysticks can be used the same way as physical gamepads:",
     "- 4 or 8 directions",
@@ -43,7 +43,40 @@
   ],
   "dependencies": [],
   "globalVariables": [],
-  "sceneVariables": [],
+  "sceneVariables": [
+    {
+      "name": "Controllers",
+      "type": "array",
+      "children": [
+        {
+          "type": "structure",
+          "children": [
+            {
+              "name": "Buttons",
+              "type": "array",
+              "children": [
+                {
+                  "type": "structure",
+                  "children": [
+                    {
+                      "name": "State",
+                      "type": "string",
+                      "value": "Idle"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Joystick",
+              "type": "structure",
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "eventsFunctions": [
     {
       "description": "Check if a button is pressed on a gamepad.",
@@ -57,10 +90,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarSceneTxt"
+                "value": "StringVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Buttons[Button].State",
+                "Controllers[ControllerIdentifier].Buttons[Button].State",
                 "=",
                 "\"Pressed\""
               ]
@@ -105,10 +138,10 @@
           "conditions": [
             {
               "type": {
-                "value": "VarSceneTxt"
+                "value": "StringVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Buttons[Button].State",
+                "Controllers[ControllerIdentifier].Buttons[Button].State",
                 "=",
                 "\"Released\""
               ]
@@ -155,10 +188,10 @@
           "actions": [
             {
               "type": {
-                "value": "ModVarSceneTxt"
+                "value": "SetStringVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Buttons[Button].State",
+                "Controllers[ControllerIdentifier].Buttons[Button].State",
                 "=",
                 "ButtonState"
               ]
@@ -200,10 +233,10 @@
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone",
+                "Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone",
                 "=",
                 "DeadZoneRadius"
               ]
@@ -248,7 +281,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone)"
+                "Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].DeadZone"
               ]
             }
           ]
@@ -1050,7 +1083,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "max(0, Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force) - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)) / (1 - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier))"
+                "max(0, Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier)) / (1 - SpriteMultitouchJoystick::DeadZone(ControllerIdentifier, JoystickIdentifier))"
               ]
             }
           ]
@@ -1088,10 +1121,10 @@
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force",
+                "Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Force",
                 "=",
                 "Value"
               ]
@@ -1175,7 +1208,7 @@
                 "value": "SetReturnNumber"
               },
               "parameters": [
-                "Variable(__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Angle)"
+                "Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Angle"
               ]
             }
           ]
@@ -1213,10 +1246,10 @@
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__MultitouchJoystick.Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Angle",
+                "Controllers[ControllerIdentifier].Joystick[JoystickIdentifier].Angle",
                 "=",
                 "Value"
               ]
@@ -3703,6 +3736,7 @@
       "defaultName": "Joystick",
       "description": "Joystick for touchscreens.",
       "fullName": "Multitouch Joystick",
+      "isUsingLegacyInstancesRenderer": true,
       "name": "SpriteMultitouchJoystick",
       "eventsFunctions": [
         {

--- a/extensions/reviewed/TiledUnitsBar.json
+++ b/extensions/reviewed/TiledUnitsBar.json
@@ -8,7 +8,7 @@
   "name": "TiledUnitsBar",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/063e9152cf65bc0f3be2a828afd950c3ecf1b1fc72feefdc2467252fe987dc0f_dots-horizontal.svg",
   "shortDescription": "A bar that represents a resource in the game (health, mana, ammo, etc).",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": [
     "A bar that represents a resource in the game (health, mana, ammo, etc).",
     "",
@@ -34,6 +34,8 @@
     "q8ubdigLvIRXLxsJDDTaokO41mc2"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {
@@ -687,9 +689,16 @@
   ],
   "eventsBasedObjects": [
     {
+      "areaMaxX": 64,
+      "areaMaxY": 64,
+      "areaMaxZ": 64,
+      "areaMinX": 0,
+      "areaMinY": 0,
+      "areaMinZ": 0,
       "defaultName": "ResourceBar",
       "description": "A bar that represents a resource in the game (health, mana, ammo, etc).",
       "fullName": "Resource bar (separated units)",
+      "isUsingLegacyInstancesRenderer": true,
       "name": "TiledUnitsBar",
       "eventsFunctions": [
         {
@@ -1025,69 +1034,84 @@
                       ]
                     }
                   ],
-                  "actions": [
+                  "actions": [],
+                  "events": [
                     {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Width",
-                        "=",
-                        "Object.Width()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Height",
-                        "=",
-                        "Object.Height()"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ScalableCapability::ScalableBehavior::SetValue"
-                      },
-                      "parameters": [
-                        "Object",
-                        "Scale",
-                        "=",
-                        "1"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResizableCapability::ResizableBehavior::SetWidth"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Resizable",
-                        "=",
-                        "Background.Variable(Width)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "ResizableCapability::ResizableBehavior::SetHeight"
-                      },
-                      "parameters": [
-                        "Background",
-                        "Resizable",
-                        "=",
-                        "Background.Variable(Height)"
-                      ]
-                    },
-                    {
-                      "type": {
-                        "value": "TiledUnitsBar::TiledUnitsBar::CenterBar"
-                      },
-                      "parameters": [
-                        "Object",
-                        ""
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Width",
+                            "=",
+                            "Object.Width()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SetNumberVariable"
+                          },
+                          "parameters": [
+                            "Height",
+                            "=",
+                            "Object.Height()"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ScalableCapability::ScalableBehavior::SetValue"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Scale",
+                            "=",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Width"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Width"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PanelSpriteObject::Height"
+                          },
+                          "parameters": [
+                            "Background",
+                            "=",
+                            "Height"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "TiledUnitsBar::TiledUnitsBar::CenterBar"
+                          },
+                          "parameters": [
+                            "Object",
+                            ""
+                          ]
+                        }
+                      ],
+                      "variables": [
+                        {
+                          "name": "Width",
+                          "type": "number",
+                          "value": 0
+                        },
+                        {
+                          "name": "Height",
+                          "type": "number",
+                          "value": 0
+                        }
                       ]
                     }
                   ]
@@ -1617,7 +1641,39 @@
             "objectName": "Background"
           }
         ]
-      }
+      },
+      "objectsGroups": [],
+      "layers": [
+        {
+          "ambientLightColorB": 200,
+          "ambientLightColorG": 200,
+          "ambientLightColorR": 200,
+          "camera3DFarPlaneDistance": 10000,
+          "camera3DFieldOfView": 45,
+          "camera3DNearPlaneDistance": 3,
+          "cameraType": "",
+          "followBaseLayerCamera": false,
+          "isLightingLayer": false,
+          "isLocked": false,
+          "name": "",
+          "renderingType": "",
+          "visibility": true,
+          "cameras": [
+            {
+              "defaultSize": true,
+              "defaultViewport": true,
+              "height": 0,
+              "viewportBottom": 1,
+              "viewportLeft": 0,
+              "viewportRight": 1,
+              "viewportTop": 0,
+              "width": 0
+            }
+          ],
+          "effects": []
+        }
+      ],
+      "instances": []
     }
   ]
 }

--- a/extensions/reviewed/TravelToRandomPositions.json
+++ b/extensions/reviewed/TravelToRandomPositions.json
@@ -1,7 +1,6 @@
 {
   "author": "Tristan Rhodes (tristan@victrisgames.com)",
   "category": "Movement",
-  "description": "When the action is used, the object(s) will select a random nearby location and begin moving towards it (using the Pathfinding behavior). \n\nIf desired, choose a direction and how closely you want the object to follow it.  This can be used to make objects chase (or run away from) the player, or to make objects cross the screen using a meandering path.\n\nIf you keep using the action, once the object reaches a destination, it will select a new random location and begin moving towards it.\n\nIf you want to modify the speed of the object, edit the Pathfinding behavior of the object.",
   "extensionNamespace": "",
   "fullName": "Make object travel to random positions",
   "helpPath": "",
@@ -9,7 +8,20 @@
   "name": "TravelToRandomPositions",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/axis-arrow.svg",
   "shortDescription": "Make object travel to random positions (with the pathfinding behavior).",
-  "version": "0.4.1",
+  "version": "0.4.2",
+  "description": [
+    "When the action is used, the object(s) will select a random nearby location and begin moving towards it (using the Pathfinding behavior). ",
+    "",
+    "If desired, choose a direction and how closely you want the object to follow it.  This can be used to make objects chase (or run away from) the player, or to make objects cross the screen using a meandering path.",
+    "",
+    "If you keep using the action, once the object reaches a destination, it will select a new random location and begin moving towards it.",
+    "",
+    "If you want to modify the speed of the object, edit the Pathfinding behavior of the object."
+  ],
+  "origin": {
+    "identifier": "TravelToRandomPositions",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "random",
     "move",
@@ -23,18 +35,17 @@
     "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [
     {
       "description": "Make object travel to a random position around the object current position. The movement is initiated only when the object is not moving already (its Pathfinding behavior speed is 0).  Move towards a specified angle, if desired.",
       "fullName": "Make object travel to a random position, with optional direction",
       "functionType": "Action",
       "name": "TravelToRandomPositions",
-      "private": false,
       "sentence": "Move _PARAM1_ to random positions, where each stop is at least _PARAM3_px and at most _PARAM4_px from the current position. Move towards angle _PARAM5_ with a bias of _PARAM6_",
       "events": [
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Comment",
           "color": {
             "b": 109,
@@ -44,17 +55,13 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "Only run when the object is not being moved by Pathfinding",
-          "comment2": ""
+          "comment": "Create a new destination every time the object stops"
         },
         {
-          "disabled": false,
-          "folded": false,
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [
             {
               "type": {
-                "inverted": false,
                 "value": "PathfindingBehavior::Speed"
               },
               "parameters": [
@@ -62,215 +69,38 @@
                 "Pathfinding",
                 "=",
                 "0"
-              ],
-              "subInstructions": []
+              ]
             }
           ],
           "actions": [],
           "events": [
             {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Gather Input",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
+                  "type": {
+                    "value": "SetNumberVariable"
                   },
-                  "comment": "Use default values if needed",
-                  "comment2": ""
+                  "parameters": [
+                    "Min",
+                    "=",
+                    "abs(MinDistanceBetweenPositions)"
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Min",
-                        "=",
-                        "abs(MinDistanceBetweenPositions)"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Min",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Min",
-                        "=",
-                        "100"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Max",
-                        "=",
-                        "abs(MaxDistanceBetweenPositions)"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Max",
-                        "=",
-                        "0"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Max",
-                        "=",
-                        "200"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Direction",
-                        "=",
-                        "Direction"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.DirectionBias",
-                        "=",
-                        "DirectionBias"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
+                  "type": {
+                    "value": "SetNumberVariable"
+                  },
+                  "parameters": [
+                    "Max",
+                    "=",
+                    "abs(MaxDistanceBetweenPositions)"
+                  ]
                 }
               ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Calculate numbers",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
               "events": [
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Comment",
                   "color": {
                     "b": 109,
@@ -280,314 +110,164 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Calculate the distance the object will travel",
-                  "comment2": ""
+                  "comment": "Use default values if needed"
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
+                  "conditions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
+                        "value": "NumberVariable"
                       },
                       "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.DistanceSelected",
+                        "Min",
                         "=",
-                        "RandomInRange(Object.Variable(__TravelToRandomPositions.Min),Object.Variable(__TravelToRandomPositions.Max))"
-                      ],
-                      "subInstructions": []
+                        "0"
+                      ]
                     }
                   ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Calculate the maximum difference in degrees allowed from \"Direction\" based on \"DirectionBias\"",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.DirectionOffsetRange",
+                        "Min",
                         "=",
-                        "360 * (1 - Object.Variable(__TravelToRandomPositions.DirectionBias)) * 0.5"
-                      ],
-                      "subInstructions": []
+                        "100"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "NumberVariable"
+                      },
+                      "parameters": [
+                        "Max",
+                        "=",
+                        "0"
+                      ]
                     }
                   ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Select a random direction within the range",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.DirectionOffsetSelected",
+                        "Min",
                         "=",
-                        "RandomInRange( -1 * Object.Variable(__TravelToRandomPositions.DirectionOffsetRange), Object.Variable(__TravelToRandomPositions.DirectionOffsetRange))"
-                      ],
-                      "subInstructions": []
+                        "200"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 },
                 {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Select a direction based on the offset",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.DirectionSelected",
+                        "DistanceSelected",
                         "=",
-                        "Object.Variable(__TravelToRandomPositions.Direction) + Object.Variable(__TravelToRandomPositions.DirectionOffsetSelected)"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Calculate position based on direction and distance",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
-                      },
-                      "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Xpos",
-                        "=",
-                        "Object.Variable(__TravelToRandomPositions.DistanceSelected) *  cos(ToRad(Object.Variable(__TravelToRandomPositions.DirectionSelected)))"
-                      ],
-                      "subInstructions": []
+                        "RandomInRange(Min, Max)"
+                      ]
                     },
                     {
                       "type": {
-                        "inverted": false,
-                        "value": "ModVarObjet"
+                        "value": "SetNumberVariable"
                       },
                       "parameters": [
-                        "Object",
-                        "__TravelToRandomPositions.Ypos",
+                        "DirectionSelected",
                         "=",
-                        "Object.Variable(__TravelToRandomPositions.DistanceSelected) *  sin(ToRad(Object.Variable(__TravelToRandomPositions.DirectionSelected)))"
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "events": []
-                }
-              ],
-              "parameters": []
-            },
-            {
-              "colorB": 228,
-              "colorG": 176,
-              "colorR": 74,
-              "creationTime": 0,
-              "disabled": false,
-              "folded": false,
-              "name": "Move object",
-              "source": "",
-              "type": "BuiltinCommonInstructions::Group",
-              "events": [
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "Create a new destination every time the object stops",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [
+                        "Direction + RandomInRange(-180, 180) * (1 - DirectionBias)"
+                      ]
+                    },
                     {
                       "type": {
-                        "inverted": false,
                         "value": "PathfindingBehavior::SetDestination"
                       },
                       "parameters": [
                         "Object",
                         "Pathfinding",
                         "",
-                        "Object.X() + Object.Variable(__TravelToRandomPositions.Xpos)",
-                        "Object.Y() + Object.Variable(__TravelToRandomPositions.Ypos)"
-                      ],
-                      "subInstructions": []
+                        "Object.X() + XFromAngleAndDistance(DirectionSelected, DistanceSelected)",
+                        "Object.Y() + YFromAngleAndDistance(DirectionSelected, DistanceSelected)"
+                      ]
                     }
-                  ],
-                  "events": []
+                  ]
                 }
               ],
-              "parameters": []
+              "variables": [
+                {
+                  "name": "Min",
+                  "type": "number",
+                  "value": 0
+                },
+                {
+                  "name": "Max",
+                  "type": "number",
+                  "value": 0
+                },
+                {
+                  "name": "DistanceSelected",
+                  "type": "number",
+                  "value": 0
+                },
+                {
+                  "name": "DirectionSelected",
+                  "type": "number",
+                  "value": 0
+                }
+              ]
             }
           ]
         }
       ],
       "parameters": [
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Object that will be travelling (must have Pathfinding behavior)",
-          "longDescription": "",
           "name": "Object",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "objectList"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Pathfinding Behavior (required)",
-          "longDescription": "",
           "name": "Pathfinding",
-          "optional": false,
           "supplementaryInformation": "PathfindingBehavior::PathfindingBehavior",
           "type": "behavior"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Minimum distance between each position (Default: 100px)",
-          "longDescription": "",
           "name": "MinDistanceBetweenPositions",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Maximum distance between each position (Default: 200px)",
-          "longDescription": "",
           "name": "MaxDistanceBetweenPositions",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Direction (in degrees) the object will move towards (Range: 0-360)",
-          "longDescription": "",
           "name": "Direction",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         },
         {
-          "codeOnly": false,
-          "defaultValue": "",
           "description": "Direction bias (Range: 0-1) ",
           "longDescription": "For example: \"0\" picks a completely random direction, \"0.5\" will select a direction within the half-circle that faces the specified direction, and \"1\" simply uses the specified direction.",
           "name": "DirectionBias",
-          "optional": false,
-          "supplementaryInformation": "",
           "type": "expression"
         }
       ],
       "objectGroups": []
     }
   ],
-  "eventsBasedBehaviors": []
+  "eventsBasedBehaviors": [],
+  "eventsBasedObjects": []
 }

--- a/extensions/reviewed/ValuesOfMultipleObjects.json
+++ b/extensions/reviewed/ValuesOfMultipleObjects.json
@@ -3,42 +3,17 @@
   "category": "Game mechanic",
   "extensionNamespace": "",
   "fullName": "Values of multiple objects",
-  "helpPath": "https://victrisgames.itch.io/values-of-multiple-objects",
+  "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWRvdHMtaGV4YWdvbiIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xNiAxMkMxNiAxMC45IDE2LjkgMTAgMTggMTBTMjAgMTAuOSAyMCAxMiAxOS4xIDE0IDE4IDE0IDE2IDEzLjEgMTYgMTJNMTAgMTJDMTAgMTAuOSAxMC45IDEwIDEyIDEwUzE0IDEwLjkgMTQgMTIgMTMuMSAxNCAxMiAxNCAxMCAxMy4xIDEwIDEyTTQgMTJDNCAxMC45IDQuOSAxMCA2IDEwUzggMTAuOSA4IDEyIDcuMSAxNCA2IDE0IDQgMTMuMSA0IDEyTTEzIDE4QzEzIDE2LjkgMTMuOSAxNiAxNSAxNlMxNyAxNi45IDE3IDE4IDE2LjEgMjAgMTUgMjAgMTMgMTkuMSAxMyAxOE03IDE4QzcgMTYuOSA3LjkgMTYgOSAxNlMxMSAxNi45IDExIDE4IDEwLjEgMjAgOSAyMCA3IDE5LjEgNyAxOE0xMyA2QzEzIDQuOSAxMy45IDQgMTUgNFMxNyA0LjkgMTcgNiAxNi4xIDggMTUgOCAxMyA3LjEgMTMgNk03IDZDNyA0LjkgNy45IDQgOSA0UzExIDQuOSAxMSA2IDEwLjEgOCA5IDggNyA3LjEgNyA2IiAvPjwvc3ZnPg==",
   "name": "ValuesOfMultipleObjects",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/dots-hexagon.svg",
   "shortDescription": "Values of picked object instances (including position, size, force and angle).",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": [
     "Provides values based on picked object instances.  ",
     "Useful for camera tracking, flocking behaviors, and more.",
     "",
-    "Included expressions",
-    "",
-    "Center points:",
-    "- X center point (absolute) ",
-    "- Y center point (absolute)",
-    "- X center point (average) ",
-    "- Y center point (average)",
-    "",
-    "Position expressions (based on AABB of objects):",
-    "- Minimum X position",
-    "- Minimum Y position",
-    "- Maximum X position",
-    "- Maximum Y position",
-    "",
-    "Force expressions:",
-    "- Average horizontal force (X)",
-    "- Average vertical force (Y)",
-    "",
-    "Angle expressions:",
-    "- Average angle of rotation",
-    "",
-    "Size expressions:",
-    "- Width (min/max/average)",
-    "- Height (min/max/average)",
-    "",
-    "Z-order expressions: (min/max/average)"
+    "An example shows how to use the extension ([open the Itch.io page](https://victrisgames.itch.io/values-of-multiple-objects))."
   ],
   "origin": {
     "identifier": "ValuesOfMultipleObjects",
@@ -66,6 +41,8 @@
     "OaVzVu7cuKhv5Qj0i3vRZYFttl72"
   ],
   "dependencies": [],
+  "globalVariables": [],
+  "sceneVariables": [],
   "eventsFunctions": [
     {
       "description": "Minimum X position of picked object instances (using AABB of objects).",
@@ -252,53 +229,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MinZOrder",
+                "MinZOrder",
                 "=",
                 "Object.ZOrder()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the smallest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -307,36 +255,43 @@
                   "parameters": [
                     "Object",
                     "<",
-                    "Variable(__ValuesOfObjects.MinZOrder)"
+                    "MinZOrder"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MinZOrder",
+                    "MinZOrder",
                     "=",
                     "Object.ZOrder()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MinZOrder)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MinZOrder"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MinZOrder",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -361,53 +316,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MaxZOrder",
+                "MaxZOrder",
                 "=",
                 "Object.ZOrder()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the largest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -416,36 +342,43 @@
                   "parameters": [
                     "Object",
                     ">",
-                    "Variable(__ValuesOfObjects.MaxZOrder)"
+                    "MaxZOrder"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MaxZOrder",
+                    "MaxZOrder",
                     "=",
                     "Object.ZOrder()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MaxZOrder)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MaxZOrder"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MaxZOrder",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -470,160 +403,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalZOrder",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their values"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalZOrder",
+                    "SubtotalZOrder",
                     "+",
                     "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalZOrder / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalZOrder)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalZOrder",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -742,160 +585,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalX",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their position value "
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalX",
+                    "SubtotalX",
                     "+",
-                    "Object.CenterX()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalX / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalX)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalX",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -921,160 +674,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalY",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their position value "
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalY",
+                    "SubtotalY",
                     "+",
-                    "Object.CenterY()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalY / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalY)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalY",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1100,53 +763,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MinHeight",
+                "MinHeight",
                 "=",
                 "Object.Height()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the smallest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -1155,36 +789,43 @@
                   "parameters": [
                     "Object",
                     "<",
-                    "Variable(__ValuesOfObjects.MinHeight)"
+                    "MinHeight"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MinHeight",
+                    "MinHeight",
                     "=",
                     "Object.Height()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MinHeight)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MinHeight"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MinHeight",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1210,53 +851,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MaxHeight",
+                "MaxHeight",
                 "=",
                 "Object.Height()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the largest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -1265,36 +877,43 @@
                   "parameters": [
                     "Object",
                     ">",
-                    "Variable(__ValuesOfObjects.MaxHeight)"
+                    "MaxHeight"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MaxHeight",
+                    "MaxHeight",
                     "=",
                     "Object.Height()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MaxHeight)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MaxHeight"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MaxHeight",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1320,160 +939,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalHeight",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their values"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalHeight",
+                    "SubtotalHeight",
                     "+",
-                    "Object.Height()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalHeight / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalHeight)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalHeight",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1498,53 +1027,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MinWidth",
+                "MinWidth",
                 "=",
                 "Object.Width()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the smallest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -1553,36 +1053,43 @@
                   "parameters": [
                     "Object",
                     "<",
-                    "Variable(__ValuesOfObjects.MinWidth)"
+                    "MinWidth"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MinWidth",
+                    "MinWidth",
                     "=",
                     "Object.Width()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MinWidth)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MinWidth"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MinWidth",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1608,53 +1115,24 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Save the value of any instance"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
           "conditions": [],
           "actions": [
             {
               "type": {
-                "value": "ModVarScene"
+                "value": "SetNumberVariable"
               },
               "parameters": [
-                "__ValuesOfObjects.MaxWidth",
+                "MaxWidth",
                 "=",
                 "Object.Width()"
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and record the largest value"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
-          "conditions": [],
-          "actions": [],
+          ],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [
                 {
                   "type": {
@@ -1663,36 +1141,43 @@
                   "parameters": [
                     "Object",
                     ">",
-                    "Variable(__ValuesOfObjects.MaxWidth)"
+                    "MaxWidth"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.MaxWidth",
+                    "MaxWidth",
                     "=",
                     "Object.Width()"
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
+            },
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.MaxWidth)"
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "MaxWidth"
+                  ]
+                }
               ]
+            }
+          ],
+          "variables": [
+            {
+              "name": "MaxWidth",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1718,160 +1203,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalWidth",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their values"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalWidth",
+                    "SubtotalWidth",
                     "+",
-                    "Object.Width()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalWidth / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalWidth)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalWidth",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -1896,160 +1291,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalHorizontalForce",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their forces"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalHorizontalForce",
+                    "SubtotalHorizontalForce",
                     "+",
-                    "Object.ForceX()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalHorizontalForce / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalHorizontalForce)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalHorizontalForce",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -2074,160 +1379,70 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalVerticalForce",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate a sum of their forces"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
             {
-              "type": "BuiltinCommonInstructions::Standard",
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
               "conditions": [],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetNumberVariable"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalVerticalForce",
+                    "SubtotalVerticalForce",
                     "+",
-                    "Object.ForceY()"
+                    "Object.ZOrder()"
                   ]
-                },
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Prevent dividing by 0"
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
+                    "Object",
+                    ">",
+                    "0"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetReturnNumber"
+                  },
+                  "parameters": [
+                    "SubtotalVerticalForce / PickedInstancesCount(Object)"
                   ]
                 }
               ]
             }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalVerticalForce)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalVerticalForce",
+              "type": "number",
+              "value": 0
             }
           ]
         }
@@ -2252,61 +1467,27 @@
       "sentence": "",
       "events": [
         {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Reset counter variables"
-        },
-        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
-          "actions": [
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
-              ]
-            },
-            {
-              "type": {
-                "value": "ModVarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.SubtotalAngle",
-                "=",
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Cycle through units and calculate average angle"
-        },
-        {
-          "type": "BuiltinCommonInstructions::ForEach",
-          "object": "Object",
           "conditions": [],
           "actions": [],
           "events": [
+            {
+              "type": "BuiltinCommonInstructions::ForEach",
+              "object": "Object",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetNumberVariable"
+                  },
+                  "parameters": [
+                    "SubtotalAngle",
+                    "+",
+                    "Object.ZOrder()"
+                  ]
+                }
+              ]
+            },
             {
               "type": "BuiltinCommonInstructions::Comment",
               "color": {
@@ -2317,151 +1498,39 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Use negative values for angles between 180 and 360 "
+              "comment": "Prevent dividing by 0"
             },
             {
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
                   "type": {
-                    "value": "Angle"
+                    "value": "PickedInstancesCount"
                   },
                   "parameters": [
                     "Object",
                     ">",
-                    "180"
+                    "0"
                   ]
                 }
               ],
               "actions": [
                 {
                   "type": {
-                    "value": "ModVarScene"
+                    "value": "SetReturnNumber"
                   },
                   "parameters": [
-                    "__ValuesOfObjects.SubtotalAngle",
-                    "+",
-                    "Object.Angle()-360"
+                    "SubtotalAngle / PickedInstancesCount(Object)"
                   ]
                 }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "value": "Angle"
-                  },
-                  "parameters": [
-                    "Object",
-                    "<=",
-                    "180"
-                  ]
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__ValuesOfObjects.SubtotalAngle",
-                    "+",
-                    "Object.Angle()"
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "value": "ModVarScene"
-                  },
-                  "parameters": [
-                    "__ValuesOfObjects.ObjectsCounted",
-                    "+",
-                    "1"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Prevent dividing by 0"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "=",
-                "0"
               ]
             }
           ],
-          "actions": [
+          "variables": [
             {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "0"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "BuiltinCommonInstructions::Comment",
-          "color": {
-            "b": 109,
-            "g": 230,
-            "r": 255,
-            "textB": 0,
-            "textG": 0,
-            "textR": 0
-          },
-          "comment": "Divide the the sum of positions by the number of objects to get the average position"
-        },
-        {
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "value": "VarScene"
-              },
-              "parameters": [
-                "__ValuesOfObjects.ObjectsCounted",
-                "!=",
-                "0"
-              ]
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "value": "SetReturnNumber"
-              },
-              "parameters": [
-                "Variable(__ValuesOfObjects.SubtotalAngle)/Variable(__ValuesOfObjects.ObjectsCounted)"
-              ]
+              "name": "SubtotalAngle",
+              "type": "number",
+              "value": 0
             }
           ]
         }


### PR DESCRIPTION
### Changes

* [Flash layer] Simplify the events
* [Double-click] Simplify the events
* [Edge scroll camera] Use extension variables.
* [Camera impulse] Use extension variables.
* [Drag camera] Fix unexpected snapping when the layer is zoomed.
* [Cursor type] Simplify events.
* [Panel sprite button] Use local variables.
* [Multitouch joystick] Use extension variables.
* [Continuous bar] Use local variables.
* [Slider] Use local variables.
* [Units bar] Use local variables.
* [Travel at random] Simplify events.
* [Values of objects] Simplify events.