### PR TITLE
Fixed hasString and hasNumber for global and object arrays

### DIFF
--- a/extensions/reviewed/ArrayTools.json
+++ b/extensions/reviewed/ArrayTools.json
@@ -45,7 +45,8 @@
     "insert"
   ],
   "authorIds": [
-    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1"
+    "ZgrsWuRTAkXgeuPV9bo0zuEcA2w1",
+    "iA9FUxZ3xSQIANVAhvvzczPydxJ3"
   ],
   "changelog": [
     {
@@ -1867,7 +1868,7 @@
               },
               "parameters": [
                 "\"Array\"",
-                "__ArrayTools.Temp"
+                "Temp"
               ]
             }
           ]
@@ -1880,7 +1881,7 @@
                 "value": "Egal"
               },
               "parameters": [
-                "ArrayTools::IndexOf(__ArrayTools.Temp, Value)",
+                "ArrayTools::IndexOf(Temp, Value)",
                 "!=",
                 "-1"
               ]
@@ -1931,7 +1932,7 @@
               },
               "parameters": [
                 "\"Array\"",
-                "__ArrayTools.Temp"
+                "Temp"
               ]
             }
           ]
@@ -1944,7 +1945,7 @@
                 "value": "Egal"
               },
               "parameters": [
-                "ArrayTools::IndexOfStr(__ArrayTools.Temp, Value)",
+                "ArrayTools::IndexOfStr(Temp, Value)",
                 "!=",
                 "-1"
               ]
@@ -3326,7 +3327,7 @@
               },
               "parameters": [
                 "\"Array\"",
-                "__ArrayTools.Temp"
+                "Temp"
               ]
             }
           ]
@@ -3339,7 +3340,7 @@
                 "value": "Egal"
               },
               "parameters": [
-                "ArrayTools::IndexOf(__ArrayTools.Temp, Value)",
+                "ArrayTools::IndexOf(Temp, Value)",
                 "!=",
                 "-1"
               ]
@@ -3394,7 +3395,7 @@
               },
               "parameters": [
                 "\"Array\"",
-                "__ArrayTools.Temp"
+                "Temp"
               ]
             }
           ]
@@ -3407,7 +3408,7 @@
                 "value": "Egal"
               },
               "parameters": [
-                "ArrayTools::IndexOfStr(__ArrayTools.Temp, Value)",
+                "ArrayTools::IndexOfStr(Temp, Value)",
                 "!=",
                 "-1"
               ]


### PR DESCRIPTION
The `HasNumber` and `HasString` conditions for objects would always return true, regardless of whether the array contained the specified value or not. The reason was that the functions referenced a nonexistent variable named `__ArrayTools.Temp`.

This PR removes all occurrences of this prefix, and now uses the extension scene variable simply named `Temp`. 

An example project where the issue is documented has been attached to this PR.
[ArrayToolsTest.zip](https://github.com/user-attachments/files/22350566/ArrayToolsTest.zip)
