### PR TITLE
Update extension: PlaygamaBridge v1.24.0

### DIFF
--- a/extensions/reviewed/PlaygamaBridge.json
+++ b/extensions/reviewed/PlaygamaBridge.json
@@ -3894,12 +3894,12 @@
       "objectGroups": []
     },
     {
-      "description": "Leaderboards Type = Not Available.",
-      "fullName": "Leaderboards Type = Not Available",
+      "description": "The leaderboard is of type Not Available.",
+      "fullName": "The leaderboard is of type Not Available",
       "functionType": "Condition",
       "group": "Leaderboards",
       "name": "LeaderboardsTypeNotAvailable",
-      "sentence": "Leaderboards Type = Not Available",
+      "sentence": "The leaderboard is of type Not Available",
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
@@ -3916,12 +3916,12 @@
       "objectGroups": []
     },
     {
-      "description": "Leaderboards Type = In Game.",
-      "fullName": "Leaderboards Type = In Game",
+      "description": "The leaderboard is of type In Game.",
+      "fullName": "The leaderboard is of type In Game",
       "functionType": "Condition",
       "group": "Leaderboards",
       "name": "LeaderboardsTypeInGame",
-      "sentence": "Leaderboards Type = In Game",
+      "sentence": "The leaderboard is of type In Game",
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",
@@ -3938,12 +3938,12 @@
       "objectGroups": []
     },
     {
-      "description": "Leaderboards Type = Native.",
-      "fullName": "Leaderboards Type = Native",
+      "description": "The leaderboard is of type Native.",
+      "fullName": "The leaderboard is of type Native",
       "functionType": "Condition",
       "group": "Leaderboards",
       "name": "LeaderboardsTypeNative",
-      "sentence": "Leaderboards Type = Native",
+      "sentence": "The leaderboard is of type Native",
       "events": [
         {
           "type": "BuiltinCommonInstructions::JsCode",


### PR DESCRIPTION
**v1.24.0**

- [x] **Added support for the BitQuest platform**
- [x] **Advertisement**
  - Added `IsInterstitialSupported`
  - Added `IsRewardedSupported`
- [x] **Platform**
  - Added `PlatformIsAudioEnabled`
  - Added `PlatformIsPaused`
  - Added `PlatformOnAudioStateChanged`
  - Added `PlatformOnPauseStateChanged`
- [x] **Leaderboards**
  - Added `isMain` property to the `playgama-bridge-config.json`
- [x] **Storage**
  - Changed `DefaultStorageType` from `local_storage` to `platform_internal` for **CrazyGames**
    > ⚠️ If you're updating your game on CrazyGames, don’t forget to [migrate your stored data](https://docs.crazygames.com/sdk/data/#integrating-data-module-into-already-published-games).
- [x] **Playgama QA Tool**
  - Added support for the `PlatformLanguage`
  - Added support for the `Leaderboards`
- [x] **Bug Fixes**
  - Fixed payments on **MSN**
  - Fixed payments on **Facebook**
  
--------

  **v1.23.0**

- [x] Added `Discord` platform _[beta]_
- [x] Added new loading screen
- [x] Added backfill advertisements for `MSN`
- [x] Added built-in advertisement popups for `MSN` and `Facebook`
- [x] Improved `leaderboards` module
- [x] Improved `Facebook` integration
- [x] Updated currency code for [Playgama.com](https://playgama.com)
- [x] Fixed `social.share` for `Playdeck`
- [x] Removed `Yandex` deprecated methods