### PR TITLE
[Reviewed] [Two choices dialog box] Simplify the events

### DIFF
--- a/extensions/reviewed/TwoChoicesDialogBoxes.json
+++ b/extensions/reviewed/TwoChoicesDialogBoxes.json
@@ -2,21 +2,24 @@
   "author": "",
   "category": "Input",
   "extensionNamespace": "",
-  "fullName": "Two Choices Dialog Boxes",
+  "fullName": "Two choices dialog boxes",
   "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQo8L3N0eWxlPg0KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjMiIHkxPSIxMSIgeDI9IjI5IiB5Mj0iMTEiLz4NCjxnPg0KCTxwYXRoIGQ9Ik03LDlDNi43LDksNi41LDguOSw2LjMsOC43QzYuMSw4LjUsNiw4LjMsNiw4YzAtMC4zLDAuMS0wLjUsMC4zLTAuN2MwLDAsMC4xLTAuMSwwLjEtMC4xYzAuMSwwLDAuMS0wLjEsMC4yLTAuMQ0KCQlDNi43LDcsNi43LDcsNi44LDdjMC4xLDAsMC4zLDAsMC40LDBjMC4xLDAsMC4xLDAsMC4yLDAuMWMwLjEsMCwwLjEsMC4xLDAuMiwwLjFjMCwwLDAuMSwwLjEsMC4xLDAuMWMwLjEsMC4xLDAuMiwwLjIsMC4yLDAuMw0KCQlDOCw3LjcsOCw3LjksOCw4YzAsMC4xLDAsMC4zLTAuMSwwLjRDNy45LDguNSw3LjgsOC42LDcuNyw4LjdDNy41LDguOSw3LjMsOSw3LDl6Ii8+DQo8L2c+DQo8Zz4NCgk8cGF0aCBkPSJNMTAsOUM5LjcsOSw5LjUsOC45LDkuMyw4LjdDOS4xLDguNSw5LDguMyw5LDhjMC0wLjEsMC0wLjMsMC4xLTAuNGMwLjEtMC4xLDAuMS0wLjIsMC4yLTAuM2MwLjEtMC4xLDAuMi0wLjIsMC4zLTAuMg0KCQlDMTAsNi45LDEwLjQsNywxMC43LDcuM2MwLjEsMC4xLDAuMiwwLjIsMC4yLDAuM0MxMSw3LjcsMTEsNy45LDExLDhjMCwwLjMtMC4xLDAuNS0wLjMsMC43QzEwLjUsOC45LDEwLjMsOSwxMCw5eiIvPg0KPC9nPg0KPGc+DQoJPHBhdGggZD0iTTEzLDljLTAuMSwwLTAuMywwLTAuNC0wLjFjLTAuMS0wLjEtMC4yLTAuMS0wLjMtMC4yYy0wLjEtMC4xLTAuMi0wLjItMC4yLTAuM0MxMiw4LjMsMTIsOC4xLDEyLDhjMC0wLjEsMC0wLjMsMC4xLTAuNA0KCQljMC4xLTAuMSwwLjEtMC4yLDAuMi0wLjNjMC40LTAuNCwxLTAuNCwxLjQsMGMwLjEsMC4xLDAuMiwwLjIsMC4yLDAuM0MxNCw3LjcsMTQsNy45LDE0LDhjMCwwLjEsMCwwLjMtMC4xLDAuNA0KCQljLTAuMSwwLjEtMC4xLDAuMi0wLjIsMC4zQzEzLjUsOC45LDEzLjMsOSwxMyw5eiIvPg0KPC9nPg0KPHBhdGggY2xhc3M9InN0MCIgZD0iTTI3LDVINUMzLjksNSwzLDUuOSwzLDd2MThjMCwxLjEsMC45LDIsMiwyaDIyYzEuMSwwLDItMC45LDItMlY3QzI5LDUuOSwyOC4xLDUsMjcsNXoiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yMywyM0g5Yy0xLjEsMC0yLTAuOS0yLTJ2LTRjMC0xLjEsMC45LTIsMi0yaDE0YzEuMSwwLDIsMC45LDIsMnY0QzI1LDIyLjEsMjQuMSwyMywyMywyM3oiLz4NCjxwb2x5bGluZSBjbGFzcz0ic3QwIiBwb2ludHM9IjE1LDE5IDE2LDIwIDE4LDE4ICIvPg0KPC9zdmc+DQo=",
   "name": "TwoChoicesDialogBoxes",
   "previewIconUrl": "https://asset-resources.gdevelop.io/public-resources/Icons/Line Hero Pack/Master/SVG/Interface Elements/0842ffc478006e9b6687fca9a5761494c4efd1df873220637af5b4ac7253f850_Interface Elements_interface_ui_window_application_app_button_cta.svg",
