### PR TITLE
Update CrazyGamesAdApi.json

### DIFF
--- a/extensions/reviewed/CrazyGamesAdApi.json
+++ b/extensions/reviewed/CrazyGamesAdApi.json
@@ -36,7 +36,6 @@
     }
   ],
   "dependencies": [],
-  "dependencies": [],
   "globalVariables": [],
   "sceneVariables": [],
   "eventsFunctions": [


### PR DESCRIPTION
The expression type "Get user session data" has been changed to a string, since we are storing a string and should expect a string, and a hint has been added that if there is no data, "null" will be returned.