### PR TITLE
Add behaviors/objects/functions details in ExtensionShortHeader

### DIFF
--- a/scripts/lib/rules/FilledOutDescriptions.js
+++ b/scripts/lib/rules/FilledOutDescriptions.js
@@ -1,7 +1,7 @@
 /** @typedef {import("../../types").Extension} Extension */
 /** @typedef {import("../../types").EventsFunction} EventsFunction */
 /** @typedef {import("../../types").EventsBasedBehavior} EventsBasedBehaviors */
-/** @typedef {import("../../types").EventsBasedObjects} EventsBasedObjects */
+/** @typedef {import("../../types").EventsBasedObject} EventsBasedObject */
 /** @typedef {import("../../types").Parameter} Parameter */
 
 /**
@@ -18,7 +18,7 @@ const NECESSARY_FIELDS = {
   ACTION_WITH_OPERATOR: ['name', 'getterName'],
   /** @type {Partial<keyof EventsBasedBehaviors>[]} */
   BEHAVIOR: ['name', 'fullName', 'description'],
-  /** @type {Partial<keyof EventsBasedObjects>[]} */
+  /** @type {Partial<keyof EventsBasedObject>[]} */
   OBJECT: ['name', 'fullName', 'description'],
   /** @type {Partial<keyof Parameter>[]} */
   PARAMETER: ['description', 'name', 'type'],

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -67,13 +67,13 @@ export interface ExtensionShortHeader
   url: string;
   headerUrl: string;
   /** Only defined for "reviewed" extensions. */
-  eventsBasedBehaviors?: EventsBasedBehaviorInsideExtensionShortHeader[],
+  eventsBasedBehaviors?: EventsBasedBehaviorInsideExtensionShortHeader[];
   eventsBasedBehaviorsCount: number;
   /** Only defined for "reviewed" extensions. */
-  eventsFunctions?: EventsFunctionInsideExtensionShortHeader[],
+  eventsFunctions?: EventsFunctionInsideExtensionShortHeader[];
   eventsFunctionsCount: number;
   /** Only defined for "reviewed" extensions. */
-  eventsBasedObjects?: EventsBasedObjectInsideExtensionShortHeader[],
+  eventsBasedObjects?: EventsBasedObjectInsideExtensionShortHeader[];
 }
 
 interface BehaviorAndShortHeaderFields {

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -31,14 +31,49 @@ interface ExtensionAndHeaderFields {
   iconUrl: string;
 }
 
+export interface EventsFunctionInsideExtensionShortHeader {
+  description: string;
+  fullName: string;
+  functionType:
+    | 'StringExpression'
+    | 'Expression'
+    | 'Action'
+    | 'Condition'
+    | 'ExpressionAndCondition'
+    | 'ActionWithOperator';
+  name: string;
+}
+
+export interface EventsBasedBehaviorInsideExtensionShortHeader {
+  description: string;
+  fullName: string;
+  name: string;
+  objectType: string;
+  eventsFunctions: EventsFunctionInsideExtensionShortHeader[];
+}
+
+export interface EventsBasedObjectInsideExtensionShortHeader {
+  description: string;
+  fullName: string;
+  name: string;
+  defaultName: string;
+  eventsFunctions: EventsFunctionInsideExtensionShortHeader[];
+}
+
 export interface ExtensionShortHeader
   extends RegistryItem,
     ExtensionAndShortHeaderFields {
   tier: ExtensionTier;
   url: string;
   headerUrl: string;
+  /** Only defined for "reviewed" extensions. */
+  eventsBasedBehaviors?: EventsBasedBehaviorInsideExtensionShortHeader[],
   eventsBasedBehaviorsCount: number;
+  /** Only defined for "reviewed" extensions. */
+  eventsFunctions?: EventsFunctionInsideExtensionShortHeader[],
   eventsFunctionsCount: number;
+  /** Only defined for "reviewed" extensions. */
+  eventsBasedObjects?: EventsBasedObjectInsideExtensionShortHeader[],
 }
 
 interface BehaviorAndShortHeaderFields {
@@ -167,11 +202,12 @@ export interface EventsBasedBehavior {
   propertyDescriptors: PropertyDescriptor[];
 }
 
-export interface EventsBasedObjects {
+export interface EventsBasedObject {
   description: string;
   fullName: string;
   name: string;
   defaultName: string;
+  private?: boolean;
   eventsFunctions: EventsFunction[];
 }
 
@@ -181,7 +217,7 @@ export interface Extension
   tags: string | string[];
   eventsFunctions: EventsFunction[];
   eventsBasedBehaviors: EventsBasedBehavior[];
-  eventsBasedObjects?: EventsBasedObjects[];
+  eventsBasedObjects?: EventsBasedObject[];
 }
 
 export interface ExtensionWithProperFileInfo {


### PR DESCRIPTION
"Database" file goes from 350K to 530K (but it contains behavior/objects registry that are separated by the API, and this is the non gzipped size, so overall it should be ok).