-  "shortDescription": "A Dialog box with buttons to let the user make a choice.",
-  "version": "0.0.1",
+  "shortDescription": "A dialog box with buttons to let users make a choice.",
+  "version": "0.1.0",
   "description": [
-    "The dialog box is showing multiple options (usually \"yes\" and \"no\") and a customizable text message.",
-    "It also has:",
-    "- Full keyboard, gamepad and touch support",
-    "- A default selected button"
+    "A dialog box showing multiple options (usually \"yes\" and \"no\") and a customizable text message.",
+    "It handles keyboard, gamepad and touch controls."
   ],
+  "origin": {
+    "identifier": "TwoChoicesDialogBoxes",
+    "name": "gdevelop-extension-store"
+  },
   "tags": [
     "dialog",
+    "dialogue",
     "box",
     "input",
     "confirmation",
@@ -39,9 +42,10 @@
       "areaMinY": 0,
       "areaMinZ": 0,
       "defaultName": "",
-      "description": "A dialog box showing two options (usually \"yes\" and \"no\") and a customizable text message.",
-      "fullName": "Two Choices Dialog Box ",
+      "description": "A dialog box showing two options.",
+      "fullName": "Two choices dialog box ",
       "isInnerAreaFollowingParentSize": true,
+      "isTextContainer": true,
       "isUsingLegacyInstancesRenderer": false,
       "name": "TwoChoicesDialogBox",
       "eventsFunctions": [
@@ -65,30 +69,18 @@
                     "\"OutlineEffect\"",
                     ""
                   ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                },
                 {
                   "type": {
                     "value": "TextContainerCapability::TextContainerBehavior::SetValue"
                   },
                   "parameters": [
-                    "Dialogue",
+                    "Object",
                     "Text",
                     "=",
                     "TextMessage"
                   ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                },
                 {
                   "type": {
                     "value": "PanelSpriteButton::PanelSpriteButton::SetLabelText"
@@ -98,13 +90,7 @@
                     "LabelButtonID0",
                     ""
                   ]
-                }
-              ]
-            },
-            {
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
+                },
                 {
                   "type": {
                     "value": "PanelSpriteButton::PanelSpriteButton::SetLabelText"
@@ -158,32 +144,20 @@
                   ]
                 }
               ],
-              "actions": [],
-              "events": [
+              "actions": [
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "BuiltinCommonInstructions::Once"
-                      },
-                      "parameters": []
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "TextContainerCapability::TextContainerBehavior::SetValue"
-                      },
-                      "parameters": [
-                        "Dialogue",
-                        "Text",
-                        "=",
-                        "TextMessage"
-                      ]
-                    }
+                  "type": {
+                    "value": "TextContainerCapability::TextContainerBehavior::SetValue"
+                  },
+                  "parameters": [
+                    "Dialogue",
+                    "Text",
+                    "=",
+                    "Object.Text::Value()"
                   ]
-                },
+                }
+              ],
+              "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
@@ -444,17 +418,6 @@
                           "parameters": [
                             "",
                             "1",
-                            "\"Circle\"",
-                            ""
-                          ]
-                        },
-                        {
-                          "type": {
-                            "value": "Gamepads::C_Button_pressed"
-                          },
-                          "parameters": [
-                            "",
-                            "1",
                             "\"B\"",
                             ""
                           ]
@@ -481,163 +444,39 @@
                       ]
                     }
                   ]
