### PR TITLE
Allow to update extensions even if they don't comply all rules

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "A build error occured while merging:
+          gh pr comment ${{ github.event.issue.number }} --body "A build error occurred while merging:
 
           \`\`\`${{ env.BUILD_LOGS }}
           \`\`\`"
@@ -96,7 +96,7 @@ jobs:
         shell: bash
 
       - name: Commit and push
-        if: ${{ steps.git-diff.outputs.changed == 'true' && contains(env.BUILD_LOGS, 'successfully updated') }}
+        if: ${{ steps.git-diff.outputs.changed == 'true' && contains(env.BUILD_LOGS, 'No fatal error found') }}
         run: |
           git add extensions
           git commit -m "Updated extension"
@@ -114,8 +114,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment ${{ github.event.issue.number }} --body "✅ Successfully updated the extension."
 
-      - name: Notify build error
-        if: ${{ steps.git-diff.outputs.changed == 'true' && !contains(env.BUILD_LOGS, 'successfully updated') }}
+      - name: Notify non-fatal build error
+        if: ${{ steps.git-diff.outputs.changed == 'true' && contains(env.BUILD_LOGS, 'No fatal error found') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "Extension updated with errors:
+
+          \`\`\`${{ env.BUILD_LOGS }}
+          \`\`\`"
+
+      - name: Notify fatal build error
+        if: ${{ steps.git-diff.outputs.changed == 'true' && !contains(env.BUILD_LOGS, 'successfully updated') && !contains(env.BUILD_LOGS, 'No fatal error found') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/generate-extensions-registry.js
+++ b/scripts/generate-extensions-registry.js
@@ -285,11 +285,13 @@ const filterEventsFunctions = (eventsFunctions) =>
     const objectShortHeaders = [];
 
     let totalErrors = 0;
+    let fatalErrors = 0;
     let fixableErrors = 0;
 
     const errors = validateNoDuplicates(allExtensionWithFileInfos);
     errors.forEach((error) => {
       totalErrors++;
+      fatalErrors++;
       shell.echo(`❌ ${error.message}`);
     });
 
@@ -301,6 +303,7 @@ const filterEventsFunctions = (eventsFunctions) =>
             `\n❌ Unable to open extension in file ${extensionWithFileInfo.filename}: ${error.message}\n`
           );
           totalErrors++;
+          fatalErrors++;
           return;
         }
 
@@ -482,7 +485,9 @@ const filterEventsFunctions = (eventsFunctions) =>
             fixableErrors > 1 ? 's are' : ' is'
           } auto-fixable - pass the argument --fix to fix them automatically.`
         );
-      shell.exit(args['disable-exit-code'] ? 0 : 1);
+      if (fatalErrors) {
+        shell.exit(args['disable-exit-code'] ? 0 : 1);
+      }
     }
 
     const views = JSON.parse(
@@ -524,7 +529,13 @@ const filterEventsFunctions = (eventsFunctions) =>
       registry
     );
 
-    console.log(`✅ Headers and registry files successfully updated`);
+    if (totalErrors) {
+      console.log(
+        `No fatal error found the extension can be updated but still need fixes.`
+      );
+    } else {
+      console.log(`✅ Headers and registry files successfully updated`);
+    }
   } catch (error) {
     console.error(
       `⚠️ Error while generating headers and registry files:`,

--- a/scripts/lib/rules/JavascriptDisallowedProperties.js
+++ b/scripts/lib/rules/JavascriptDisallowedProperties.js
@@ -138,7 +138,7 @@ async function validate({ extension, onError }) {
           accumulator +
           inspect(current, undefined, undefined, process.env.CI !== 'true') +
           '\n',
-        `Found disallowed properties in extension '${extension.name}':\n`
+        `JavaScript usage of the extension '${extension.name}' must be checked by the reviewer:\n`
       )
       // Remove the last \n
       .slice(0, -1);


### PR DESCRIPTION
It avoids to block extension with JavaScript to be updated:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/1755

In a more general manner, it's better to have a missing dot at the end of a sentence rather than a bug in the events. The bot still asks to update the extension again for any broken rule.