-                },
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "description": "Object",
+              "name": "Object",
+              "supplementaryInformation": "TwoChoicesDialogBoxes::TwoChoicesDialogBox",
+              "type": "object"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onHotReloading",
+          "sentence": "",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
                 {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [],
-                  "actions": [],
-                  "events": [
-                    {
-                      "type": "BuiltinCommonInstructions::ForEach",
-                      "object": "Buttons",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "NumberVariable"
-                          },
-                          "parameters": [
-                            "MaxID",
-                            "<",
-                            "Buttons.ID"
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "SetNumberVariable"
-                          },
-                          "parameters": [
-                            "MaxID",
-                            "=",
-                            "Buttons.ID"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "TwoChoicesDialogBoxes::TwoChoicesDialogBox::ActiveButtonById"
-                          },
-                          "parameters": [
-                            "Object",
-                            "<",
-                            "0",
-                            ""
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "TwoChoicesDialogBoxes::TwoChoicesDialogBox::SetActiveButtonById"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "MaxID",
-                            ""
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "value": "TwoChoicesDialogBoxes::TwoChoicesDialogBox::ActiveButtonById"
-                          },
-                          "parameters": [
-                            "Object",
-                            ">",
-                            "MaxID",
-                            ""
-                          ]
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "value": "TwoChoicesDialogBoxes::TwoChoicesDialogBox::SetActiveButtonById"
-                          },
-                          "parameters": [
-                            "Object",
-                            "=",
-                            "0",
-                            ""
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "variables": [
-                    {
-                      "name": "MaxID",
-                      "type": "number",
-                      "value": 0
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Buttons",
-                        "ID",
-                        "=",
-                        "Object.ActiveButtonById()"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "EffectCapability::EffectBehavior::EnableEffect"
-                      },
-                      "parameters": [
-                        "Buttons",
-                        "Effect",
-                        "\"OutlineEffect\"",
-                        "yes"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BuiltinCommonInstructions::Standard",
-                  "conditions": [
-                    {
-                      "type": {
-                        "value": "VarObjet"
-                      },
-                      "parameters": [
-                        "Buttons",
-                        "ID",
-                        "!=",
-                        "Object.ActiveButtonById()"
-                      ]
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "type": {
-                        "value": "EffectCapability::EffectBehavior::EnableEffect"
-                      },
-                      "parameters": [
-                        "Buttons",
-                        "Effect",
-                        "\"OutlineEffect\"",
-                        "no"
-                      ]
-                    }
+                  "type": {
+                    "value": "TextContainerCapability::TextContainerBehavior::SetValue"
+                  },
+                  "parameters": [
+                    "Object",
+                    "Text",
+                    "=",
+                    "TextMessage"
                   ]
                 }
               ]
@@ -758,17 +597,6 @@
                               "parameters": [
                                 "",
                                 "Space"
-                              ]
-                            },
-                            {
-                              "type": {
-                                "value": "Gamepads::C_Button_pressed"
-                              },
-                              "parameters": [
-                                "",
-                                "1",
-                                "\"Cross\"",
-                                ""
                               ]
                             }
                           ]
@@ -937,12 +765,13 @@
           "objectGroups": []
         },
         {
-          "description": "the active button identifier.",
-          "fullName": "Active button identifier",
+          "description": "the highlighted button.",
+          "fullName": "Highlighted button",
           "functionType": "ExpressionAndCondition",
           "group": "Dialog Box configuration",
           "name": "ActiveButtonById",
-          "sentence": "the active button identifier",
+          "private": true,
+          "sentence": "the highlighted button",
           "events": [
             {
               "type": "BuiltinCommonInstructions::Standard",
@@ -977,6 +806,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "ActiveButtonById",
           "name": "SetActiveButtonById",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -990,7 +820,65 @@
                   "parameters": [
                     "Object",
                     "=",
-                    "Value"
+                    "mod(Value, SceneInstancesCount(Buttons))"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarObjet"
+                  },
+                  "parameters": [
+                    "Buttons",
+                    "ID",
+                    "=",
+                    "ActiveButtonById"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "EffectCapability::EffectBehavior::EnableEffect"
+                  },
+                  "parameters": [
+                    "Buttons",
+                    "Effect",
+                    "\"OutlineEffect\"",
+                    "yes"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "VarObjet"
+                  },
+                  "parameters": [
+                    "Buttons",
+                    "ID",
+                    "!=",
+                    "ActiveButtonById"
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "EffectCapability::EffectBehavior::EnableEffect"
+                  },
+                  "parameters": [
+                    "Buttons",
+                    "Effect",
+                    "\"OutlineEffect\"",
+                    "no"
                   ]
                 }
               ]
@@ -1048,6 +936,7 @@
           "functionType": "ActionWithOperator",
           "getterName": "TextMessage",
           "name": "SetTextMessage",
+          "private": true,
           "sentence": "",
           "events": [
             {
@@ -1093,7 +982,7 @@
         {
           "value": "Default message. Continue?",
           "type": "String",
-          "label": "Default text",
+          "label": "Message",
           "description": "",
           "group": "",
           "extraInformation": [],
@@ -1103,10 +992,11 @@
           "value": "0",
           "type": "Number",
           "unit": "Dimensionless",
-          "label": "Default selected button identifier",
-          "description": "Default selected button identifier.",
+          "label": "Default highlighted button identifier",
+          "description": "Default highlighted button identifier.",
           "group": "",
           "extraInformation": [],
+          "deprecated": true,
           "name": "ActiveButtonById"
         },
         {


### PR DESCRIPTION
### Changes
- Simplify the events
- Hide instructions and properties about button id because users can't know what it means.
  - if the feature is ask, it should probably use user-defined button labels. 

### Demo
- https://github.com/GDevelopApp/GDevelop-examples/pull/746